### PR TITLE
fix token type check

### DIFF
--- a/contracts/CreateAccount.sol
+++ b/contracts/CreateAccount.sol
@@ -155,6 +155,9 @@ contract CreateAccount is FraudProofHelpers {
         if (to_account_proof.accountIP.pathToAccount != _tx.stateID) {
             return ("", "", Types.ErrorCode.NotOnDesignatedStateLeaf, false);
         }
+        if (tokenRegistry.registeredTokens(_tx.tokenType) == address(0)) {
+            return ("", "", Types.ErrorCode.InvalidTokenAddress, false);
+        }
 
         // Validate we are creating on a zero account
         if (

--- a/contracts/FraudProof.sol
+++ b/contracts/FraudProof.sol
@@ -110,13 +110,6 @@ contract FraudProofHelpers is FraudProofSetup {
         Types.Transaction memory _tx,
         Types.UserAccount memory _from_account
     ) public view returns (Types.ErrorCode) {
-        // verify that tokens are registered
-        if (tokenRegistry.registeredTokens(_tx.tokenType) == address(0)) {
-            // invalid state transition
-            // to be slashed because the submitted transaction
-            // had invalid token type
-            return Types.ErrorCode.InvalidTokenAddress;
-        }
         if (_tx.nonce != _from_account.nonce.add(1)) {
             return Types.ErrorCode.BadNonce;
         }

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -147,7 +147,10 @@ contract Transfer is FraudProofHelpers {
             return (ZERO_BYTES32, "", "", err_code, false);
 
         // account holds the token type in the tx
-        if (accountProofs.from.accountIP.account.tokenType != _tx.tokenType)
+        if (
+            accountProofs.from.accountIP.account.tokenType !=
+            accountProofs.to.accountIP.account.tokenType
+        )
             // invalid state transition
             // needs to be slashed because the submitted transaction
             // had invalid token type
@@ -167,19 +170,6 @@ contract Transfer is FraudProofHelpers {
 
         // validate if leaf exists in the updated balance tree
         ValidateAccountMP(newRoot, accountProofs.to);
-
-        // account holds the token type in the tx
-        if (accountProofs.to.accountIP.account.tokenType != _tx.tokenType)
-            // invalid state transition
-            // needs to be slashed because the submitted transaction
-            // had invalid token type
-            return (
-                ZERO_BYTES32,
-                "",
-                "",
-                Types.ErrorCode.BadFromTokenType,
-                false
-            );
 
         (new_to_account, newRoot) = ApplyTx(accountProofs.to, _tx);
 

--- a/contracts/airdrop.sol
+++ b/contracts/airdrop.sol
@@ -146,7 +146,10 @@ contract Airdrop is FraudProofHelpers {
             return (ZERO_BYTES32, "", "", err_code, false);
 
         // account holds the token type in the tx
-        if (accountProofs.from.accountIP.account.tokenType != _tx.tokenType)
+        if (
+            accountProofs.from.accountIP.account.tokenType !=
+            accountProofs.to.accountIP.account.tokenType
+        )
             // invalid state transition
             // needs to be slashed because the submitted transaction
             // had invalid token type
@@ -166,19 +169,6 @@ contract Airdrop is FraudProofHelpers {
 
         // validate if leaf exists in the updated balance tree
         ValidateAccountMP(newRoot, accountProofs.to);
-
-        // account holds the token type in the tx
-        if (accountProofs.to.accountIP.account.tokenType != _tx.tokenType)
-            // invalid state transition
-            // needs to be slashed because the submitted transaction
-            // had invalid token type
-            return (
-                ZERO_BYTES32,
-                "",
-                "",
-                Types.ErrorCode.BadFromTokenType,
-                false
-            );
 
         (new_to_account, newRoot) = ApplyAirdropTx(accountProofs.to, _tx);
 
@@ -215,14 +205,6 @@ contract Airdrop is FraudProofHelpers {
         Types.DropTx memory _tx,
         Types.UserAccount memory _from_account
     ) public view returns (Types.ErrorCode) {
-        // verify that tokens are registered
-        if (tokenRegistry.registeredTokens(_tx.tokenType) == address(0)) {
-            // invalid state transition
-            // to be slashed because the submitted transaction
-            // had invalid token type
-            return Types.ErrorCode.InvalidTokenAddress;
-        }
-
         return _validateTxBasic(_tx.amount, _from_account);
     }
 }

--- a/test/Rollup.spec.ts
+++ b/test/Rollup.spec.ts
@@ -348,9 +348,9 @@ contract("Rollup", async function(accounts) {
             txType: Usage.Transfer,
             fromIndex: Alice.AccID,
             toIndex: Bob.AccID,
-            tokenType: 2, // false token type (Token not valid)
+            tokenType: 1,
             amount: tranferAmount,
-            nonce: 2
+            nonce: 100 // BadNonce
         };
         tx.signature = await utils.signTx(tx, wallets[0]);
 
@@ -434,7 +434,7 @@ contract("Rollup", async function(accounts) {
         var falseResult = await utils.falseProcessTx(tx, accountProofs);
         assert.equal(
             result[3],
-            ErrorCode.InvalidTokenAddress,
+            ErrorCode.BadNonce,
             "False error ID. It should be `1`"
         );
         await utils.compressAndSubmitBatch(tx, falseResult);
@@ -679,9 +679,9 @@ contract("Rollup", async function(accounts) {
             txType: Usage.Transfer,
             fromIndex: Alice.AccID,
             toIndex: Bob.AccID,
-            tokenType: 2, // error
+            tokenType: 1,
             amount: tranferAmount,
-            nonce: 2
+            nonce: 100 // bad nonce
         };
 
         tx.signature = await utils.signTx(tx, wallets[0]);
@@ -774,7 +774,7 @@ contract("Rollup", async function(accounts) {
         var falseResult = await utils.falseProcessTx(tx, accountProofs);
         assert.equal(
             result[3],
-            ErrorCode.BadFromTokenType,
+            ErrorCode.BadNonce,
             "False ErrorId. It should be `4`"
         );
         await utils.compressAndSubmitBatch(tx, falseResult);
@@ -792,7 +792,7 @@ contract("Rollup", async function(accounts) {
         let batchId = await rollupCoreInstance.numOfBatchesSubmitted();
         falseBatchFive.batchId = Number(batchId) - 1;
     });
-    it("dispute batch false 5th batch(From Token Type)", async function() {
+    it("dispute batch false 5th batch", async function() {
         await rollupCoreInstance.disputeBatch(
             falseBatchFive.batchId,
             falseBatchFive.txs,
@@ -844,9 +844,9 @@ contract("Rollup", async function(accounts) {
             txType: Usage.Transfer,
             fromIndex: Alice.AccID,
             toIndex: Bob.AccID,
-            tokenType: 3, // false type
+            tokenType: 1,
             amount: tranferAmount,
-            nonce: 2
+            nonce: 100 // bad nonce
         };
         tx.signature = await utils.signTx(tx, wallets[0]);
         // alice balance tree merkle proof
@@ -935,7 +935,7 @@ contract("Rollup", async function(accounts) {
         );
 
         var falseResult = await utils.falseProcessTx(tx, accountProofs);
-        assert.equal(result[3], 1, "Wrong ErrorId");
+        assert.equal(result[3], ErrorCode.BadNonce, "Wrong ErrorId");
         await utils.compressAndSubmitBatch(tx, falseResult);
 
         falseBatchComb = {


### PR DESCRIPTION
1. We can trust a tokenType in an account is registered because:
  - if the account is created by deposit, we check the tokenType is registered when deposit
  - if the account is created by createAccount, we had a fraud proof for that.

2. We can remove the token check against tx because we can check against from account and to account instead
