### PR TITLE
cleanup merkle utils

### DIFF
--- a/contracts/BurnConsent.sol
+++ b/contracts/BurnConsent.sol
@@ -5,7 +5,6 @@ import { FraudProofHelpers } from "./FraudProof.sol";
 import { Types } from "./libs/Types.sol";
 import { ITokenRegistry } from "./interfaces/ITokenRegistry.sol";
 import { RollupUtils } from "./libs/RollupUtils.sol";
-import { MerkleTreeUtils as MTUtils } from "./MerkleTreeUtils.sol";
 import { Governance } from "./Governance.sol";
 import { NameRegistry as Registry } from "./NameRegistry.sol";
 import { ParamManager } from "./libs/ParamManager.sol";
@@ -19,10 +18,6 @@ contract BurnConsent is FraudProofHelpers {
 
         governance = Governance(
             nameRegistry.getContractDetails(ParamManager.Governance())
-        );
-
-        merkleUtils = MTUtils(
-            nameRegistry.getContractDetails(ParamManager.MERKLE_UTILS())
         );
 
         tokenRegistry = ITokenRegistry(
@@ -83,7 +78,7 @@ contract BurnConsent is FraudProofHelpers {
         Types.AccountMerkleProof memory _merkle_proof,
         bytes memory txs,
         uint256 i
-    ) public view returns (bytes memory updatedAccount, bytes32 newRoot) {
+    ) public pure returns (bytes memory updatedAccount, bytes32 newRoot) {
         Types.UserAccount memory account = _merkle_proof.accountIP.account;
         account.burn = txs.burnConsent_amountOf(i);
         account.nonce++;

--- a/contracts/BurnExecution.sol
+++ b/contracts/BurnExecution.sol
@@ -5,7 +5,6 @@ import { FraudProofHelpers } from "./FraudProof.sol";
 import { Types } from "./libs/Types.sol";
 import { ITokenRegistry } from "./interfaces/ITokenRegistry.sol";
 import { RollupUtils } from "./libs/RollupUtils.sol";
-import { MerkleTreeUtils as MTUtils } from "./MerkleTreeUtils.sol";
 import { Governance } from "./Governance.sol";
 import { NameRegistry as Registry } from "./NameRegistry.sol";
 import { ParamManager } from "./libs/ParamManager.sol";
@@ -19,10 +18,6 @@ contract BurnExecution is FraudProofHelpers {
 
         governance = Governance(
             nameRegistry.getContractDetails(ParamManager.Governance())
-        );
-
-        merkleUtils = MTUtils(
-            nameRegistry.getContractDetails(ParamManager.MERKLE_UTILS())
         );
 
         tokenRegistry = ITokenRegistry(

--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -124,9 +124,8 @@ contract DepositManager {
             deposits[0] = pendingDeposits[pendingDeposits.length - 2];
             deposits[1] = pendingDeposits[pendingDeposits.length - 1];
 
-            pendingDeposits[pendingDeposits.length - 2] = merkleUtils.getParent(
-                deposits[0],
-                deposits[1]
+            pendingDeposits[pendingDeposits.length - 2] = keccak256(
+                abi.encode(deposits[0], deposits[1])
             );
 
             // remove 1 deposit from the pending deposit queue

--- a/contracts/FraudProof.sol
+++ b/contracts/FraudProof.sol
@@ -10,7 +10,7 @@ import { Types } from "./libs/Types.sol";
 import { RollupUtils } from "./libs/RollupUtils.sol";
 import { ParamManager } from "./libs/ParamManager.sol";
 
-import { MerkleTreeUtils as MTUtils } from "./MerkleTreeUtils.sol";
+import { MerkleTreeUtilsLib } from "./MerkleTreeUtils.sol";
 import { Governance } from "./Governance.sol";
 import { NameRegistry as Registry } from "./NameRegistry.sol";
 
@@ -18,7 +18,6 @@ contract FraudProofSetup {
     using SafeMath for uint256;
     using Tx for bytes;
 
-    MTUtils public merkleUtils;
     ITokenRegistry public tokenRegistry;
     Registry public nameRegistry;
 
@@ -32,14 +31,14 @@ contract FraudProofHelpers is FraudProofSetup {
     function ValidateAccountMP(
         bytes32 root,
         Types.AccountMerkleProof memory merkle_proof
-    ) public view {
+    ) public pure {
         bytes32 accountLeaf = RollupUtils.HashFromAccount(
             merkle_proof.accountIP.account
         );
 
         // verify from leaf exists in the balance tree
         require(
-            merkleUtils.verifyLeaf(
+            MerkleTreeUtilsLib.verifyLeaf(
                 root,
                 accountLeaf,
                 merkle_proof.accountIP.pathToAccount,
@@ -97,7 +96,7 @@ contract FraudProofHelpers is FraudProofSetup {
         uint256 fromIndex,
         uint256 toIndex,
         uint256 amount
-    ) public view returns (bytes memory updatedAccount, bytes32 newRoot) {
+    ) public pure returns (bytes memory updatedAccount, bytes32 newRoot) {
         Types.UserAccount memory account = _merkle_proof.accountIP.account;
         if (fromIndex == account.ID) {
             account = RemoveTokensFromAccount(account, amount);
@@ -153,12 +152,12 @@ contract FraudProofHelpers is FraudProofSetup {
     function UpdateAccountWithSiblings(
         Types.UserAccount memory new_account,
         Types.AccountMerkleProof memory _merkle_proof
-    ) public view returns (bytes32) {
-        bytes32 newRoot = merkleUtils.updateLeafWithSiblings(
+    ) public pure returns (bytes32) {
+        bytes32 newRoot = MerkleTreeUtilsLib.rootFromWitnesses(
             keccak256(RollupUtils.BytesFromAccount(new_account)),
             _merkle_proof.accountIP.pathToAccount,
             _merkle_proof.siblings
         );
-        return (newRoot);
+        return newRoot;
     }
 }

--- a/contracts/MerkleTreeUtils.sol
+++ b/contracts/MerkleTreeUtils.sol
@@ -1,6 +1,33 @@
 pragma solidity ^0.5.15;
 pragma experimental ABIEncoderV2;
 
+library MerkleTreeUtilsLib {
+    function rootFromWitnesses(
+        bytes32 leaf,
+        uint256 path,
+        bytes32[] memory witnesses
+    ) internal pure returns (bytes32) {
+        for (uint256 i = 0; i < witnesses.length; i++) {
+            // get i-th bit from right
+            if (((path >> i) & 1) == 0) {
+                leaf = keccak256(abi.encode(leaf, witnesses[i]));
+            } else {
+                leaf = keccak256(abi.encode(witnesses[i], leaf));
+            }
+        }
+        return leaf;
+    }
+
+    function verifyLeaf(
+        bytes32 root,
+        bytes32 leaf,
+        uint256 path,
+        bytes32[] memory witnesses
+    ) internal pure returns (bool) {
+        return rootFromWitnesses(leaf, path, witnesses) == root;
+    }
+}
+
 contract MerkleTreeUtils {
     // The default hashes
     bytes32[] public defaultHashes;
@@ -55,10 +82,6 @@ contract MerkleTreeUtils {
         returns (bytes32)
     {
         return defaultHashes[index];
-    }
-
-    function keecakHash(bytes memory data) public pure returns (bytes32) {
-        return keccak256(data);
     }
 
     /**
@@ -116,87 +139,6 @@ contract MerkleTreeUtils {
     }
 
     /**
-     * @notice Calculate root from an inclusion proof.
-     * @param _dataBlock The data block we're calculating root for.
-     * @param _path The path from the leaf to the root.
-     * @param _siblings The sibling nodes along the way.
-     * @return The next level of the tree
-     * NOTE: This is a stateless operation
-     */
-    function computeInclusionProofRoot(
-        bytes memory _dataBlock,
-        uint256 _path,
-        bytes32[] memory _siblings
-    ) public pure returns (bytes32) {
-        // First compute the leaf node
-        bytes32 computedNode = keccak256(_dataBlock);
-
-        for (uint256 i = 0; i < _siblings.length; i++) {
-            bytes32 sibling = _siblings[i];
-            uint8 isComputedRightSibling = getNthBitFromRight(_path, i);
-            if (isComputedRightSibling == 0) {
-                computedNode = getParent(computedNode, sibling);
-            } else {
-                computedNode = getParent(sibling, computedNode);
-            }
-        }
-        // Check if the computed node (_root) is equal to the provided root
-        return computedNode;
-    }
-
-    /**
-     * @notice Calculate root from an inclusion proof.
-     * @param _leaf The data block we're calculating root for.
-     * @param _path The path from the leaf to the root.
-     * @param _siblings The sibling nodes along the way.
-     * @return The next level of the tree
-     * NOTE: This is a stateless operation
-     */
-    function computeInclusionProofRootWithLeaf(
-        bytes32 _leaf,
-        uint256 _path,
-        bytes32[] memory _siblings
-    ) public pure returns (bytes32) {
-        // First compute the leaf node
-        bytes32 computedNode = _leaf;
-        for (uint256 i = 0; i < _siblings.length; i++) {
-            bytes32 sibling = _siblings[i];
-            uint8 isComputedRightSibling = getNthBitFromRight(_path, i);
-            if (isComputedRightSibling == 0) {
-                computedNode = getParent(computedNode, sibling);
-            } else {
-                computedNode = getParent(sibling, computedNode);
-            }
-        }
-        // Check if the computed node (_root) is equal to the provided root
-        return computedNode;
-    }
-
-    /**
-     * @notice Verify an inclusion proof.
-     * @param _root The root of the tree we are verifying inclusion for.
-     * @param _dataBlock The data block we're verifying inclusion for.
-     * @param _path The path from the leaf to the root.
-     * @param _siblings The sibling nodes along the way.
-     * @return The next level of the tree
-     * NOTE: This is a stateless operation
-     */
-    function verify(
-        bytes32 _root,
-        bytes memory _dataBlock,
-        uint256 _path,
-        bytes32[] memory _siblings
-    ) public pure returns (bool) {
-        // First compute the leaf node
-        bytes32 calculatedRoot = computeInclusionProofRoot(
-            _dataBlock,
-            _path,
-            _siblings
-        );
-        return calculatedRoot == _root;
-    }
-
-    /**
      * @notice Verify an inclusion proof.
      * @param _root The root of the tree we are verifying inclusion for.
      * @param _leaf The data block we're verifying inclusion for.
@@ -211,12 +153,7 @@ contract MerkleTreeUtils {
         uint256 _path,
         bytes32[] memory _siblings
     ) public pure returns (bool) {
-        bytes32 calculatedRoot = computeInclusionProofRootWithLeaf(
-            _leaf,
-            _path,
-            _siblings
-        );
-        return calculatedRoot == _root;
+        return MerkleTreeUtilsLib.verifyLeaf(_root, _leaf, _path, _siblings);
     }
 
     /**
@@ -232,85 +169,6 @@ contract MerkleTreeUtils {
         uint256 _path,
         bytes32[] memory _siblings
     ) public pure returns (bytes32) {
-        bytes32 computedNode = _leaf;
-        for (uint256 i = 0; i < _siblings.length; i++) {
-            bytes32 parent;
-            bytes32 sibling = _siblings[i];
-            uint8 isComputedRightSibling = getNthBitFromRight(_path, i);
-            if (isComputedRightSibling == 0) {
-                parent = getParent(computedNode, sibling);
-            } else {
-                parent = getParent(sibling, computedNode);
-            }
-            computedNode = parent;
-        }
-        return computedNode;
-    }
-
-    /**
-     * @notice Get the parent of two children nodes in the tree
-     * @param _left The left child
-     * @param _right The right child
-     * @return The parent node
-     */
-    function getParent(bytes32 _left, bytes32 _right)
-        public
-        pure
-        returns (bytes32)
-    {
-        return keccak256(abi.encode(_left, _right));
-    }
-
-    /**
-     * @notice get the n'th bit in a uint.
-     *         For instance, if exampleUint=binary(11), getNth(exampleUint, 0) == 1, getNth(2, 1) == 1
-     * @param _intVal The uint we are extracting a bit out of
-     * @param _index The index of the bit we want to extract
-     * @return The bit (1 or 0) in a uint8
-     */
-    function getNthBitFromRight(uint256 _intVal, uint256 _index)
-        public
-        pure
-        returns (uint8)
-    {
-        return uint8((_intVal >> _index) & 1);
-    }
-
-    /**
-     * @notice Get the right sibling key. Note that these keys overwrite the first bit of the hash
-               to signify if it is on the right side of the parent or on the left
-     * @param _parent The parent node
-     * @return the key for the left sibling (0 as the first bit)
-     */
-    function getLeftSiblingKey(bytes32 _parent) public pure returns (bytes32) {
-        return
-            _parent &
-            0x0111111111111111111111111111111111111111111111111111111111111111;
-    }
-
-    /**
-     * @notice Get the right sibling key. Note that these keys overwrite the first bit of the hash
-               to signify if it is on the right side of the parent or on the left
-     * @param _parent The parent node
-     * @return the key for the right sibling (1 as the first bit)
-     */
-    function getRightSiblingKey(bytes32 _parent) public pure returns (bytes32) {
-        return
-            _parent |
-            0x1000000000000000000000000000000000000000000000000000000000000000;
-    }
-
-    function pathToIndex(uint256 path, uint256 height)
-        public
-        pure
-        returns (uint256)
-    {
-        uint256 result = 0;
-        for (uint256 i = 0; i < height; i++) {
-            uint8 temp = getNthBitFromRight(path, i);
-            // UNSAFE FIX THIS
-            result = result + (temp * (2**i));
-        }
-        return result;
+        return MerkleTreeUtilsLib.rootFromWitnesses(_leaf, _path, _siblings);
     }
 }

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -4,7 +4,6 @@ import { FraudProofHelpers } from "./FraudProof.sol";
 import { Types } from "./libs/Types.sol";
 import { ITokenRegistry } from "./interfaces/ITokenRegistry.sol";
 import { RollupUtils } from "./libs/RollupUtils.sol";
-import { MerkleTreeUtils as MTUtils } from "./MerkleTreeUtils.sol";
 import { Governance } from "./Governance.sol";
 import { NameRegistry as Registry } from "./NameRegistry.sol";
 import { ParamManager } from "./libs/ParamManager.sol";
@@ -160,20 +159,6 @@ contract Transfer is FraudProofHelpers {
     //         nameRegistry.getContractDetails(ParamManager.TOKEN_REGISTRY())
     //     );
     // }
-
-    function generateTxRoot(Types.Transaction[] memory _txs)
-        public
-        view
-        returns (bytes32 txRoot)
-    {
-        // generate merkle tree from the txs provided by user
-        bytes[] memory txs = new bytes[](_txs.length);
-        for (uint256 i = 0; i < _txs.length; i++) {
-            txs[i] = RollupUtils.CompressTx(_txs[i]);
-        }
-        txRoot = merkleUtils.getMerkleRoot(txs);
-        return txRoot;
-    }
 
     /**
      * @notice processBatch processes a whole batch

--- a/contracts/airdrop.sol
+++ b/contracts/airdrop.sol
@@ -5,7 +5,6 @@ import { FraudProofHelpers } from "./FraudProof.sol";
 import { Types } from "./libs/Types.sol";
 import { ITokenRegistry } from "./interfaces/ITokenRegistry.sol";
 import { RollupUtils } from "./libs/RollupUtils.sol";
-import { MerkleTreeUtils as MTUtils } from "./MerkleTreeUtils.sol";
 import { Governance } from "./Governance.sol";
 import { NameRegistry as Registry } from "./NameRegistry.sol";
 import { ParamManager } from "./libs/ParamManager.sol";
@@ -19,10 +18,6 @@ contract Airdrop is FraudProofHelpers {
 
         governance = Governance(
             nameRegistry.getContractDetails(ParamManager.Governance())
-        );
-
-        merkleUtils = MTUtils(
-            nameRegistry.getContractDetails(ParamManager.MERKLE_UTILS())
         );
 
         tokenRegistry = ITokenRegistry(

--- a/test/merkalization/MerkleTree.spec.ts
+++ b/test/merkalization/MerkleTree.spec.ts
@@ -53,42 +53,6 @@ describe("MerkleTreeUtils", async function() {
         }
     });
 
-    it("utils hash should be the same as keccak hash", async function() {
-        var data = utils.StringToBytes32("0x123");
-
-        var hash = utils.Hash(data);
-
-        var keccakHash = await mtlibInstance.keecakHash(data);
-        expect(keccakHash).to.be.deep.eq(hash);
-    });
-
-    it("test get parent", async function() {
-        let localHash = utils.getParentLeaf(firstDataBlock, secondDataBlock);
-        let contractHash = await mtlibInstance.getParent(
-            firstDataBlock,
-            secondDataBlock
-        );
-
-        expect(localHash).to.be.deep.eq(contractHash);
-    });
-
-    it("test index to path", async function() {
-        var result = await mtlibInstance.pathToIndex("10", 2);
-        expect(result.toNumber()).to.be.deep.eq(2);
-
-        var result2 = await mtlibInstance.pathToIndex("11", 2);
-        expect(result2.toNumber()).to.be.deep.eq(3);
-
-        var result3 = await mtlibInstance.pathToIndex("111", 3);
-        expect(result3.toNumber()).to.be.deep.eq(7);
-
-        // var result4 = await mtlibInstance.pathToIndex(
-        //   "11111111111111111111111",
-        //   "11111111111111111111111".length
-        // );
-        // expect(result4.toNumber()).to.be.deep.eq(8388607);
-    });
-
     it("[LEAF] [STATELESS] verifying correct proof", async function() {
         var root = await mtlibInstance.getMerkleRoot(dataBlocks);
 
@@ -107,23 +71,6 @@ describe("MerkleTreeUtils", async function() {
             path,
             siblings
         );
-
-        expect(isValid).to.be.deep.eq(true);
-    });
-
-    it("[DATABLOCK] [STATELESS] verifying correct proof", async function() {
-        var root = await mtlibInstance.getMerkleRoot(dataBlocks);
-
-        var siblings: Array<string> = [
-            dataLeaves[1],
-            utils.getParentLeaf(dataLeaves[2], dataLeaves[3])
-        ];
-
-        var leaf = dataBlocks[0];
-
-        var path: string = "00";
-
-        var isValid = await mtlibInstance.verify(root, leaf, path, siblings);
 
         expect(isValid).to.be.deep.eq(true);
     });


### PR DESCRIPTION
The merkleutils contract has two parts: One that depends on default hashes and one doesn't.

By moving the stateless part of functions to a library we don't have to worry about passing addresses to constructors or linking libraries.