### PR TITLE
Cleanup RollupUtils

### DIFF
--- a/contracts/BurnConsent.sol
+++ b/contracts/BurnConsent.sol
@@ -38,7 +38,7 @@ contract BurnConsent is FraudProofHelpers {
         // generate merkle tree from the txs provided by user
         bytes[] memory txs = new bytes[](_txs.length);
         for (uint256 i = 0; i < _txs.length; i++) {
-            txs[i] = RollupUtils.CompressConsent(_txs[i]);
+            txs[i] = RollupUtils.CompressBurnConsent(_txs[i]);
         }
         txRoot = merkleUtils.getMerkleRoot(txs);
         return txRoot;

--- a/contracts/BurnExecution.sol
+++ b/contracts/BurnExecution.sol
@@ -38,7 +38,7 @@ contract BurnExecution is FraudProofHelpers {
         // generate merkle tree from the txs provided by user
         bytes[] memory txs = new bytes[](_txs.length);
         for (uint256 i = 0; i < _txs.length; i++) {
-            txs[i] = RollupUtils.CompressExecution(_txs[i]);
+            txs[i] = RollupUtils.CompressBurnExecution(_txs[i]);
         }
         txRoot = merkleUtils.getMerkleRoot(txs);
         return txRoot;

--- a/contracts/airdrop.sol
+++ b/contracts/airdrop.sol
@@ -38,7 +38,7 @@ contract Airdrop is FraudProofHelpers {
         // generate merkle tree from the txs provided by user
         bytes[] memory txs = new bytes[](_txs.length);
         for (uint256 i = 0; i < _txs.length; i++) {
-            txs[i] = RollupUtils.CompressDrop(_txs[i]);
+            txs[i] = RollupUtils.CompressAirdrop(_txs[i]);
         }
         txRoot = merkleUtils.getMerkleRoot(txs);
         return txRoot;

--- a/contracts/libs/RollupUtils.sol
+++ b/contracts/libs/RollupUtils.sol
@@ -98,6 +98,39 @@ library RollupUtils {
 
     // ---------- Tx Related Utils -------------------
 
+    /*
+        The order with:
+
+        BytesFromX
+        BytesFromXNoStruct
+        XFromBytes
+        XSignBytes
+        CompressX
+        CompressXNoStruct
+        CompressXWithMessage
+        DecompressX
+     */
+
+    //
+    // CreateAccount
+    //
+
+    function BytesFromCreateAccount(Types.CreateAccount memory _tx)
+        public
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodePacked(_tx.toIndex, _tx.tokenType);
+    }
+
+    function BytesFromCreateAccountNoStruct(uint256 toIndex, uint256 tokenType)
+        public
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodePacked(toIndex, tokenType);
+    }
+
     function CreateAccountTxFromBytes(bytes memory txBytes)
         public
         pure
@@ -106,6 +139,180 @@ library RollupUtils {
         Types.CreateAccount memory _tx;
         (_tx.toIndex, _tx.tokenType) = abi.decode(txBytes, (uint256, uint256));
         return _tx;
+    }
+
+    function getCreateAccountSignBytes(uint256 toIndex, uint256 tokenType)
+        public
+        pure
+        returns (bytes32)
+    {
+        return keccak256(abi.encodePacked(toIndex, tokenType));
+    }
+
+    function CompressCreateAccount(Types.CreateAccount memory _tx)
+        public
+        pure
+        returns (bytes memory)
+    {
+        return abi.encode(_tx.toIndex, _tx.tokenType, _tx.signature);
+    }
+
+    function CompressCreateAccountNoStruct(
+        uint256 toIndex,
+        uint256 tokenType,
+        uint256 signature
+    ) public pure returns (bytes memory) {
+        return abi.encode(toIndex, tokenType, signature);
+    }
+
+    function CompressCreateAccountTxWithMessage(
+        bytes memory message,
+        bytes memory sig
+    ) public pure returns (bytes memory) {
+        Types.CreateAccount memory _tx;
+        (_tx.toIndex, _tx.tokenType, ) = abi.decode(
+            message,
+            (uint256, uint256, bytes)
+        );
+        return abi.encode(_tx.toIndex, _tx.tokenType, sig);
+    }
+
+    function DecompressCreateAccount(bytes memory txBytes)
+        public
+        pure
+        returns (Types.CreateAccount memory)
+    {
+        Types.CreateAccount memory _tx;
+        (_tx.toIndex, _tx.tokenType) = abi.decode(txBytes, (uint256, uint256));
+        return _tx;
+    }
+
+    //
+    // Airdrop
+    //
+
+    function BytesFromAirdrop(Types.DropTx memory _tx)
+        public
+        pure
+        returns (bytes memory)
+    {
+        return
+            abi.encodePacked(
+                _tx.fromIndex,
+                _tx.toIndex,
+                _tx.tokenType,
+                _tx.nonce,
+                _tx.txType,
+                _tx.amount
+            );
+    }
+
+    function BytesFromTxAirdropDeconstructed(
+        uint256 from,
+        uint256 to,
+        uint256 tokenType,
+        uint256 nonce,
+        uint256 txType,
+        uint256 amount
+    ) public pure returns (bytes memory) {
+        return abi.encodePacked(from, to, tokenType, nonce, txType, amount);
+    }
+
+    function AirdropTxFromBytes(bytes memory txBytes)
+        public
+        pure
+        returns (Types.DropTx memory)
+    {
+        Types.DropTx memory transaction;
+        (
+            transaction.fromIndex,
+            transaction.toIndex,
+            transaction.tokenType,
+            transaction.nonce,
+            transaction.txType,
+            transaction.amount
+        ) = abi.decode(
+            txBytes,
+            (uint256, uint256, uint256, uint256, uint256, uint256)
+        );
+        return transaction;
+    }
+
+    function AirdropTxFromBytesNoStruct(bytes memory txBytes)
+        public
+        pure
+        returns (
+            uint256 from,
+            uint256 to,
+            uint256 tokenType,
+            uint256 nonce,
+            uint256 txType,
+            uint256 amount
+        )
+    {
+        return
+            abi.decode(
+                txBytes,
+                (uint256, uint256, uint256, uint256, uint256, uint256)
+            );
+    }
+
+    function getDropSignBytes(
+        uint256 fromIndex,
+        uint256 toIndex,
+        uint256 tokenType,
+        uint256 txType,
+        uint256 nonce,
+        uint256 amount
+    ) public pure returns (bytes32) {
+        return
+            keccak256(
+                BytesFromTxAirdropDeconstructed(
+                    fromIndex,
+                    toIndex,
+                    tokenType,
+                    nonce,
+                    txType,
+                    amount
+                )
+            );
+    }
+
+    function CompressDrop(Types.DropTx memory _tx)
+        public
+        pure
+        returns (bytes memory)
+    {
+        return abi.encode(_tx.toIndex, _tx.amount, _tx.signature);
+    }
+
+    function CompressDropNoStruct(
+        uint256 toIndex,
+        uint256 amount,
+        bytes memory sig
+    ) public pure returns (bytes memory) {
+        return abi.encodePacked(toIndex, amount, sig);
+    }
+
+    function CompressAirdropTxWithMessage(
+        bytes memory message,
+        bytes memory sig
+    ) public pure returns (bytes memory) {
+        Types.DropTx memory _tx = AirdropTxFromBytes(message);
+        return abi.encode(_tx.fromIndex, _tx.toIndex, _tx.amount, sig);
+    }
+
+    function DecompressDrop(bytes memory dropBytes)
+        public
+        pure
+        returns (Types.DropTx memory)
+    {
+        Types.DropTx memory drop;
+        (drop.toIndex, drop.amount, drop.signature) = abi.decode(
+            dropBytes,
+            (uint256, uint256, bytes)
+        );
+        return drop;
     }
 
     function BurnConsentTxFromBytes(bytes memory txBytes)
@@ -152,16 +359,6 @@ library RollupUtils {
         return _tx;
     }
 
-    function DecompressCreateAccount(bytes memory txBytes)
-        public
-        pure
-        returns (Types.CreateAccount memory)
-    {
-        Types.CreateAccount memory _tx;
-        (_tx.toIndex, _tx.tokenType) = abi.decode(txBytes, (uint256, uint256));
-        return _tx;
-    }
-
     function CompressConsent(Types.BurnConsent memory _tx)
         public
         pure
@@ -194,53 +391,9 @@ library RollupUtils {
         return abi.encode(fromIndex, signature);
     }
 
-    function CompressCreateAccount(Types.CreateAccount memory _tx)
-        public
-        pure
-        returns (bytes memory)
-    {
-        return abi.encode(_tx.toIndex, _tx.tokenType, _tx.signature);
-    }
-
-    function CompressCreateAccountNoStruct(
-        uint256 toIndex,
-        uint256 tokenType,
-        uint256 signature
-    ) public pure returns (bytes memory) {
-        return abi.encode(toIndex, tokenType, signature);
-    }
-
-    function CompressCreateAccountTxWithMessage(
-        bytes memory message,
-        bytes memory sig
-    ) public pure returns (bytes memory) {
-        Types.CreateAccount memory _tx;
-        (_tx.toIndex, _tx.tokenType, ) = abi.decode(
-            message,
-            (uint256, uint256, bytes)
-        );
-        return abi.encode(_tx.toIndex, _tx.tokenType, sig);
-    }
-
     //
     // BytesFromTx and BytesFromTxDeconstructed do the same thing i.e encode transaction to bytes
     //
-
-    function BytesFromCreateAccount(Types.CreateAccount memory _tx)
-        public
-        pure
-        returns (bytes memory)
-    {
-        return abi.encodePacked(_tx.toIndex, _tx.tokenType);
-    }
-
-    function BytesFromCreateAccountNoStruct(uint256 toIndex, uint256 tokenType)
-        public
-        pure
-        returns (bytes memory)
-    {
-        return abi.encodePacked(toIndex, tokenType);
-    }
 
     function BytesFromBurnConsent(Types.BurnConsent memory _tx)
         public
@@ -274,7 +427,6 @@ library RollupUtils {
     ) public pure returns (bytes memory) {
         return abi.encodePacked(to, tokenType);
     }
-
 
     function BytesFromTxBurnExecutionDeconstructed(uint256 fromIndex)
         public
@@ -440,103 +592,6 @@ library RollupUtils {
         return abi.encode(_tx.fromIndex, _tx.toIndex, _tx.amount, sig);
     }
 
-    //
-    // Airdrop Utils
-    //
-
-    function CompressDrop(Types.DropTx memory _tx)
-        public
-        pure
-        returns (bytes memory)
-    {
-        return abi.encode(_tx.toIndex, _tx.amount, _tx.signature);
-    }
-
-    function CompressAirdropTxWithMessage(
-        bytes memory message,
-        bytes memory sig
-    ) public pure returns (bytes memory) {
-        Types.DropTx memory _tx = AirdropTxFromBytes(message);
-        return abi.encode(_tx.fromIndex, _tx.toIndex, _tx.amount, sig);
-    }
-
-    function CompressDropNoStruct(
-        uint256 toIndex,
-        uint256 amount,
-        bytes memory sig
-    ) public pure returns (bytes memory) {
-        return abi.encodePacked(toIndex, amount, sig);
-    }
-
-    function DecompressDrop(bytes memory dropBytes)
-        public
-        pure
-        returns (Types.DropTx memory)
-    {
-        Types.DropTx memory drop;
-        (drop.toIndex, drop.amount, drop.signature) = abi.decode(
-            dropBytes,
-            (uint256, uint256, bytes)
-        );
-        return drop;
-    }
-
-    function BytesFromTxAirdropDeconstructed(
-        uint256 from,
-        uint256 to,
-        uint256 tokenType,
-        uint256 nonce,
-        uint256 txType,
-        uint256 amount
-    ) public pure returns (bytes memory) {
-        return abi.encodePacked(from, to, tokenType, nonce, txType, amount);
-    }
-
-    function BytesFromAirdrop(Types.DropTx memory _tx)
-        public
-        pure
-        returns (bytes memory)
-    {
-        return
-            abi.encodePacked(
-                _tx.fromIndex,
-                _tx.toIndex,
-                _tx.tokenType,
-                _tx.nonce,
-                _tx.txType,
-                _tx.amount
-            );
-    }
-
-    function getCreateAccountSignBytes(uint256 toIndex, uint256 tokenType)
-        public
-        pure
-        returns (bytes32)
-    {
-        return keccak256(abi.encodePacked(toIndex, tokenType));
-    }
-
-    function getDropSignBytes(
-        uint256 fromIndex,
-        uint256 toIndex,
-        uint256 tokenType,
-        uint256 txType,
-        uint256 nonce,
-        uint256 amount
-    ) public pure returns (bytes32) {
-        return
-            keccak256(
-                BytesFromTxAirdropDeconstructed(
-                    fromIndex,
-                    toIndex,
-                    tokenType,
-                    nonce,
-                    txType,
-                    amount
-                )
-            );
-    }
-
     function getBurnConsentSignBytes(
         uint256 fromIndex,
         uint256 amount,
@@ -560,45 +615,6 @@ library RollupUtils {
         returns (bytes32)
     {
         return keccak256(BytesFromTxBurnExecutionDeconstructed(fromIndex));
-    }
-
-    function AirdropTxFromBytesNoStruct(bytes memory txBytes)
-        public
-        pure
-        returns (
-            uint256 from,
-            uint256 to,
-            uint256 tokenType,
-            uint256 nonce,
-            uint256 txType,
-            uint256 amount
-        )
-    {
-        return
-            abi.decode(
-                txBytes,
-                (uint256, uint256, uint256, uint256, uint256, uint256)
-            );
-    }
-
-    function AirdropTxFromBytes(bytes memory txBytes)
-        public
-        pure
-        returns (Types.DropTx memory)
-    {
-        Types.DropTx memory transaction;
-        (
-            transaction.fromIndex,
-            transaction.toIndex,
-            transaction.tokenType,
-            transaction.nonce,
-            transaction.txType,
-            transaction.amount
-        ) = abi.decode(
-            txBytes,
-            (uint256, uint256, uint256, uint256, uint256, uint256)
-        );
-        return transaction;
     }
 
     //

--- a/contracts/libs/RollupUtils.sol
+++ b/contracts/libs/RollupUtils.sol
@@ -194,7 +194,7 @@ library RollupUtils {
         return abi.encodePacked(toIndex, tokenType);
     }
 
-    function CreateAccountTxFromBytes(bytes memory txBytes)
+    function CreateAccountFromBytes(bytes memory txBytes)
         public
         pure
         returns (Types.CreateAccount memory)
@@ -204,7 +204,7 @@ library RollupUtils {
         return _tx;
     }
 
-    function getCreateAccountSignBytes(uint256 toIndex, uint256 tokenType)
+    function CreateAccountSignBytes(uint256 toIndex, uint256 tokenType)
         public
         pure
         returns (bytes32)
@@ -228,7 +228,7 @@ library RollupUtils {
         return abi.encode(toIndex, tokenType, signature);
     }
 
-    function CompressCreateAccountTxWithMessage(
+    function CompressCreateAccountWithMessage(
         bytes memory message,
         bytes memory sig
     ) public pure returns (bytes memory) {
@@ -270,7 +270,7 @@ library RollupUtils {
             );
     }
 
-    function BytesFromTxAirdropDeconstructed(
+    function BytesFromAirdropNoStruct(
         uint256 from,
         uint256 to,
         uint256 tokenType,
@@ -281,7 +281,7 @@ library RollupUtils {
         return abi.encodePacked(from, to, tokenType, nonce, txType, amount);
     }
 
-    function AirdropTxFromBytes(bytes memory txBytes)
+    function AirdropFromBytes(bytes memory txBytes)
         public
         pure
         returns (Types.DropTx memory)
@@ -301,7 +301,7 @@ library RollupUtils {
         return transaction;
     }
 
-    function AirdropTxFromBytesNoStruct(bytes memory txBytes)
+    function AirdropFromBytesNoStruct(bytes memory txBytes)
         public
         pure
         returns (
@@ -320,7 +320,7 @@ library RollupUtils {
             );
     }
 
-    function getDropSignBytes(
+    function AirdropSignBytes(
         uint256 fromIndex,
         uint256 toIndex,
         uint256 tokenType,
@@ -330,7 +330,7 @@ library RollupUtils {
     ) public pure returns (bytes32) {
         return
             keccak256(
-                BytesFromTxAirdropDeconstructed(
+                BytesFromAirdropNoStruct(
                     fromIndex,
                     toIndex,
                     tokenType,
@@ -341,7 +341,7 @@ library RollupUtils {
             );
     }
 
-    function CompressDrop(Types.DropTx memory _tx)
+    function CompressAirdrop(Types.DropTx memory _tx)
         public
         pure
         returns (bytes memory)
@@ -349,7 +349,7 @@ library RollupUtils {
         return abi.encode(_tx.toIndex, _tx.amount, _tx.signature);
     }
 
-    function CompressDropNoStruct(
+    function CompressAirdropNoStruct(
         uint256 toIndex,
         uint256 amount,
         bytes memory sig
@@ -361,11 +361,11 @@ library RollupUtils {
         bytes memory message,
         bytes memory sig
     ) public pure returns (bytes memory) {
-        Types.DropTx memory _tx = AirdropTxFromBytes(message);
+        Types.DropTx memory _tx = AirdropFromBytes(message);
         return abi.encode(_tx.fromIndex, _tx.toIndex, _tx.amount, sig);
     }
 
-    function DecompressDrop(bytes memory dropBytes)
+    function DecompressAirdrop(bytes memory dropBytes)
         public
         pure
         returns (Types.DropTx memory)
@@ -532,7 +532,7 @@ library RollupUtils {
             abi.encodePacked(_tx.fromIndex, _tx.amount, _tx.nonce, _tx.cancel);
     }
 
-    function BytesFromBurnConsentDeconstructed(
+    function BytesFromBurnConsentNoStruct(
         uint256 fromIndex,
         uint256 amount,
         uint256 nonce,
@@ -554,7 +554,7 @@ library RollupUtils {
         return _tx;
     }
 
-    function getBurnConsentSignBytes(
+    function BurnConsentSignBytes(
         uint256 fromIndex,
         uint256 amount,
         uint256 nonce,
@@ -562,7 +562,7 @@ library RollupUtils {
     ) public pure returns (bytes32) {
         return
             keccak256(
-                BytesFromBurnConsentDeconstructed(
+                BytesFromBurnConsentNoStruct(
                     fromIndex,
                     amount,
                     nonce,
@@ -571,7 +571,7 @@ library RollupUtils {
             );
     }
 
-    function CompressConsent(Types.BurnConsent memory _tx)
+    function CompressBurnConsent(Types.BurnConsent memory _tx)
         public
         pure
         returns (bytes memory)
@@ -579,7 +579,7 @@ library RollupUtils {
         return abi.encode(_tx.fromIndex, _tx.amount, _tx.cancel, _tx.signature);
     }
 
-    function CompressConsentNoStruct(
+    function CompressBurnConsentNoStruct(
         uint256 fromIndex,
         uint256 amount,
         bool cancel,
@@ -588,7 +588,7 @@ library RollupUtils {
         return abi.encode(fromIndex, amount, cancel, sig);
     }
 
-    function DecompressConsent(bytes memory txBytes)
+    function DecompressBurnConsent(bytes memory txBytes)
         public
         pure
         returns (Types.BurnConsent memory)
@@ -599,12 +599,12 @@ library RollupUtils {
         return _tx;
     }
 
-    function HashFromConsent(Types.BurnConsent memory _tx)
+    function HashFromBurnConsent(Types.BurnConsent memory _tx)
         public
         pure
         returns (bytes32)
     {
-        return keccak256(CompressConsent(_tx));
+        return keccak256(CompressBurnConsent(_tx));
     }
 
     //
@@ -619,7 +619,7 @@ library RollupUtils {
         return abi.encodePacked(_tx.fromIndex);
     }
 
-    function BytesFromTxBurnExecutionDeconstructed(uint256 fromIndex)
+    function BytesFromBurnExecutionNoStruct(uint256 fromIndex)
         public
         pure
         returns (bytes memory)
@@ -627,7 +627,7 @@ library RollupUtils {
         return abi.encodePacked(fromIndex);
     }
 
-    function BurnExecutionTxFromBytes(bytes memory txBytes)
+    function BurnExecutionFromBytes(bytes memory txBytes)
         public
         pure
         returns (Types.BurnExecution memory)
@@ -637,15 +637,15 @@ library RollupUtils {
         return _tx;
     }
 
-    function getBurnExecutionSignBytes(uint256 fromIndex)
+    function BurnExecutionSignBytes(uint256 fromIndex)
         public
         pure
         returns (bytes32)
     {
-        return keccak256(BytesFromTxBurnExecutionDeconstructed(fromIndex));
+        return keccak256(BytesFromBurnExecutionNoStruct(fromIndex));
     }
 
-    function CompressExecution(Types.BurnExecution memory _tx)
+    function CompressBurnExecution(Types.BurnExecution memory _tx)
         public
         pure
         returns (bytes memory)
@@ -653,14 +653,14 @@ library RollupUtils {
         return abi.encode(_tx.fromIndex);
     }
 
-    function CompressExecutionNoStruct(
+    function CompressBurnExecutionNoStruct(
         uint256 fromIndex,
         bytes memory signature
     ) public pure returns (bytes memory) {
         return abi.encode(fromIndex, signature);
     }
 
-    function DecompressExecution(bytes memory txBytes)
+    function DecompressBurnExecution(bytes memory txBytes)
         public
         pure
         returns (Types.BurnExecution memory)
@@ -670,12 +670,12 @@ library RollupUtils {
         return _tx;
     }
 
-    function HashFromExecution(Types.BurnExecution memory _tx)
+    function HashFromBurnExecution(Types.BurnExecution memory _tx)
         public
         pure
         returns (bytes32)
     {
-        return keccak256(CompressExecution(_tx));
+        return keccak256(CompressBurnExecution(_tx));
     }
 
     function GetYearMonth() public view returns (uint256 yearMonth) {

--- a/contracts/libs/RollupUtils.sol
+++ b/contracts/libs/RollupUtils.sol
@@ -315,6 +315,147 @@ library RollupUtils {
         return drop;
     }
 
+    //
+    // Transfer
+    //
+
+    function BytesFromTx(Types.Transaction memory _tx)
+        public
+        pure
+        returns (bytes memory)
+    {
+        return
+            abi.encodePacked(
+                _tx.fromIndex,
+                _tx.toIndex,
+                _tx.tokenType,
+                _tx.nonce,
+                _tx.txType,
+                _tx.amount
+            );
+    }
+
+    function BytesFromTxDeconstructed(
+        uint256 from,
+        uint256 to,
+        uint256 tokenType,
+        uint256 nonce,
+        uint256 txType,
+        uint256 amount
+    ) public pure returns (bytes memory) {
+        return abi.encodePacked(from, to, tokenType, nonce, txType, amount);
+    }
+
+    function TxFromBytes(bytes memory txBytes)
+        public
+        pure
+        returns (Types.Transaction memory)
+    {
+        Types.Transaction memory transaction;
+        (
+            transaction.fromIndex,
+            transaction.toIndex,
+            transaction.tokenType,
+            transaction.nonce,
+            transaction.txType,
+            transaction.amount
+        ) = abi.decode(
+            txBytes,
+            (uint256, uint256, uint256, uint256, uint256, uint256)
+        );
+        return transaction;
+    }
+
+    // Decoding transaction from bytes
+    function TxFromBytesDeconstructed(bytes memory txBytes)
+        public
+        pure
+        returns (
+            uint256 from,
+            uint256 to,
+            uint256 tokenType,
+            uint256 nonce,
+            uint256 txType,
+            uint256 amount
+        )
+    {
+        return
+            abi.decode(
+                txBytes,
+                (uint256, uint256, uint256, uint256, uint256, uint256)
+            );
+    }
+
+    function getTxSignBytes(
+        uint256 fromIndex,
+        uint256 toIndex,
+        uint256 tokenType,
+        uint256 txType,
+        uint256 nonce,
+        uint256 amount
+    ) public pure returns (bytes32) {
+        return
+            keccak256(
+                BytesFromTxDeconstructed(
+                    fromIndex,
+                    toIndex,
+                    tokenType,
+                    nonce,
+                    txType,
+                    amount
+                )
+            );
+    }
+
+    function CompressTx(Types.Transaction memory _tx)
+        public
+        pure
+        returns (bytes memory)
+    {
+        return
+            abi.encode(_tx.fromIndex, _tx.toIndex, _tx.amount, _tx.signature);
+    }
+
+    function CompressTxWithMessage(bytes memory message, bytes memory sig)
+        public
+        pure
+        returns (bytes memory)
+    {
+        Types.Transaction memory _tx = TxFromBytes(message);
+        return abi.encode(_tx.fromIndex, _tx.toIndex, _tx.amount, sig);
+    }
+
+    function DecompressTx(bytes memory txBytes)
+        public
+        pure
+        returns (
+            uint256 from,
+            uint256 to,
+            uint256 nonce,
+            bytes memory sig
+        )
+    {
+        return abi.decode(txBytes, (uint256, uint256, uint256, bytes));
+    }
+
+    function HashFromTx(Types.Transaction memory _tx)
+        public
+        pure
+        returns (bytes32)
+    {
+        return
+            keccak256(
+                BytesFromTxDeconstructed(
+                    _tx.fromIndex,
+                    _tx.toIndex,
+                    _tx.tokenType,
+                    _tx.nonce,
+                    _tx.txType,
+                    _tx.amount
+                )
+            );
+    }
+
     function BurnConsentTxFromBytes(bytes memory txBytes)
         public
         pure
@@ -450,146 +591,6 @@ library RollupUtils {
         returns (bytes32)
     {
         return keccak256(CompressExecution(_tx));
-    }
-
-    //
-    // Transfer Utils
-    //
-    function getTxSignBytes(
-        uint256 fromIndex,
-        uint256 toIndex,
-        uint256 tokenType,
-        uint256 txType,
-        uint256 nonce,
-        uint256 amount
-    ) public pure returns (bytes32) {
-        return
-            keccak256(
-                BytesFromTxDeconstructed(
-                    fromIndex,
-                    toIndex,
-                    tokenType,
-                    nonce,
-                    txType,
-                    amount
-                )
-            );
-    }
-
-    function HashFromTx(Types.Transaction memory _tx)
-        public
-        pure
-        returns (bytes32)
-    {
-        return
-            keccak256(
-                BytesFromTxDeconstructed(
-                    _tx.fromIndex,
-                    _tx.toIndex,
-                    _tx.tokenType,
-                    _tx.nonce,
-                    _tx.txType,
-                    _tx.amount
-                )
-            );
-    }
-
-    function BytesFromTx(Types.Transaction memory _tx)
-        public
-        pure
-        returns (bytes memory)
-    {
-        return
-            abi.encodePacked(
-                _tx.fromIndex,
-                _tx.toIndex,
-                _tx.tokenType,
-                _tx.nonce,
-                _tx.txType,
-                _tx.amount
-            );
-    }
-
-    function BytesFromTxDeconstructed(
-        uint256 from,
-        uint256 to,
-        uint256 tokenType,
-        uint256 nonce,
-        uint256 txType,
-        uint256 amount
-    ) public pure returns (bytes memory) {
-        return abi.encodePacked(from, to, tokenType, nonce, txType, amount);
-    }
-
-    // Decoding transaction from bytes
-    function TxFromBytesDeconstructed(bytes memory txBytes)
-        public
-        pure
-        returns (
-            uint256 from,
-            uint256 to,
-            uint256 tokenType,
-            uint256 nonce,
-            uint256 txType,
-            uint256 amount
-        )
-    {
-        return
-            abi.decode(
-                txBytes,
-                (uint256, uint256, uint256, uint256, uint256, uint256)
-            );
-    }
-
-    function TxFromBytes(bytes memory txBytes)
-        public
-        pure
-        returns (Types.Transaction memory)
-    {
-        Types.Transaction memory transaction;
-        (
-            transaction.fromIndex,
-            transaction.toIndex,
-            transaction.tokenType,
-            transaction.nonce,
-            transaction.txType,
-            transaction.amount
-        ) = abi.decode(
-            txBytes,
-            (uint256, uint256, uint256, uint256, uint256, uint256)
-        );
-        return transaction;
-    }
-
-    function CompressTx(Types.Transaction memory _tx)
-        public
-        pure
-        returns (bytes memory)
-    {
-        return
-            abi.encode(_tx.fromIndex, _tx.toIndex, _tx.amount, _tx.signature);
-    }
-
-    function DecompressTx(bytes memory txBytes)
-        public
-        pure
-        returns (
-            uint256 from,
-            uint256 to,
-            uint256 nonce,
-            bytes memory sig
-        )
-    {
-        return abi.decode(txBytes, (uint256, uint256, uint256, bytes));
-    }
-
-    function CompressTxWithMessage(bytes memory message, bytes memory sig)
-        public
-        pure
-        returns (bytes memory)
-    {
-        Types.Transaction memory _tx = TxFromBytes(message);
-        return abi.encode(_tx.fromIndex, _tx.toIndex, _tx.amount, sig);
     }
 
     function getBurnConsentSignBytes(

--- a/contracts/libs/RollupUtils.sol
+++ b/contracts/libs/RollupUtils.sol
@@ -96,6 +96,69 @@ library RollupUtils {
         return keccak256(BytesFromAccount(account));
     }
 
+    /**
+     * @notice Calculates the address from the pubkey
+     * @param pub is the pubkey
+     * @return Returns the address that has been calculated from the pubkey
+     */
+    function calculateAddress(bytes memory pub)
+        public
+        pure
+        returns (address addr)
+    {
+        bytes32 hash = keccak256(pub);
+        assembly {
+            mstore(0, hash)
+            addr := mload(0)
+        }
+    }
+
+    function GetGenesisLeaves() public pure returns (bytes32[2] memory leaves) {
+        Types.UserAccount memory account1 = Types.UserAccount({
+            ID: 0,
+            tokenType: 0,
+            balance: 0,
+            nonce: 0,
+            burn: 0,
+            lastBurn: 0
+        });
+        Types.UserAccount memory account2 = Types.UserAccount({
+            ID: 1,
+            tokenType: 0,
+            balance: 0,
+            nonce: 0,
+            burn: 0,
+            lastBurn: 0
+        });
+        leaves[0] = HashFromAccount(account1);
+        leaves[1] = HashFromAccount(account2);
+    }
+
+    function GetGenesisDataBlocks()
+        public
+        pure
+        returns (bytes[2] memory dataBlocks)
+    {
+        Types.UserAccount memory account1 = Types.UserAccount({
+            ID: 0,
+            tokenType: 0,
+            balance: 0,
+            nonce: 0,
+            burn: 0,
+            lastBurn: 0
+        });
+        Types.UserAccount memory account2 = Types.UserAccount({
+            ID: 1,
+            tokenType: 0,
+            balance: 0,
+            nonce: 0,
+            burn: 0,
+            lastBurn: 0
+        });
+        dataBlocks[0] = BytesFromAccount(account1);
+        dataBlocks[1] = BytesFromAccount(account2);
+    }
+
     // ---------- Tx Related Utils -------------------
 
     /*
@@ -613,69 +676,6 @@ library RollupUtils {
         returns (bytes32)
     {
         return keccak256(CompressExecution(_tx));
-    }
-
-    /**
-     * @notice Calculates the address from the pubkey
-     * @param pub is the pubkey
-     * @return Returns the address that has been calculated from the pubkey
-     */
-    function calculateAddress(bytes memory pub)
-        public
-        pure
-        returns (address addr)
-    {
-        bytes32 hash = keccak256(pub);
-        assembly {
-            mstore(0, hash)
-            addr := mload(0)
-        }
-    }
-
-    function GetGenesisLeaves() public pure returns (bytes32[2] memory leaves) {
-        Types.UserAccount memory account1 = Types.UserAccount({
-            ID: 0,
-            tokenType: 0,
-            balance: 0,
-            nonce: 0,
-            burn: 0,
-            lastBurn: 0
-        });
-        Types.UserAccount memory account2 = Types.UserAccount({
-            ID: 1,
-            tokenType: 0,
-            balance: 0,
-            nonce: 0,
-            burn: 0,
-            lastBurn: 0
-        });
-        leaves[0] = HashFromAccount(account1);
-        leaves[1] = HashFromAccount(account2);
-    }
-
-    function GetGenesisDataBlocks()
-        public
-        pure
-        returns (bytes[2] memory dataBlocks)
-    {
-        Types.UserAccount memory account1 = Types.UserAccount({
-            ID: 0,
-            tokenType: 0,
-            balance: 0,
-            nonce: 0,
-            burn: 0,
-            lastBurn: 0
-        });
-        Types.UserAccount memory account2 = Types.UserAccount({
-            ID: 1,
-            tokenType: 0,
-            balance: 0,
-            nonce: 0,
-            burn: 0,
-            lastBurn: 0
-        });
-        dataBlocks[0] = BytesFromAccount(account1);
-        dataBlocks[1] = BytesFromAccount(account2);
     }
 
     function GetYearMonth() public view returns (uint256 yearMonth) {

--- a/contracts/libs/RollupUtils.sol
+++ b/contracts/libs/RollupUtils.sol
@@ -544,6 +544,26 @@ library RollupUtils {
         return keccak256(CompressConsent(_tx));
     }
 
+    //
+    // Burn Execution
+    //
+
+    function BytesFromBurnExecution(Types.BurnExecution memory _tx)
+        public
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodePacked(_tx.fromIndex);
+    }
+
+    function BytesFromTxBurnExecutionDeconstructed(uint256 fromIndex)
+        public
+        pure
+        returns (bytes memory)
+    {
+        return abi.encodePacked(fromIndex);
+    }
+
     function BurnExecutionTxFromBytes(bytes memory txBytes)
         public
         pure
@@ -554,14 +574,12 @@ library RollupUtils {
         return _tx;
     }
 
-    function DecompressExecution(bytes memory txBytes)
+    function getBurnExecutionSignBytes(uint256 fromIndex)
         public
         pure
-        returns (Types.BurnExecution memory)
+        returns (bytes32)
     {
-        Types.BurnExecution memory _tx;
-        _tx.fromIndex = abi.decode(txBytes, (uint256));
-        return _tx;
+        return keccak256(BytesFromTxBurnExecutionDeconstructed(fromIndex));
     }
 
     function CompressExecution(Types.BurnExecution memory _tx)
@@ -579,31 +597,14 @@ library RollupUtils {
         return abi.encode(fromIndex, signature);
     }
 
-    //
-    // BytesFromTx and BytesFromTxDeconstructed do the same thing i.e encode transaction to bytes
-    //
-
-    function BytesFromBurnExecution(Types.BurnExecution memory _tx)
+    function DecompressExecution(bytes memory txBytes)
         public
         pure
-        returns (bytes memory)
+        returns (Types.BurnExecution memory)
     {
-        return abi.encodePacked(_tx.fromIndex);
-    }
-
-    function BytesFromTxCreateAccountDeconstructed(
-        uint256 to,
-        uint256 tokenType
-    ) public pure returns (bytes memory) {
-        return abi.encodePacked(to, tokenType);
-    }
-
-    function BytesFromTxBurnExecutionDeconstructed(uint256 fromIndex)
-        public
-        pure
-        returns (bytes memory)
-    {
-        return abi.encodePacked(fromIndex);
+        Types.BurnExecution memory _tx;
+        _tx.fromIndex = abi.decode(txBytes, (uint256));
+        return _tx;
     }
 
     function HashFromExecution(Types.BurnExecution memory _tx)
@@ -614,12 +615,15 @@ library RollupUtils {
         return keccak256(CompressExecution(_tx));
     }
 
-    function getBurnExecutionSignBytes(uint256 fromIndex)
-        public
-        pure
-        returns (bytes32)
-    {
-        return keccak256(BytesFromTxBurnExecutionDeconstructed(fromIndex));
+    //
+    // BytesFromTx and BytesFromTxDeconstructed do the same thing i.e encode transaction to bytes
+    //
+
+    function BytesFromTxCreateAccountDeconstructed(
+        uint256 to,
+        uint256 tokenType
+    ) public pure returns (bytes memory) {
+        return abi.encodePacked(to, tokenType);
     }
 
     //

--- a/contracts/libs/RollupUtils.sol
+++ b/contracts/libs/RollupUtils.sol
@@ -615,25 +615,6 @@ library RollupUtils {
         return keccak256(CompressExecution(_tx));
     }
 
-    //
-    // BytesFromTx and BytesFromTxDeconstructed do the same thing i.e encode transaction to bytes
-    //
-
-    function BytesFromTxCreateAccountDeconstructed(
-        uint256 to,
-        uint256 tokenType
-    ) public pure returns (bytes memory) {
-        return abi.encodePacked(to, tokenType);
-    }
-
-    //
-    // Burn
-    //
-
-    //
-    // Create Account
-    //
-
     /**
      * @notice Calculates the address from the pubkey
      * @param pub is the pubkey

--- a/contracts/libs/RollupUtils.sol
+++ b/contracts/libs/RollupUtils.sol
@@ -456,6 +456,28 @@ library RollupUtils {
             );
     }
 
+    //
+    // Burn Consent
+    //
+
+    function BytesFromBurnConsent(Types.BurnConsent memory _tx)
+        public
+        pure
+        returns (bytes memory)
+    {
+        return
+            abi.encodePacked(_tx.fromIndex, _tx.amount, _tx.nonce, _tx.cancel);
+    }
+
+    function BytesFromBurnConsentDeconstructed(
+        uint256 fromIndex,
+        uint256 amount,
+        uint256 nonce,
+        bool cancel
+    ) public pure returns (bytes memory) {
+        return abi.encode(fromIndex, amount, nonce, cancel);
+    }
+
     function BurnConsentTxFromBytes(bytes memory txBytes)
         public
         pure
@@ -469,35 +491,21 @@ library RollupUtils {
         return _tx;
     }
 
-    function BurnExecutionTxFromBytes(bytes memory txBytes)
-        public
-        pure
-        returns (Types.BurnExecution memory)
-    {
-        Types.BurnExecution memory _tx;
-        _tx.fromIndex = abi.decode(txBytes, (uint256));
-        return _tx;
-    }
-
-    function DecompressConsent(bytes memory txBytes)
-        public
-        pure
-        returns (Types.BurnConsent memory)
-    {
-        Types.BurnConsent memory _tx;
-        (_tx.fromIndex, _tx.amount, _tx.nonce, _tx.cancel, _tx.signature) = abi
-            .decode(txBytes, (uint256, uint256, uint256, bool, bytes));
-        return _tx;
-    }
-
-    function DecompressExecution(bytes memory txBytes)
-        public
-        pure
-        returns (Types.BurnExecution memory)
-    {
-        Types.BurnExecution memory _tx;
-        _tx.fromIndex = abi.decode(txBytes, (uint256));
-        return _tx;
+    function getBurnConsentSignBytes(
+        uint256 fromIndex,
+        uint256 amount,
+        uint256 nonce,
+        bool cancel
+    ) public pure returns (bytes32) {
+        return
+            keccak256(
+                BytesFromBurnConsentDeconstructed(
+                    fromIndex,
+                    amount,
+                    nonce,
+                    cancel
+                )
+            );
     }
 
     function CompressConsent(Types.BurnConsent memory _tx)
@@ -515,6 +523,45 @@ library RollupUtils {
         bytes memory sig
     ) public pure returns (bytes memory) {
         return abi.encode(fromIndex, amount, cancel, sig);
+    }
+
+    function DecompressConsent(bytes memory txBytes)
+        public
+        pure
+        returns (Types.BurnConsent memory)
+    {
+        Types.BurnConsent memory _tx;
+        (_tx.fromIndex, _tx.amount, _tx.nonce, _tx.cancel, _tx.signature) = abi
+            .decode(txBytes, (uint256, uint256, uint256, bool, bytes));
+        return _tx;
+    }
+
+    function HashFromConsent(Types.BurnConsent memory _tx)
+        public
+        pure
+        returns (bytes32)
+    {
+        return keccak256(CompressConsent(_tx));
+    }
+
+    function BurnExecutionTxFromBytes(bytes memory txBytes)
+        public
+        pure
+        returns (Types.BurnExecution memory)
+    {
+        Types.BurnExecution memory _tx;
+        _tx.fromIndex = abi.decode(txBytes, (uint256));
+        return _tx;
+    }
+
+    function DecompressExecution(bytes memory txBytes)
+        public
+        pure
+        returns (Types.BurnExecution memory)
+    {
+        Types.BurnExecution memory _tx;
+        _tx.fromIndex = abi.decode(txBytes, (uint256));
+        return _tx;
     }
 
     function CompressExecution(Types.BurnExecution memory _tx)
@@ -535,24 +582,6 @@ library RollupUtils {
     //
     // BytesFromTx and BytesFromTxDeconstructed do the same thing i.e encode transaction to bytes
     //
-
-    function BytesFromBurnConsent(Types.BurnConsent memory _tx)
-        public
-        pure
-        returns (bytes memory)
-    {
-        return
-            abi.encodePacked(_tx.fromIndex, _tx.amount, _tx.nonce, _tx.cancel);
-    }
-
-    function BytesFromBurnConsentDeconstructed(
-        uint256 fromIndex,
-        uint256 amount,
-        uint256 nonce,
-        bool cancel
-    ) public pure returns (bytes memory) {
-        return abi.encode(fromIndex, amount, nonce, cancel);
-    }
 
     function BytesFromBurnExecution(Types.BurnExecution memory _tx)
         public
@@ -577,37 +606,12 @@ library RollupUtils {
         return abi.encodePacked(fromIndex);
     }
 
-    function HashFromConsent(Types.BurnConsent memory _tx)
-        public
-        pure
-        returns (bytes32)
-    {
-        return keccak256(CompressConsent(_tx));
-    }
-
     function HashFromExecution(Types.BurnExecution memory _tx)
         public
         pure
         returns (bytes32)
     {
         return keccak256(CompressExecution(_tx));
-    }
-
-    function getBurnConsentSignBytes(
-        uint256 fromIndex,
-        uint256 amount,
-        uint256 nonce,
-        bool cancel
-    ) public pure returns (bytes32) {
-        return
-            keccak256(
-                BytesFromBurnConsentDeconstructed(
-                    fromIndex,
-                    amount,
-                    nonce,
-                    cancel
-                )
-            );
     }
 
     function getBurnExecutionSignBytes(uint256 fromIndex)

--- a/contracts/rollupReddit.sol
+++ b/contracts/rollupReddit.sol
@@ -49,7 +49,7 @@ contract RollupReddit {
         bytes memory txBytes
     ) public view returns (bytes memory, bytes32 newRoot) {
         Types.CreateAccount memory transaction = RollupUtils
-            .CreateAccountTxFromBytes(txBytes);
+            .CreateAccountFromBytes(txBytes);
         return createAccount.ApplyCreateAccountTx(_merkle_proof, transaction);
     }
 
@@ -69,7 +69,7 @@ contract RollupReddit {
             bool
         )
     {
-        Types.CreateAccount memory _tx = RollupUtils.CreateAccountTxFromBytes(
+        Types.CreateAccount memory _tx = RollupUtils.CreateAccountFromBytes(
             txBytes
         );
         return
@@ -90,7 +90,7 @@ contract RollupReddit {
         Types.AccountMerkleProof memory _merkle_proof,
         bytes memory txBytes
     ) public view returns (bytes memory, bytes32 newRoot) {
-        Types.DropTx memory transaction = RollupUtils.AirdropTxFromBytes(
+        Types.DropTx memory transaction = RollupUtils.AirdropFromBytes(
             txBytes
         );
         return airdrop.ApplyAirdropTx(_merkle_proof, transaction);
@@ -114,7 +114,7 @@ contract RollupReddit {
             bool
         )
     {
-        Types.DropTx memory _tx = RollupUtils.AirdropTxFromBytes(txBytes);
+        Types.DropTx memory _tx = RollupUtils.AirdropFromBytes(txBytes);
         _tx.signature = sig;
         return
             airdrop.processAirdropTx(
@@ -221,7 +221,7 @@ contract RollupReddit {
         bytes memory txBytes
     ) public view returns (bytes memory updatedAccount, bytes32 newRoot) {
         Types.BurnExecution memory transaction = RollupUtils
-            .BurnExecutionTxFromBytes(txBytes);
+            .BurnExecutionFromBytes(txBytes);
         return burnExecution.ApplyBurnExecutionTx(_merkle_proof, transaction);
     }
 
@@ -239,7 +239,7 @@ contract RollupReddit {
             bool
         )
     {
-        Types.BurnExecution memory _tx = RollupUtils.BurnExecutionTxFromBytes(
+        Types.BurnExecution memory _tx = RollupUtils.BurnExecutionFromBytes(
             txBytes
         );
         return

--- a/test/Reddit.spec.ts
+++ b/test/Reddit.spec.ts
@@ -131,7 +131,7 @@ contract("Reddit", async function () {
             toIndex: userAccountID,
             tokenType: 1
         } as CreateAccount;
-        const signBytes = await RollupUtilsInstance.getCreateAccountSignBytes(tx.toIndex, tx.tokenType);
+        const signBytes = await RollupUtilsInstance.CreateAccountSignBytes(tx.toIndex, tx.tokenType);
         tx.signature = utils.sign(signBytes, Reddit.Wallet);
         const txBytes = await RollupUtilsInstance.BytesFromCreateAccountNoStruct(tx.toIndex, tx.tokenType);
 
@@ -177,11 +177,11 @@ contract("Reddit", async function () {
             txType: Usage.Airdrop,
             amount: 10,
         } as DropTx
-        const signBytes = await RollupUtilsInstance.getDropSignBytes(
+        const signBytes = await RollupUtilsInstance.AirdropSignBytes(
             tx.fromIndex, tx.toIndex, tx.tokenType, tx.txType, tx.nonce, tx.amount
         );
         tx.signature = utils.sign(signBytes, Reddit.Wallet);
-        const txBytes = await RollupUtilsInstance.BytesFromTxAirdropDeconstructed(
+        const txBytes = await RollupUtilsInstance.BytesFromAirdropNoStruct(
             tx.fromIndex, tx.toIndex, tx.tokenType, tx.txType, tx.nonce, tx.amount
         );
 
@@ -211,7 +211,7 @@ contract("Reddit", async function () {
         assert.equal(errorCode, ErrorCode.NoError);
         assert.equal(newBalanceRoot, resultTo[1]);
 
-        const compressedTx = await RollupUtilsInstance.CompressDropNoStruct(
+        const compressedTx = await RollupUtilsInstance.CompressAirdropNoStruct(
             tx.toIndex, tx.amount, tx.signature
         );
         await rollupCoreInstance.submitBatch(
@@ -232,11 +232,11 @@ contract("Reddit", async function () {
             nonce: userMP.accountIP.account.nonce,
             cancel: false,
         } as BurnConsentTx
-        const signBytes = await RollupUtilsInstance.getBurnConsentSignBytes(
+        const signBytes = await RollupUtilsInstance.BurnConsentSignBytes(
             tx.fromIndex, tx.amount, tx.nonce, tx.cancel
         );
         tx.signature = utils.sign(signBytes, User.Wallet);
-        const txBytes = await RollupUtilsInstance.BytesFromBurnConsentDeconstructed(
+        const txBytes = await RollupUtilsInstance.BytesFromBurnConsentNoStruct(
             tx.fromIndex, tx.amount, tx.nonce, tx.cancel
         );
         await RollupUtilsInstance.BurnConsentTxFromBytes(txBytes);
@@ -263,7 +263,7 @@ contract("Reddit", async function () {
         assert.equal(errorCode, ErrorCode.NoError);
         assert.equal(newBalanceRoot, result[1]);
 
-        const compressedTx = await RollupUtilsInstance.CompressConsentNoStruct(
+        const compressedTx = await RollupUtilsInstance.CompressBurnConsentNoStruct(
             tx.fromIndex, tx.amount, tx.cancel, tx.signature
         );
         await rollupCoreInstance.submitBatch(
@@ -281,14 +281,14 @@ contract("Reddit", async function () {
         const tx = {
             fromIndex: User.AccID,
         } as BurnExecutionTx
-        const signBytes = await RollupUtilsInstance.getBurnExecutionSignBytes(
+        const signBytes = await RollupUtilsInstance.BurnExecutionSignBytes(
             tx.fromIndex
         );
         tx.signature = utils.sign(signBytes, User.Wallet);
-        const txBytes = await RollupUtilsInstance.BytesFromTxBurnExecutionDeconstructed(
+        const txBytes = await RollupUtilsInstance.BytesFromBurnExecutionNoStruct(
             tx.fromIndex
         );
-        await RollupUtilsInstance.BurnExecutionTxFromBytes(txBytes);
+        await RollupUtilsInstance.BurnExecutionFromBytes(txBytes);
 
 
         const result = await rollupRedditInstance.ApplyBurnExecutionTx(userMP, txBytes);
@@ -306,7 +306,7 @@ contract("Reddit", async function () {
         assert.equal(errorCode, ErrorCode.NoError, "processTx returns error");
         assert.equal(newBalanceRoot, result[1], "mismatch balance root");
 
-        const compressedTx = await RollupUtilsInstance.CompressExecutionNoStruct(
+        const compressedTx = await RollupUtilsInstance.CompressBurnExecutionNoStruct(
             tx.fromIndex, tx.signature
         );
         await rollupCoreInstance.submitBatch(


### PR DESCRIPTION
The utils are now organized as follows, following this order:

1. BytesFromX
2. BytesFromXNoStruct
3. XFromBytes
4. XSignBytes
5. CompressX
6. CompressXNoStruct
7. CompressXWithMessage
8. DecompressX
9. HashFromX?

@vaibhavchellani Can you confirm do we need XFromBytesNoStruct and HashFromX ?


### Utils for accounts

1. 26b3285d  =>  PDALeafToHash(Types.PDALeaf)
2. 1a636e86  =>  AccountFromBytes(bytes)
3. 61efb43e  =>  BytesFromAccount(Types.UserAccount)
4. a9ef7f3a  =>  BytesFromAccountDeconstructed(uint256,uint256,uint256,uint256,uint256,uint256)
5. dc84864c  =>  getAccountHash(uint256,uint256,uint256,uint256,uint256,uint256)
6. 0d68f924  =>  HashFromAccount(Types.UserAccount)
7. e8a4c04e  =>  calculateAddress(bytes)
8. 3043be91  =>  GetGenesisLeaves()
9. 5e31c831  =>  GetGenesisDataBlocks()

### CreateAccount

1. e594e728  =>  BytesFromCreateAccount(Types.CreateAccount)
2. 34aed69c  =>  BytesFromCreateAccountNoStruct(uint256,uint256)
3. b3c2ec13  =>  CreateAccountFromBytes(bytes)
4. 20fab6d8  =>  CreateAccountSignBytes(uint256,uint256)
5. 73c69e0d  =>  CompressCreateAccount(Types.CreateAccount)
6. c7d4234d  =>  CompressCreateAccountNoStruct(uint256,uint256,uint256)
7. 758d5b28  =>  CompressCreateAccountWithMessage(bytes,bytes)
8. 22002f28  =>  DecompressCreateAccount(bytes)

### Airdrop

1. b1456ad2  =>  BytesFromAirdrop(Types.DropTx)
2. 7368b4a0  =>  BytesFromAirdropNoStruct(uint256,uint256,uint256,uint256,uint256,uint256)
3. bfecfbf3  =>  AirdropFromBytes(bytes)
4. b34dc92b  =>  AirdropFromBytesNoStruct(bytes)
5. 73f43f31  =>  AirdropSignBytes(uint256,uint256,uint256,uint256,uint256,uint256)
6. f2a6e065  =>  CompressAirdrop(Types.DropTx)
7. 1345dc05  =>  CompressAirdropNoStruct(uint256,uint256,bytes)
8. 79f8cb6f  =>  CompressAirdropTxWithMessage(bytes,bytes)
9. 006de34f  =>  DecompressAirdrop(bytes)

### Transfer

I didn't standardize the name in this section to prevent breaking things.

1. dbcbdf9f  =>  BytesFromTx(Types.Transaction)
2. b1b84d99  =>  BytesFromTxDeconstructed(uint256,uint256,uint256,uint256,uint256,uint256)
3. bdbf417a  =>  TxFromBytes(bytes)
4. 2013a0cf  =>  TxFromBytesDeconstructed(bytes)
5. 3ff55544  =>  getTxSignBytes(uint256,uint256,uint256,uint256,uint256,uint256)
6. 26398f63  =>  CompressTx(Types.Transaction)
7. 6877401d  =>  CompressTxWithMessage(bytes,bytes)
8. eedeb9d9  =>  DecompressTx(bytes)
9. ae97e1bf  =>  HashFromTx(Types.Transaction)

### Burn Consent

1. d8bd4f20  =>  BytesFromBurnConsent(Types.BurnConsent)
2. f8ce4bfd  =>  BytesFromBurnConsentNoStruct(uint256,uint256,uint256,bool)
3. 4ff16171  =>  BurnConsentTxFromBytes(bytes)
4. e66d6505  =>  BurnConsentSignBytes(uint256,uint256,uint256,bool)
5. a6def820  =>  CompressBurnConsent(Types.BurnConsent)
6. e2232adb  =>  CompressBurnConsentNoStruct(uint256,uint256,bool,bytes)
7. 0cda9938  =>  DecompressBurnConsent(bytes)
8. 39140429  =>  HashFromBurnConsent(Types.BurnConsent)

### Burn Execution

1. 94e91b86  =>  BytesFromBurnExecution(Types.BurnExecution)
2. 04a585f4  =>  BytesFromBurnExecutionNoStruct(uint256)
3. 7b1849fa  =>  BurnExecutionFromBytes(bytes)
4. 1d587f39  =>  BurnExecutionSignBytes(uint256)
5. 5a8de628  =>  CompressBurnExecution(Types.BurnExecution)
6. 6deba4fe  =>  CompressBurnExecutionNoStruct(uint256,bytes)
7. 659175bb  =>  DecompressBurnExecution(bytes)
8. 9509fe30  =>  HashFromBurnExecution(Types.BurnExecution)

da296257  =>  GetYearMonth()
