### PR TITLE
rm burn-consent-amount-check

### DIFF
--- a/contracts/BurnConsent.sol
+++ b/contracts/BurnConsent.sol
@@ -135,14 +135,6 @@ contract BurnConsent is FraudProofHelpers {
         Types.UserAccount memory account = _fromAccountProof.accountIP.account;
 
         // TODO: Validate only certain token is allow to burn
-        if (txs.burnConsent_amountOf(i) == 0) {
-            return (
-                ZERO_BYTES32,
-                "",
-                Types.ErrorCode.InvalidTokenAmount,
-                false
-            );
-        }
 
         if (txs.burnConsent_nonceOf(i) != account.nonce.add(1)) {
             return (ZERO_BYTES32, "", Types.ErrorCode.BadNonce, false);


### PR DESCRIPTION
We now interpret the amount in the burn consent tx as letting the user set arbitrary account.burn. No point to require non-zero amount now