### PR TITLE
no need to deploy types

### DIFF
--- a/migrations/2_deploy.js
+++ b/migrations/2_deploy.js
@@ -1,11 +1,9 @@
 const fs = require("fs");
 var argv = require("minimist")(process.argv.slice(2));
-const { ethers } = require("ethers");
 // Libs
 const ECVerifyLib = artifacts.require("ECVerify");
 const paramManagerLib = artifacts.require("ParamManager");
 const rollupUtilsLib = artifacts.require("RollupUtils");
-const Types = artifacts.require("Types");
 
 // Contracts Deployer
 const governanceContract = artifacts.require("Governance");
@@ -26,7 +24,6 @@ const rollupRedditContract = artifacts.require("RollupReddit");
 const testTokenContract = artifacts.require("TestToken");
 const merkleTreeUtilsContract = artifacts.require("MerkleTreeUtils");
 const POBContract = artifacts.require("POB");
-const utils = "../test/helpers/utils.ts";
 
 function writeContractAddresses(contractAddresses) {
     fs.writeFileSync(
@@ -41,7 +38,6 @@ async function deploy(deployer) {
 
     // deploy libs
     await deployer.deploy(ECVerifyLib);
-    await deployer.deploy(Types);
     const paramManagerInstance = await deployer.deploy(paramManagerLib);
     await deployer.deploy(rollupUtilsLib);
 
@@ -61,7 +57,7 @@ async function deploy(deployer) {
     const mtUtilsInstance = await deployAndRegister(
         deployer,
         MTUtilsContract,
-        [ECVerifyLib, Types, paramManagerLib, rollupUtilsLib],
+        [ECVerifyLib, paramManagerLib, rollupUtilsLib],
         [nameRegistryInstance.address],
         "MERKLE_UTILS"
     );
@@ -79,7 +75,7 @@ async function deploy(deployer) {
     const tokenRegistryInstance = await deployAndRegister(
         deployer,
         tokenRegistryContract,
-        [ECVerifyLib, Types, paramManagerLib, rollupUtilsLib],
+        [ECVerifyLib, paramManagerLib, rollupUtilsLib],
         [nameRegistryInstance.address],
         "TOKEN_REGISTRY"
     );
@@ -87,7 +83,7 @@ async function deploy(deployer) {
     const transferInstance = await deployAndRegister(
         deployer,
         transferContract,
-        [ECVerifyLib, Types, paramManagerLib, rollupUtilsLib],
+        [ECVerifyLib, paramManagerLib, rollupUtilsLib],
         [nameRegistryInstance.address],
         "TRANSFER"
     );
@@ -95,21 +91,21 @@ async function deploy(deployer) {
     const airdropInstance = await deployAndRegister(
         deployer,
         airdropContract,
-        [ECVerifyLib, Types, paramManagerLib, rollupUtilsLib],
+        [ECVerifyLib, paramManagerLib, rollupUtilsLib],
         [nameRegistryInstance.address],
         "AIRDROP"
     );
     const burnConsentInstance = await deployAndRegister(
         deployer,
         burnConsentContract,
-        [ECVerifyLib, Types, paramManagerLib, rollupUtilsLib],
+        [ECVerifyLib, paramManagerLib, rollupUtilsLib],
         [nameRegistryInstance.address],
         "BURN_CONSENT"
     );
     const burnExecutionInstance = await deployAndRegister(
         deployer,
         burnExecutionContract,
-        [ECVerifyLib, Types, paramManagerLib, rollupUtilsLib],
+        [ECVerifyLib, paramManagerLib, rollupUtilsLib],
         [nameRegistryInstance.address],
         "BURN_EXECUTION"
     );
@@ -134,7 +130,7 @@ async function deploy(deployer) {
     const createAccountInstance = await deployAndRegister(
         deployer,
         createAccountContract,
-        [ECVerifyLib, Types, paramManagerLib, rollupUtilsLib],
+        [ECVerifyLib, paramManagerLib, rollupUtilsLib],
         [nameRegistryInstance.address],
         "CREATE_ACCOUNT"
     );
@@ -153,7 +149,7 @@ async function deploy(deployer) {
     const depositManagerInstance = await deployAndRegister(
         deployer,
         depositManagerContract,
-        [Types, paramManagerLib, rollupUtilsLib],
+        [paramManagerLib, rollupUtilsLib],
         [nameRegistryInstance.address],
         "DEPOSIT_MANAGER"
     );
@@ -161,7 +157,7 @@ async function deploy(deployer) {
     const rollupRedditInstance = await deployAndRegister(
         deployer,
         rollupRedditContract,
-        [Types, paramManagerLib, rollupUtilsLib],
+        [paramManagerLib, rollupUtilsLib],
         [nameRegistryInstance.address],
         "ROLLUP_REDDIT"
     );
@@ -170,7 +166,7 @@ async function deploy(deployer) {
     const rollupInstance = await deployAndRegister(
         deployer,
         rollupContract,
-        [ECVerifyLib, Types, paramManagerLib, rollupUtilsLib],
+        [ECVerifyLib, paramManagerLib, rollupUtilsLib],
         [nameRegistryInstance.address, root],
         "ROLLUP_CORE"
     );

--- a/migrations/4_IncrementalTree.js
+++ b/migrations/4_IncrementalTree.js
@@ -1,11 +1,9 @@
-const fs = require("fs");
 var argv = require("minimist")(process.argv.slice(2));
 
 // Libs
 const ECVerifyLib = artifacts.require("ECVerify");
 const paramManagerLib = artifacts.require("ParamManager");
 const rollupUtilsLib = artifacts.require("RollupUtils");
-const Types = artifacts.require("Types");
 
 // Contracts Deployer
 const governanceContract = artifacts.require("Governance");
@@ -15,15 +13,12 @@ const nameRegistryContract = artifacts.require("NameRegistry");
 
 module.exports = async function(deployer) {
     if (argv.dn && argv.dn == 4) {
-        // picked address from mnemoic
-        var coordinator = "0x9fB29AAc15b9A4B7F17c3385939b007540f4d791";
         var max_depth = 4;
         var maxDepositSubtreeDepth = 1;
 
         // deploy libs
         await deployer.deploy(ECVerifyLib);
         await deployer.deploy(Types);
-        const paramManagerInstance = await deployer.deploy(paramManagerLib);
         await deployer.deploy(rollupUtilsLib);
 
         // deploy name registry
@@ -44,7 +39,7 @@ module.exports = async function(deployer) {
         const mtUtilsInstance = await deployAndRegister(
             deployer,
             MTUtilsContract,
-            [ECVerifyLib, Types, paramManagerLib, rollupUtilsLib],
+            [ECVerifyLib, paramManagerLib, rollupUtilsLib],
             [nameRegistryInstance.address],
             "MERKLE_UTILS"
         );


### PR DESCRIPTION
If a library has no public or external function, no need to deploy it.

https://medium.com/@jeancvllr/solidity-tutorial-all-about-libraries-762e5a3692f9

> Embedded Library: If a smart contract is consuming a library which have only internal functions, then the EVM simply embeds library into the contract. Instead of using delegate call to call a function, it simply uses JUMP statement(normal method call). There is no need to separately deploy library in this scenario.