### PR TITLE
remove nonce check in transfer

### DIFF
--- a/contracts/BurnConsent.sol
+++ b/contracts/BurnConsent.sol
@@ -136,10 +136,6 @@ contract BurnConsent is FraudProofHelpers {
 
         // TODO: Validate only certain token is allow to burn
 
-        if (txs.burnConsent_nonceOf(i) != account.nonce.add(1)) {
-            return (ZERO_BYTES32, "", Types.ErrorCode.BadNonce, false);
-        }
-
         bytes32 newRoot;
         bytes memory new_from_account;
         (new_from_account, newRoot) = ApplyBurnConsentTx(

--- a/contracts/FraudProof.sol
+++ b/contracts/FraudProof.sol
@@ -112,10 +112,6 @@ contract FraudProofHelpers is FraudProofSetup {
         uint256 i,
         Types.UserAccount memory _from_account
     ) public pure returns (Types.ErrorCode) {
-        if (txs.transfer_nonceOf(i) != _from_account.nonce.add(1)) {
-            return Types.ErrorCode.BadNonce;
-        }
-
         return _validateTxBasic(txs.transfer_amountOf(i), _from_account);
     }
 

--- a/contracts/FraudProof.sol
+++ b/contracts/FraudProof.sol
@@ -85,7 +85,7 @@ contract FraudProofHelpers is FraudProofSetup {
         );
     }
 
-    function _validateTxBasic(
+    function validateTxBasic(
         uint256 amount,
         Types.UserAccount memory _from_account
     ) public pure returns (Types.ErrorCode) {
@@ -105,14 +105,6 @@ contract FraudProofHelpers is FraudProofSetup {
         }
 
         return Types.ErrorCode.NoError;
-    }
-
-    function validateTxBasic(
-        bytes memory txs,
-        uint256 i,
-        Types.UserAccount memory _from_account
-    ) public pure returns (Types.ErrorCode) {
-        return _validateTxBasic(txs.transfer_amountOf(i), _from_account);
     }
 
     function RemoveTokensFromAccount(

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -139,8 +139,7 @@ contract Transfer is FraudProofHelpers {
         ValidateAccountMP(_balanceRoot, accountProofs.from);
 
         Types.ErrorCode err_code = validateTxBasic(
-            txs,
-            i,
+            txs.transfer_amountOf(i),
             accountProofs.from.accountIP.account
         );
         if (err_code != Types.ErrorCode.NoError)

--- a/contracts/airdrop.sol
+++ b/contracts/airdrop.sol
@@ -119,9 +119,8 @@ contract Airdrop is FraudProofHelpers {
         // Validate the from account merkle proof
         ValidateAccountMP(_balanceRoot, accountProofs.from);
 
-        Types.ErrorCode err_code = validateAirDropTxBasic(
-            txs,
-            i,
+        Types.ErrorCode err_code = validateTxBasic(
+            txs.transfer_amountOf(i),
             accountProofs.from.accountIP.account
         );
         if (err_code != Types.ErrorCode.NoError)
@@ -179,13 +178,5 @@ contract Airdrop is FraudProofHelpers {
                 txs.transfer_receiverOf(i),
                 txs.transfer_amountOf(i)
             );
-    }
-
-    function validateAirDropTxBasic(
-        bytes memory txs,
-        uint256 i,
-        Types.UserAccount memory _from_account
-    ) public pure returns (Types.ErrorCode) {
-        return _validateTxBasic(txs.transfer_amountOf(i), _from_account);
     }
 }

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -142,7 +142,6 @@ library Types {
         BurnAlreadyExecuted,
         NotOnDesignatedStateLeaf,
         NotCreatingOnZeroAccount,
-        BadSignature,
-        BadNonce
+        BadSignature
     }
 }

--- a/scripts/helpers/interfaces.ts
+++ b/scripts/helpers/interfaces.ts
@@ -61,8 +61,7 @@ export enum ErrorCode {
     BurnAlreadyExecuted,
     NotOnDesignatedStateLeaf,
     NotCreatingOnZeroAccount,
-    BadSignature,
-    BadNonce
+    BadSignature
 }
 
 export interface CreateAccount {

--- a/test/Rollup.spec.ts
+++ b/test/Rollup.spec.ts
@@ -352,8 +352,8 @@ contract("Rollup", async function(accounts) {
             fromIndex: Alice.AccID,
             toIndex: Bob.AccID,
             tokenType: 1,
-            amount: tranferAmount,
-            nonce: 100 // BadNonce
+            amount: 0, // InvalidTokenAmount
+            nonce: 2
         };
         tx.signature = await utils.signTx(tx, wallets[0]);
 
@@ -437,7 +437,7 @@ contract("Rollup", async function(accounts) {
         var falseResult = await utils.falseProcessTx(tx, accountProofs);
         assert.equal(
             result[3],
-            ErrorCode.BadNonce,
+            ErrorCode.InvalidTokenAmount,
             "False error ID. It should be `1`"
         );
         await utils.compressAndSubmitBatch(tx, falseResult);
@@ -674,8 +674,6 @@ contract("Rollup", async function(accounts) {
         var AliceAccountLeaf = await utils.createLeaf(Alice);
         var BobAccountLeaf = await utils.createLeaf(Bob);
 
-        // make a transfer between alice and bob's account
-        var tranferAmount = 1;
         // prepare data for process Tx
         var currentRoot = await rollupCoreInstance.getLatestBalanceTreeRoot();
         var accountRoot = await IMTInstance.getTreeRoot();
@@ -693,8 +691,8 @@ contract("Rollup", async function(accounts) {
             fromIndex: Alice.AccID,
             toIndex: Bob.AccID,
             tokenType: 1,
-            amount: tranferAmount,
-            nonce: 100 // bad nonce
+            amount: 0, // InvalidTokenAmount
+            nonce: 2
         };
 
         tx.signature = await utils.signTx(tx, wallets[0]);
@@ -785,11 +783,7 @@ contract("Rollup", async function(accounts) {
         );
 
         var falseResult = await utils.falseProcessTx(tx, accountProofs);
-        assert.equal(
-            result[3],
-            ErrorCode.BadNonce,
-            "False ErrorId. It should be `4`"
-        );
+        assert.equal(result[3], ErrorCode.InvalidTokenAmount, "False ErrorId.");
         await utils.compressAndSubmitBatch(tx, falseResult);
         const compressedTxs = await RollupUtilsInstance.CompressManyTransferFromEncoded(
             [txByte]
@@ -835,9 +829,6 @@ contract("Rollup", async function(accounts) {
     it("submit new batch 6nd(False Batch)", async function() {
         var AliceAccountLeaf = await utils.createLeaf(Alice);
         var BobAccountLeaf = await utils.createLeaf(Bob);
-
-        // make a transfer between alice and bob's account
-        var tranferAmount = 1;
         // prepare data for process Tx
         var currentRoot = await rollupCoreInstance.getLatestBalanceTreeRoot();
         var accountRoot = await IMTInstance.getTreeRoot();
@@ -863,8 +854,8 @@ contract("Rollup", async function(accounts) {
             fromIndex: Alice.AccID,
             toIndex: Bob.AccID,
             tokenType: 1,
-            amount: tranferAmount,
-            nonce: 100 // bad nonce
+            amount: 0, // InvalidTokenAmount
+            nonce: 2
         };
         tx.signature = await utils.signTx(tx, wallets[0]);
         // alice balance tree merkle proof
@@ -953,7 +944,7 @@ contract("Rollup", async function(accounts) {
         );
 
         var falseResult = await utils.falseProcessTx(tx, accountProofs);
-        assert.equal(result[3], ErrorCode.BadNonce, "Wrong ErrorId");
+        assert.equal(result[3], ErrorCode.InvalidTokenAmount, "Wrong ErrorId");
         await utils.compressAndSubmitBatch(tx, falseResult);
         const compressedTxs = await RollupUtilsInstance.CompressManyTransferFromEncoded(
             [txByte]


### PR DESCRIPTION
We decided in Monday that we don't commit nonce of the transfer. So no nonce check.

The Raw transfer has nonce field and the user sign the raw transfer with the nonce field.
The compressed transfer has no nonce field, we get nonce from the account in the fraud-proof and the signature should match.