### PR TITLE
Rework disputeBatch

### DIFF
--- a/contracts/BurnConsent.sol
+++ b/contracts/BurnConsent.sol
@@ -48,10 +48,10 @@ contract BurnConsent is FraudProofHelpers {
      * @notice processBatch processes a whole batch
      * @return returns updatedRoot, txRoot and if the batch is valid or not
      * */
-    function processBatch(
+    function processBurnConsentBatch(
         bytes32 stateRoot,
         bytes32 accountsRoot,
-        Types.BurnConsent[] memory _txs,
+        bytes[] memory _txBytes,
         Types.BatchValidationProofs memory batchProofs,
         bytes32 expectedTxRoot
     )
@@ -63,6 +63,10 @@ contract BurnConsent is FraudProofHelpers {
             bool
         )
     {
+        Types.BurnConsent[] memory _txs;
+        for (uint256 i = 0; i < _txBytes.length; i++) {
+            _txs[i] = RollupUtils.BurnConsentFromBytes(_txBytes[i]);
+        }
         bytes32 actualTxRoot = generateTxRoot(_txs);
         // if there is an expectation set, revert if it's not met
         if (expectedTxRoot == ZERO_BYTES32) {

--- a/contracts/BurnConsent.sol
+++ b/contracts/BurnConsent.sol
@@ -52,6 +52,7 @@ contract BurnConsent is FraudProofHelpers {
         bytes32 stateRoot,
         bytes32 accountsRoot,
         bytes[] memory _txBytes,
+        bytes[] memory signatures,
         Types.BatchValidationProofs memory batchProofs,
         bytes32 expectedTxRoot
     )
@@ -63,9 +64,16 @@ contract BurnConsent is FraudProofHelpers {
             bool
         )
     {
-        Types.BurnConsent[] memory _txs;
+        require(
+            _txBytes.length == signatures.length,
+            "Mismatch length of signature and txs"
+        );
+        Types.BurnConsent[] memory _txs = new Types.BurnConsent[](
+            _txBytes.length
+        );
         for (uint256 i = 0; i < _txBytes.length; i++) {
             _txs[i] = RollupUtils.BurnConsentFromBytes(_txBytes[i]);
+            _txs[i].signature = signatures[i];
         }
         bytes32 actualTxRoot = generateTxRoot(_txs);
         // if there is an expectation set, revert if it's not met

--- a/contracts/BurnExecution.sol
+++ b/contracts/BurnExecution.sol
@@ -48,10 +48,10 @@ contract BurnExecution is FraudProofHelpers {
      * @notice processBatch processes a whole batch
      * @return returns updatedRoot, txRoot and if the batch is valid or not
      * */
-    function processBatch(
+    function processBurnExecutionBatch(
         bytes32 stateRoot,
         bytes32 accountsRoot,
-        Types.BurnExecution[] memory _txs,
+        bytes[] memory _txBytes,
         Types.BatchValidationProofs memory batchProofs,
         bytes32 expectedTxRoot
     )
@@ -63,6 +63,10 @@ contract BurnExecution is FraudProofHelpers {
             bool
         )
     {
+        Types.BurnExecution[] memory _txs;
+        for (uint256 i = 0; i < _txBytes.length; i++) {
+            _txs[i] = RollupUtils.BurnExecutionFromBytes(_txBytes[i]);
+        }
         bytes32 actualTxRoot = generateTxRoot(_txs);
         // if there is an expectation set, revert if it's not met
         if (expectedTxRoot == ZERO_BYTES32) {

--- a/contracts/CreateAccount.sol
+++ b/contracts/CreateAccount.sol
@@ -67,14 +67,10 @@ contract CreateAccount is FraudProofHelpers {
         return txRoot;
     }
 
-    /**
-     * @notice processBatch processes a whole batch
-     * @return returns updatedRoot, txRoot and if the batch is valid or not
-     * */
-    function processBatch(
+    function processCreateAccountBatch(
         bytes32 stateRoot,
         bytes32 accountsRoot,
-        Types.CreateAccount[] memory _txs,
+        bytes[] memory _txBytes,
         Types.BatchValidationProofs memory batchProofs,
         bytes32 expectedTxRoot
     )
@@ -86,6 +82,11 @@ contract CreateAccount is FraudProofHelpers {
             bool
         )
     {
+        Types.CreateAccount[] memory _txs;
+        for (uint256 i = 0; i < _txBytes.length; i++) {
+            _txs[i] = RollupUtils.CreateAccountFromBytes(_txBytes[i]);
+        }
+
         bytes32 actualTxRoot = generateTxRoot(_txs);
         // if there is an expectation set, revert if it's not met
         if (expectedTxRoot == ZERO_BYTES32) {

--- a/contracts/CreateAccount.sol
+++ b/contracts/CreateAccount.sol
@@ -71,6 +71,7 @@ contract CreateAccount is FraudProofHelpers {
         bytes32 stateRoot,
         bytes32 accountsRoot,
         bytes[] memory _txBytes,
+        bytes[] memory signatures,
         Types.BatchValidationProofs memory batchProofs,
         bytes32 expectedTxRoot
     )
@@ -82,9 +83,16 @@ contract CreateAccount is FraudProofHelpers {
             bool
         )
     {
-        Types.CreateAccount[] memory _txs;
+        require(
+            _txBytes.length == signatures.length,
+            "Mismatch length of signature and txs"
+        );
+        Types.CreateAccount[] memory _txs = new Types.CreateAccount[](
+            _txBytes.length
+        );
         for (uint256 i = 0; i < _txBytes.length; i++) {
             _txs[i] = RollupUtils.CreateAccountFromBytes(_txBytes[i]);
+            _txs[i].signature = signatures[i];
         }
 
         bytes32 actualTxRoot = generateTxRoot(_txs);

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -51,6 +51,7 @@ contract Transfer is FraudProofHelpers {
         bytes32 stateRoot,
         bytes32 accountsRoot,
         bytes[] memory _txBytes,
+        bytes[] memory signatures,
         Types.BatchValidationProofs memory batchProofs,
         bytes32 expectedTxRoot
     )
@@ -62,9 +63,16 @@ contract Transfer is FraudProofHelpers {
             bool
         )
     {
-        Types.Transaction[] memory _txs;
+        require(
+            _txBytes.length == signatures.length,
+            "Mismatch length of signature and txs"
+        );
+        Types.Transaction[] memory _txs = new Types.Transaction[](
+            _txBytes.length
+        );
         for (uint256 i = 0; i < _txBytes.length; i++) {
             _txs[i] = RollupUtils.TxFromBytes(_txBytes[i]);
+            _txs[i].signature = signatures[i];
         }
         bytes32 actualTxRoot = generateTxRoot(_txs);
         // if there is an expectation set, revert if it's not met

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -47,10 +47,10 @@ contract Transfer is FraudProofHelpers {
      * @notice processBatch processes a whole batch
      * @return returns updatedRoot, txRoot and if the batch is valid or not
      * */
-    function processBatch(
+    function processTransferBatch(
         bytes32 stateRoot,
         bytes32 accountsRoot,
-        Types.Transaction[] memory _txs,
+        bytes[] memory _txBytes,
         Types.BatchValidationProofs memory batchProofs,
         bytes32 expectedTxRoot
     )
@@ -62,6 +62,10 @@ contract Transfer is FraudProofHelpers {
             bool
         )
     {
+        Types.Transaction[] memory _txs;
+        for (uint256 i = 0; i < _txBytes.length; i++) {
+            _txs[i] = RollupUtils.TxFromBytes(_txBytes[i]);
+        }
         bytes32 actualTxRoot = generateTxRoot(_txs);
         // if there is an expectation set, revert if it's not met
         if (expectedTxRoot == ZERO_BYTES32) {

--- a/contracts/airdrop.sol
+++ b/contracts/airdrop.sol
@@ -51,7 +51,7 @@ contract Airdrop is FraudProofHelpers {
     function processAirdropBatch(
         bytes32 stateRoot,
         bytes32 accountsRoot,
-        Types.DropTx[] memory _txs,
+        bytes[] memory _txBytes,
         Types.BatchValidationProofs memory batchProofs,
         bytes32 expectedTxRoot
     )
@@ -63,6 +63,10 @@ contract Airdrop is FraudProofHelpers {
             bool
         )
     {
+        Types.DropTx[] memory _txs;
+        for (uint256 i = 0; i < _txBytes.length; i++) {
+            _txs[i] = RollupUtils.AirdropFromBytes(_txBytes[i]);
+        }
         bytes32 actualTxRoot = generateTxRoot(_txs);
         // if there is an expectation set, revert if it's not met
         if (expectedTxRoot == ZERO_BYTES32) {

--- a/contracts/airdrop.sol
+++ b/contracts/airdrop.sol
@@ -52,6 +52,7 @@ contract Airdrop is FraudProofHelpers {
         bytes32 stateRoot,
         bytes32 accountsRoot,
         bytes[] memory _txBytes,
+        bytes[] memory signatures,
         Types.BatchValidationProofs memory batchProofs,
         bytes32 expectedTxRoot
     )
@@ -63,9 +64,15 @@ contract Airdrop is FraudProofHelpers {
             bool
         )
     {
-        Types.DropTx[] memory _txs;
+        require(
+            _txBytes.length == signatures.length,
+            "Mismatch length of signature and txs"
+        );
+
+        Types.DropTx[] memory _txs = new Types.DropTx[](_txBytes.length);
         for (uint256 i = 0; i < _txBytes.length; i++) {
             _txs[i] = RollupUtils.AirdropFromBytes(_txBytes[i]);
+            _txs[i].signature = signatures[i];
         }
         bytes32 actualTxRoot = generateTxRoot(_txs);
         // if there is an expectation set, revert if it's not met

--- a/contracts/interfaces/IReddit.sol
+++ b/contracts/interfaces/IReddit.sol
@@ -132,7 +132,67 @@ interface IReddit {
             bool
         );
 
-    function processBatch(
+    function processCreateAccountBatch(
+        bytes32 initialStateRoot,
+        bytes32 accountsRoot,
+        bytes[] calldata _txs,
+        Types.BatchValidationProofs calldata batchProofs,
+        bytes32 expectedTxRoot
+    )
+        external
+        view
+        returns (
+            bytes32,
+            bytes32,
+            bool
+        );
+
+    function processAirdropBatch(
+        bytes32 initialStateRoot,
+        bytes32 accountsRoot,
+        bytes[] calldata _txs,
+        Types.BatchValidationProofs calldata batchProofs,
+        bytes32 expectedTxRoot
+    )
+        external
+        view
+        returns (
+            bytes32,
+            bytes32,
+            bool
+        );
+
+    function processTransferBatch(
+        bytes32 initialStateRoot,
+        bytes32 accountsRoot,
+        bytes[] calldata _txs,
+        Types.BatchValidationProofs calldata batchProofs,
+        bytes32 expectedTxRoot
+    )
+        external
+        view
+        returns (
+            bytes32,
+            bytes32,
+            bool
+        );
+
+    function processBurnConsentBatch(
+        bytes32 initialStateRoot,
+        bytes32 accountsRoot,
+        bytes[] calldata _txs,
+        Types.BatchValidationProofs calldata batchProofs,
+        bytes32 expectedTxRoot
+    )
+        external
+        view
+        returns (
+            bytes32,
+            bytes32,
+            bool
+        );
+
+    function processBurnExecutionBatch(
         bytes32 initialStateRoot,
         bytes32 accountsRoot,
         bytes[] calldata _txs,

--- a/contracts/interfaces/IReddit.sol
+++ b/contracts/interfaces/IReddit.sol
@@ -136,6 +136,7 @@ interface IReddit {
         bytes32 initialStateRoot,
         bytes32 accountsRoot,
         bytes[] calldata _txs,
+        bytes[] calldata signatures,
         Types.BatchValidationProofs calldata batchProofs,
         bytes32 expectedTxRoot
     )
@@ -151,6 +152,7 @@ interface IReddit {
         bytes32 initialStateRoot,
         bytes32 accountsRoot,
         bytes[] calldata _txs,
+        bytes[] calldata signatures,
         Types.BatchValidationProofs calldata batchProofs,
         bytes32 expectedTxRoot
     )
@@ -166,6 +168,7 @@ interface IReddit {
         bytes32 initialStateRoot,
         bytes32 accountsRoot,
         bytes[] calldata _txs,
+        bytes[] calldata signatures,
         Types.BatchValidationProofs calldata batchProofs,
         bytes32 expectedTxRoot
     )
@@ -181,6 +184,7 @@ interface IReddit {
         bytes32 initialStateRoot,
         bytes32 accountsRoot,
         bytes[] calldata _txs,
+        bytes[] calldata signatures,
         Types.BatchValidationProofs calldata batchProofs,
         bytes32 expectedTxRoot
     )

--- a/contracts/libs/RollupUtils.sol
+++ b/contracts/libs/RollupUtils.sol
@@ -374,7 +374,7 @@ library RollupUtils {
         returns (bytes memory)
     {
         return
-            abi.encodePacked(
+            abi.encode(
                 _tx.fromIndex,
                 _tx.toIndex,
                 _tx.tokenType,
@@ -392,7 +392,7 @@ library RollupUtils {
         uint256 txType,
         uint256 amount
     ) public pure returns (bytes memory) {
-        return abi.encodePacked(from, to, tokenType, nonce, txType, amount);
+        return abi.encode(from, to, tokenType, nonce, txType, amount);
     }
 
     function TxFromBytes(bytes memory txBytes)

--- a/contracts/rollup.sol
+++ b/contracts/rollup.sol
@@ -22,6 +22,7 @@ interface IRollupReddit {
         bytes32 initialStateRoot,
         bytes32 accountsRoot,
         bytes[] calldata _txs,
+        bytes[] calldata signatures,
         Types.BatchValidationProofs calldata batchProofs,
         bytes32 expectedTxRoot,
         Types.Usage batchType
@@ -323,6 +324,7 @@ contract Rollup is RollupHelpers {
     function disputeBatch(
         uint256 _batch_id,
         bytes[] memory _txs,
+        bytes[] memory signatures,
         Types.BatchValidationProofs memory batchProofs
     ) public {
         {
@@ -357,6 +359,7 @@ contract Rollup is RollupHelpers {
             batches[_batch_id - 1].stateRoot,
             batches[_batch_id - 1].accountRoot,
             _txs,
+            signatures,
             batchProofs,
             batches[_batch_id].txRoot,
             batches[_batch_id].batchType

--- a/contracts/rollup.sol
+++ b/contracts/rollup.sol
@@ -21,12 +21,12 @@ interface IRollupReddit {
     function processBatch(
         bytes32 initialStateRoot,
         bytes32 accountsRoot,
-        bytes[] memory _txs,
-        Types.BatchValidationProofs memory batchProofs,
+        bytes[] calldata _txs,
+        Types.BatchValidationProofs calldata batchProofs,
         bytes32 expectedTxRoot,
         Types.Usage batchType
     )
-        public
+        external
         view
         returns (
             bytes32,
@@ -322,7 +322,7 @@ contract Rollup is RollupHelpers {
      */
     function disputeBatch(
         uint256 _batch_id,
-        Types.Transaction[] memory _txs,
+        bytes[] memory _txs,
         Types.BatchValidationProofs memory batchProofs
     ) public {
         {

--- a/contracts/rollup.sol
+++ b/contracts/rollup.sol
@@ -5,7 +5,6 @@ import { SafeMath } from "@openzeppelin/contracts/math/SafeMath.sol";
 import "solidity-bytes-utils/contracts/BytesLib.sol";
 import { IERC20 } from "./interfaces/IERC20.sol";
 import { ITokenRegistry } from "./interfaces/ITokenRegistry.sol";
-import { IFraudProof } from "./interfaces/IFraudProof.sol";
 import { ParamManager } from "./libs/ParamManager.sol";
 import { Types } from "./libs/Types.sol";
 import { RollupUtils } from "./libs/RollupUtils.sol";
@@ -17,6 +16,24 @@ import { MerkleTreeUtils as MTUtils } from "./MerkleTreeUtils.sol";
 import { NameRegistry as Registry } from "./NameRegistry.sol";
 import { Governance } from "./Governance.sol";
 import { DepositManager } from "./DepositManager.sol";
+
+interface IRollupReddit {
+    function processBatch(
+        bytes32 initialStateRoot,
+        bytes32 accountsRoot,
+        bytes[] memory _txs,
+        Types.BatchValidationProofs memory batchProofs,
+        bytes32 expectedTxRoot,
+        Types.Usage batchType
+    )
+        public
+        view
+        returns (
+            bytes32,
+            bytes32,
+            bool
+        );
+}
 
 contract RollupSetup {
     using SafeMath for uint256;
@@ -36,7 +53,7 @@ contract RollupSetup {
     Types.Batch[] public batches;
     MTUtils public merkleUtils;
 
-    IFraudProof public fraudProof;
+    IRollupReddit public rollupReddit;
 
     bytes32
         public constant ZERO_BYTES32 = 0x0000000000000000000000000000000000000000000000000000000000000000;
@@ -237,8 +254,8 @@ contract Rollup is RollupHelpers {
             nameRegistry.getContractDetails(ParamManager.TOKEN_REGISTRY())
         );
 
-        fraudProof = IFraudProof(
-            nameRegistry.getContractDetails(ParamManager.TRANSFER())
+        rollupReddit = IRollupReddit(
+            nameRegistry.getContractDetails(ParamManager.ROLLUP_REDDIT())
         );
         addNewBatch(ZERO_BYTES32, genesisStateRoot, Types.Usage.Genesis);
     }
@@ -335,12 +352,14 @@ contract Rollup is RollupHelpers {
         bytes32 updatedBalanceRoot;
         bool isDisputeValid;
         bytes32 txRoot;
-        (updatedBalanceRoot, txRoot, isDisputeValid) = processBatch(
+        (updatedBalanceRoot, txRoot, isDisputeValid) = rollupReddit
+            .processBatch(
             batches[_batch_id - 1].stateRoot,
             batches[_batch_id - 1].accountRoot,
             _txs,
             batchProofs,
-            batches[_batch_id].txRoot
+            batches[_batch_id].txRoot,
+            batches[_batch_id].batchType
         );
 
         // dispute is valid, we need to slash and rollback :(
@@ -359,81 +378,6 @@ contract Rollup is RollupHelpers {
             SlashAndRollback();
             return;
         }
-    }
-
-    function ApplyTx(
-        Types.AccountMerkleProof memory _merkle_proof,
-        bytes memory txBytes
-    ) public view returns (bytes memory, bytes32 newRoot) {
-        Types.Transaction memory transaction = RollupUtils.TxFromBytes(txBytes);
-        return fraudProof.ApplyTx(_merkle_proof, transaction);
-    }
-
-    /**
-     * @notice processTx processes a transactions and returns the updated balance tree
-     *  and the updated leaves
-     * conditions in require mean that the dispute be declared invalid
-     * if conditons evaluate if the coordinator was at fault
-     * @return Total number of batches submitted onchain
-     */
-    function processTx(
-        bytes32 _balanceRoot,
-        bytes32 _accountsRoot,
-        bytes memory txBytes,
-        Types.PDAMerkleProof memory _from_pda_proof,
-        Types.AccountProofs memory accountProofs
-    )
-        public
-        view
-        returns (
-            bytes32,
-            bytes memory,
-            bytes memory,
-            Types.ErrorCode,
-            bool
-        )
-    {
-        Types.Transaction memory _tx = RollupUtils.TxFromBytes(txBytes);
-        return
-            fraudProof.processTx(
-                _balanceRoot,
-                _accountsRoot,
-                _tx,
-                _from_pda_proof,
-                accountProofs
-            );
-    }
-
-    /**
-     * @notice processBatch processes a batch and returns the updated balance tree
-     *  and the updated leaves
-     * conditions in require mean that the dispute be declared invalid
-     * if conditons evaluate if the coordinator was at fault
-     * @return Total number of batches submitted onchain
-     */
-    function processBatch(
-        bytes32 initialStateRoot,
-        bytes32 accountsRoot,
-        Types.Transaction[] memory _txs,
-        Types.BatchValidationProofs memory batchProofs,
-        bytes32 expectedTxRoot
-    )
-        public
-        view
-        returns (
-            bytes32,
-            bytes32,
-            bool
-        )
-    {
-        return
-            fraudProof.processBatch(
-                initialStateRoot,
-                accountsRoot,
-                _txs,
-                batchProofs,
-                expectedTxRoot
-            );
     }
 
     /**

--- a/contracts/rollupReddit.sol
+++ b/contracts/rollupReddit.sol
@@ -256,6 +256,7 @@ contract RollupReddit {
         bytes32 initialStateRoot,
         bytes32 accountsRoot,
         bytes[] memory _txs,
+        bytes[] memory signatures,
         Types.BatchValidationProofs memory batchProofs,
         bytes32 expectedTxRoot,
         Types.Usage batchType
@@ -274,6 +275,7 @@ contract RollupReddit {
                     initialStateRoot,
                     accountsRoot,
                     _txs,
+                    signatures,
                     batchProofs,
                     expectedTxRoot
                 );
@@ -283,6 +285,7 @@ contract RollupReddit {
                     initialStateRoot,
                     accountsRoot,
                     _txs,
+                    signatures,
                     batchProofs,
                     expectedTxRoot
                 );
@@ -292,6 +295,7 @@ contract RollupReddit {
                     initialStateRoot,
                     accountsRoot,
                     _txs,
+                    signatures,
                     batchProofs,
                     expectedTxRoot
                 );
@@ -301,6 +305,7 @@ contract RollupReddit {
                     initialStateRoot,
                     accountsRoot,
                     _txs,
+                    signatures,
                     batchProofs,
                     expectedTxRoot
                 );

--- a/contracts/rollupReddit.sol
+++ b/contracts/rollupReddit.sol
@@ -251,4 +251,70 @@ contract RollupReddit {
                 _fromAccountProof
             );
     }
+
+    function processBatch(
+        bytes32 initialStateRoot,
+        bytes32 accountsRoot,
+        bytes[] memory _txs,
+        Types.BatchValidationProofs memory batchProofs,
+        bytes32 expectedTxRoot,
+        Types.Usage batchType
+    )
+        public
+        view
+        returns (
+            bytes32,
+            bytes32,
+            bool
+        )
+    {
+        if (batchType == Types.Usage.CreateAccount) {
+            return
+                createAccount.processCreateAccountBatch(
+                    initialStateRoot,
+                    accountsRoot,
+                    _txs,
+                    batchProofs,
+                    expectedTxRoot
+                );
+        } else if (batchType == Types.Usage.Airdrop) {
+            return
+                airdrop.processAirdropBatch(
+                    initialStateRoot,
+                    accountsRoot,
+                    _txs,
+                    batchProofs,
+                    expectedTxRoot
+                );
+        } else if (batchType == Types.Usage.Transfer) {
+            return
+                transfer.processTransferBatch(
+                    initialStateRoot,
+                    accountsRoot,
+                    _txs,
+                    batchProofs,
+                    expectedTxRoot
+                );
+        } else if (batchType == Types.Usage.BurnConsent) {
+            return
+                burnConsent.processBurnConsentBatch(
+                    initialStateRoot,
+                    accountsRoot,
+                    _txs,
+                    batchProofs,
+                    expectedTxRoot
+                );
+        } else if (batchType == Types.Usage.BurnExecution) {
+            return
+                burnExecution.processBurnExecutionBatch(
+                    initialStateRoot,
+                    accountsRoot,
+                    _txs,
+                    batchProofs,
+                    expectedTxRoot
+                );
+        } else {
+            revert("Invalid BatchType to dispute");
+        }
+    }
 }

--- a/migrations/2_deploy.js
+++ b/migrations/2_deploy.js
@@ -159,6 +159,14 @@ async function deploy(deployer) {
         "DEPOSIT_MANAGER"
     );
 
+    const rollupRedditInstance = await deployAndRegister(
+        deployer,
+        rollupRedditContract,
+        [Types, paramManagerLib, rollupUtilsLib],
+        [nameRegistryInstance.address],
+        "ROLLUP_REDDIT"
+    );
+
     // deploy Rollup core
     const rollupInstance = await deployAndRegister(
         deployer,
@@ -166,13 +174,6 @@ async function deploy(deployer) {
         [ECVerifyLib, Types, paramManagerLib, rollupUtilsLib],
         [nameRegistryInstance.address, root],
         "ROLLUP_CORE"
-    );
-    const rollupRedditInstance = await deployAndRegister(
-        deployer,
-        rollupRedditContract,
-        [Types, paramManagerLib, rollupUtilsLib],
-        [nameRegistryInstance.address],
-        "ROLLUP_REDDIT"
     );
 
     const contractAddresses = {

--- a/test/Rollup.spec.ts
+++ b/test/Rollup.spec.ts
@@ -7,7 +7,7 @@ const TestToken = artifacts.require("TestToken");
 const DepositManager = artifacts.require("DepositManager");
 const IMT = artifacts.require("IncrementalTree");
 const RollupUtils = artifacts.require("RollupUtils");
-const EcVerify = artifacts.require("ECVerify");
+const RollupReddit = artifacts.require("RollupReddit");
 
 contract("Rollup", async function(accounts) {
     var wallets: any;
@@ -20,6 +20,7 @@ contract("Rollup", async function(accounts) {
     let RollupUtilsInstance: any;
     let tokenRegistryInstance: any;
     let IMTInstance: any;
+    let RollupRedditInstance: any;
 
     let Alice: any;
     let Bob: any;
@@ -53,6 +54,7 @@ contract("Rollup", async function(accounts) {
         RollupUtilsInstance = await RollupUtils.deployed();
         tokenRegistryInstance = await utils.getTokenRegistry();
         IMTInstance = await IMT.deployed();
+        RollupRedditInstance = await RollupReddit.deployed();
 
         Alice = {
             Address: wallets[0].getAddressString(),
@@ -119,6 +121,7 @@ contract("Rollup", async function(accounts) {
                 from: wallets[0].getAddressString()
             }
         );
+
         await testToken.approve(
             depositManagerInstance.address,
             ethers.utils.parseEther("1"),
@@ -270,11 +273,14 @@ contract("Rollup", async function(accounts) {
             to: BobAccountMP
         };
 
+        const txByte = await utils.TxToBytes(tx);
+
         // process transaction validity with process tx
-        var result = await rollupCoreInstance.processTx(
+        const result = await RollupRedditInstance.processTransferTx(
             currentRoot,
             accountRoot,
-            await utils.TxToBytes(tx),
+            tx.signature,
+            txByte,
             alicePDAProof,
             accountProofs
         );
@@ -284,7 +290,8 @@ contract("Rollup", async function(accounts) {
 
         falseBatchZero = {
             batchId: 0,
-            txs: [tx],
+            txs: [txByte],
+            signatures: [tx.signature],
             batchProofs: {
                 accountProofs: [accountProofs],
                 pdaProof: [alicePDAProof]
@@ -299,6 +306,7 @@ contract("Rollup", async function(accounts) {
         await rollupCoreInstance.disputeBatch(
             falseBatchZero.batchId,
             falseBatchZero.txs,
+            falseBatchZero.signatures,
             falseBatchZero.batchProofs
         );
 
@@ -407,12 +415,13 @@ contract("Rollup", async function(accounts) {
             from: AliceAccountMP,
             to: BobAccountMP
         };
-
+        const txByte = await utils.TxToBytes(tx);
         // process transaction validity with process tx
-        var result = await rollupCoreInstance.processTx(
+        const result = await RollupRedditInstance.processTransferTx(
             currentRoot,
             accountRoot,
-            await utils.TxToBytes(tx),
+            tx.signature,
+            txByte,
             alicePDAProof,
             accountProofs
         );
@@ -427,7 +436,8 @@ contract("Rollup", async function(accounts) {
 
         falseBatchOne = {
             batchId: 0,
-            txs: [tx],
+            txs: [txByte],
+            signatures: [tx.signature],
             batchProofs: {
                 accountProofs: [accountProofs],
                 pdaProof: [alicePDAProof]
@@ -442,6 +452,7 @@ contract("Rollup", async function(accounts) {
         await rollupCoreInstance.disputeBatch(
             falseBatchOne.batchId,
             falseBatchOne.txs,
+            falseBatchOne.signatures,
             falseBatchOne.batchProofs
         );
 
@@ -453,8 +464,9 @@ contract("Rollup", async function(accounts) {
             falseBatchOne.batchId - 1,
             "batchId doesnt match"
         );
-        Alice.Amount += falseBatchOne.txs[0].amount;
-        Bob.Amount -= falseBatchOne.txs[0].amount;
+        const tx = await RollupUtilsInstance.TxFromBytes(falseBatchOne.txs[0]);
+        Alice.Amount += Number(tx.amount);
+        Bob.Amount -= Number(tx.amount);
         Alice.nonce--;
     });
 
@@ -559,11 +571,14 @@ contract("Rollup", async function(accounts) {
             to: BobAccountMP
         };
 
+        const txByte = await utils.TxToBytes(tx);
+
         // process transaction validity with process tx
-        var result = await rollupCoreInstance.processTx(
+        const result = await RollupRedditInstance.processTransferTx(
             currentRoot,
             accountRoot,
-            await utils.TxToBytes(tx),
+            tx.signature,
+            txByte,
             alicePDAProof,
             accountProofs
         );
@@ -579,7 +594,8 @@ contract("Rollup", async function(accounts) {
 
         falseBatchTwo = {
             batchId: 0,
-            txs: [tx],
+            txs: [txByte],
+            signatures: [tx.signature],
             batchProofs: {
                 accountProofs: [accountProofs],
                 pdaProof: [alicePDAProof]
@@ -594,6 +610,7 @@ contract("Rollup", async function(accounts) {
         await rollupCoreInstance.disputeBatch(
             falseBatchTwo.batchId,
             falseBatchTwo.txs,
+            falseBatchTwo.signatures,
             falseBatchTwo.batchProofs
         );
 
@@ -605,8 +622,9 @@ contract("Rollup", async function(accounts) {
             falseBatchTwo.batchId - 1,
             "batchId doesnt match"
         );
-        Alice.Amount += falseBatchTwo.txs[0].amount;
-        Bob.Amount -= falseBatchTwo.txs[0].amount;
+        const tx = await RollupUtilsInstance.TxFromBytes(falseBatchTwo.txs[0]);
+        Alice.Amount += Number(tx.amount);
+        Bob.Amount -= Number(tx.amount);
         Alice.nonce--;
     });
 
@@ -736,11 +754,14 @@ contract("Rollup", async function(accounts) {
             to: BobAccountMP
         };
 
+        const txByte = await utils.TxToBytes(tx);
+
         // process transaction validity with process tx
-        var result = await rollupCoreInstance.processTx(
+        const result = await RollupRedditInstance.processTransferTx(
             currentRoot,
             accountRoot,
-            await utils.TxToBytes(tx),
+            tx.signature,
+            txByte,
             alicePDAProof,
             accountProofs
         );
@@ -755,7 +776,8 @@ contract("Rollup", async function(accounts) {
 
         falseBatchFive = {
             batchId: 0,
-            txs: [tx],
+            txs: [txByte],
+            signatures: [tx.signature],
             batchProofs: {
                 accountProofs: [accountProofs],
                 pdaProof: [alicePDAProof]
@@ -769,6 +791,7 @@ contract("Rollup", async function(accounts) {
         await rollupCoreInstance.disputeBatch(
             falseBatchFive.batchId,
             falseBatchFive.txs,
+            falseBatchFive.signatures,
             falseBatchFive.batchProofs
         );
 
@@ -780,8 +803,9 @@ contract("Rollup", async function(accounts) {
             falseBatchFive.batchId - 1,
             "batchId doesnt match"
         );
-        Alice.Amount += falseBatchFive.txs[0].amount;
-        Bob.Amount -= falseBatchFive.txs[0].amount;
+        const tx = await RollupUtilsInstance.TxFromBytes(falseBatchFive.txs[0]);
+        Alice.Amount += Number(tx.amount);
+        Bob.Amount -= Number(tx.amount);
         Alice.nonce--;
     });
 
@@ -893,11 +917,14 @@ contract("Rollup", async function(accounts) {
             to: BobAccountMP
         };
 
+        const txByte = await utils.TxToBytes(tx);
+
         // process transaction validity with process tx
-        var result = await rollupCoreInstance.processTx(
+        const result = await RollupRedditInstance.processTransferTx(
             currentRoot,
             accountRoot,
-            await utils.TxToBytes(tx),
+            tx.signature,
+            txByte,
             alicePDAProof,
             accountProofs
         );
@@ -908,7 +935,8 @@ contract("Rollup", async function(accounts) {
 
         falseBatchComb = {
             batchId: 0,
-            txs: [tx],
+            txs: [txByte],
+            signatures: [tx.signature],
             batchProofs: {
                 accountProofs: [accountProofs],
                 pdaProof: [alicePDAProof]
@@ -1020,11 +1048,14 @@ contract("Rollup", async function(accounts) {
             to: BobAccountMP
         };
 
+        const txByte = await utils.TxToBytes(tx);
+
         // process transaction validity with process tx
-        var result = await rollupCoreInstance.processTx(
+        const result = await RollupRedditInstance.processTransferTx(
             currentRoot,
             accountRoot,
-            await utils.TxToBytes(tx),
+            tx.signature,
+            txByte,
             alicePDAProof,
             accountProofs
         );
@@ -1037,7 +1068,8 @@ contract("Rollup", async function(accounts) {
         );
         await utils.compressAndSubmitBatch(tx, falseResult);
 
-        falseBatchComb.txs.push(tx);
+        falseBatchComb.txs.push(txByte);
+        falseBatchComb.signatures.push(tx.signature);
         falseBatchComb.batchProofs.accountProofs.push(accountProofs);
         falseBatchComb.batchProofs.pdaProof.push(alicePDAProof);
     });
@@ -1046,6 +1078,7 @@ contract("Rollup", async function(accounts) {
         await rollupCoreInstance.disputeBatch(
             falseBatchComb.batchId,
             falseBatchComb.txs,
+            falseBatchComb.signatures,
             falseBatchComb.batchProofs
         );
 
@@ -1057,10 +1090,16 @@ contract("Rollup", async function(accounts) {
             falseBatchComb.batchId - 1,
             "batchId doesnt match"
         );
-        Alice.Amount += falseBatchComb.txs[0].amount;
-        Alice.Amount += falseBatchComb.txs[1].amount;
-        Bob.Amount -= falseBatchComb.txs[0].amount;
-        Bob.Amount -= falseBatchComb.txs[1].amount;
+        const tx0 = await RollupUtilsInstance.TxFromBytes(
+            falseBatchComb.txs[0]
+        );
+        const tx1 = await RollupUtilsInstance.TxFromBytes(
+            falseBatchComb.txs[1]
+        );
+        Alice.Amount += Number(tx0.amount);
+        Alice.Amount += Number(tx1.amount);
+        Bob.Amount -= Number(tx0.amount);
+        Bob.Amount -= Number(tx1.amount);
         Alice.nonce--;
         Alice.nonce--;
     });


### PR DESCRIPTION
> how dispute call propagetes?
rollup.sol::disputeBatch -> redditrollup.sol::processBatch -> X.sol::processXBatch

The transfer disputes are tests in the Rollup.spec.ts. But disputes for the other txTypes remain untested.