### PR TITLE
remove signature fields in dispute/process batch

### DIFF
--- a/contracts/BurnConsent.sol
+++ b/contracts/BurnConsent.sol
@@ -38,7 +38,6 @@ contract BurnConsent is FraudProofHelpers {
         bytes32 stateRoot,
         bytes32 accountsRoot,
         bytes memory txs,
-        bytes[] memory signatures,
         Types.BatchValidationProofs memory batchProofs,
         bytes32 expectedTxRoot
     )
@@ -51,10 +50,6 @@ contract BurnConsent is FraudProofHelpers {
         )
     {
         uint256 length = txs.burnConsent_size();
-        require(
-            signatures.length == length,
-            "Mismatch length of signature and txs"
-        );
         bytes32 actualTxRoot = merkleUtils.getMerkleRootFromLeaves(
             txs.burnConsent_toLeafs()
         );

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -51,7 +51,6 @@ contract Transfer is FraudProofHelpers {
         bytes32 stateRoot,
         bytes32 accountsRoot,
         bytes memory txs,
-        bytes[] memory signatures,
         Types.BatchValidationProofs memory batchProofs,
         bytes32 expectedTxRoot
     )
@@ -64,10 +63,6 @@ contract Transfer is FraudProofHelpers {
         )
     {
         uint256 length = txs.transfer_size();
-        require(
-            signatures.length == length,
-            "Mismatch length of signature and txs"
-        );
         bytes32 actualTxRoot = merkleUtils.getMerkleRootFromLeaves(
             txs.transfer_toLeafs()
         );

--- a/contracts/airdrop.sol
+++ b/contracts/airdrop.sol
@@ -38,7 +38,6 @@ contract Airdrop is FraudProofHelpers {
         bytes32 stateRoot,
         bytes32 accountsRoot,
         bytes memory txs,
-        bytes[] memory signatures,
         Types.BatchValidationProofs memory batchProofs,
         bytes32 expectedTxRoot
     )

--- a/contracts/interfaces/IReddit.sol
+++ b/contracts/interfaces/IReddit.sol
@@ -159,7 +159,6 @@ interface IReddit {
         bytes32 initialStateRoot,
         bytes32 accountsRoot,
         bytes calldata txs,
-        bytes[] calldata signatures,
         Types.BatchValidationProofs calldata batchProofs,
         bytes32 expectedTxRoot
     )
@@ -175,7 +174,6 @@ interface IReddit {
         bytes32 initialStateRoot,
         bytes32 accountsRoot,
         bytes calldata txs,
-        bytes[] calldata signatures,
         Types.BatchValidationProofs calldata batchProofs,
         bytes32 expectedTxRoot
     )
@@ -191,7 +189,6 @@ interface IReddit {
         bytes32 initialStateRoot,
         bytes32 accountsRoot,
         bytes calldata txs,
-        bytes[] calldata signatures,
         Types.BatchValidationProofs calldata batchProofs,
         bytes32 expectedTxRoot
     )

--- a/contracts/rollup.sol
+++ b/contracts/rollup.sol
@@ -23,7 +23,6 @@ interface IRollupReddit {
         bytes32 initialStateRoot,
         bytes32 accountsRoot,
         bytes calldata _txs,
-        bytes[] calldata signatures,
         Types.BatchValidationProofs calldata batchProofs,
         bytes32 expectedTxRoot,
         Types.Usage batchType
@@ -333,7 +332,6 @@ contract Rollup is RollupHelpers {
     function disputeBatch(
         uint256 _batch_id,
         bytes memory txs,
-        bytes[] memory signatures,
         Types.BatchValidationProofs memory batchProofs
     ) public {
         {
@@ -366,7 +364,6 @@ contract Rollup is RollupHelpers {
             batches[_batch_id - 1].stateRoot,
             batches[_batch_id].accountRoot,
             txs,
-            signatures,
             batchProofs,
             batches[_batch_id].txRoot,
             batches[_batch_id].batchType

--- a/contracts/rollupReddit.sol
+++ b/contracts/rollupReddit.sol
@@ -274,7 +274,6 @@ contract RollupReddit {
         bytes32 initialStateRoot,
         bytes32 accountsRoot,
         bytes memory txs,
-        bytes[] memory signatures,
         Types.BatchValidationProofs memory batchProofs,
         bytes32 expectedTxRoot,
         Types.Usage batchType
@@ -302,7 +301,6 @@ contract RollupReddit {
                     initialStateRoot,
                     accountsRoot,
                     txs,
-                    signatures,
                     batchProofs,
                     expectedTxRoot
                 );
@@ -312,7 +310,6 @@ contract RollupReddit {
                     initialStateRoot,
                     accountsRoot,
                     txs,
-                    signatures,
                     batchProofs,
                     expectedTxRoot
                 );
@@ -322,7 +319,6 @@ contract RollupReddit {
                     initialStateRoot,
                     accountsRoot,
                     txs,
-                    signatures,
                     batchProofs,
                     expectedTxRoot
                 );

--- a/scripts/helpers/interfaces.ts
+++ b/scripts/helpers/interfaces.ts
@@ -103,7 +103,6 @@ export interface AccountProofs {
 export interface Dispute {
     batchId: number;
     txs: string[];
-    signatures: string[];
     batchProofs: {
         accountProofs: AccountProofs[];
         pdaProof: PDAMerkleProof[];

--- a/scripts/helpers/utils.ts
+++ b/scripts/helpers/utils.ts
@@ -314,7 +314,6 @@ export async function disputeBatch(dispute: Dispute) {
     await rollupCoreInstance.disputeBatch(
         dispute.batchId,
         dispute.txs,
-        dispute.signatures,
         dispute.batchProofs
     );
 }

--- a/test/Reddit.spec.ts
+++ b/test/Reddit.spec.ts
@@ -209,7 +209,6 @@ contract("Reddit", async function() {
         const dispute: Dispute = {
             batchId,
             txs: compressedTxs,
-            signatures: [],
             batchProofs: {
                 accountProofs: [
                     {
@@ -309,7 +308,6 @@ contract("Reddit", async function() {
         const dispute: Dispute = {
             batchId,
             txs: compressedTxs,
-            signatures: [tx.signature],
             batchProofs: {
                 accountProofs: [
                     {
@@ -407,7 +405,6 @@ contract("Reddit", async function() {
         const dispute: Dispute = {
             batchId,
             txs: compressedTxs,
-            signatures: [tx.signature],
             batchProofs: {
                 accountProofs: [
                     {
@@ -491,7 +488,6 @@ contract("Reddit", async function() {
         const dispute: Dispute = {
             batchId,
             txs: compressedTxs,
-            signatures: [tx.signature],
             batchProofs: {
                 accountProofs: [
                     {
@@ -559,7 +555,6 @@ contract("Reddit", async function() {
         const dispute: Dispute = {
             batchId,
             txs: compressedTxs,
-            signatures: [],
             batchProofs: {
                 accountProofs: [
                     {

--- a/test/Rollup.spec.ts
+++ b/test/Rollup.spec.ts
@@ -316,7 +316,6 @@ contract("Rollup", async function(accounts) {
         await rollupCoreInstance.disputeBatch(
             falseBatchZero.batchId,
             falseBatchZero.txs,
-            falseBatchZero.signatures,
             falseBatchZero.batchProofs
         );
 
@@ -465,7 +464,6 @@ contract("Rollup", async function(accounts) {
         await rollupCoreInstance.disputeBatch(
             falseBatchOne.batchId,
             falseBatchOne.txs,
-            falseBatchOne.signatures,
             falseBatchOne.batchProofs
         );
 
@@ -629,7 +627,6 @@ contract("Rollup", async function(accounts) {
         await rollupCoreInstance.disputeBatch(
             falseBatchTwo.batchId,
             falseBatchTwo.txs,
-            falseBatchTwo.signatures,
             falseBatchTwo.batchProofs
         );
 
@@ -810,7 +807,6 @@ contract("Rollup", async function(accounts) {
         await rollupCoreInstance.disputeBatch(
             falseBatchFive.batchId,
             falseBatchFive.txs,
-            falseBatchFive.signatures,
             falseBatchFive.batchProofs
         );
 
@@ -1095,7 +1091,6 @@ contract("Rollup", async function(accounts) {
         await rollupCoreInstance.disputeBatch(
             falseBatchComb.batchId,
             falseBatchComb.txs,
-            falseBatchComb.signatures,
             falseBatchComb.batchProofs
         );
 


### PR DESCRIPTION
We now compress signatures with txs, so no need these arrays now