### PR TITLE
Flatten account proofs

### DIFF
--- a/contracts/BurnConsent.sol
+++ b/contracts/BurnConsent.sol
@@ -13,7 +13,7 @@ contract BurnConsent is FraudProofHelpers {
     function processBurnConsentBatch(
         bytes32 stateRoot,
         bytes memory txs,
-        Types.BatchValidationProofs memory batchProofs,
+        Types.AccountMerkleProof[] memory accountProofs,
         bytes32 expectedTxHashCommitment
     )
         public
@@ -41,7 +41,7 @@ contract BurnConsent is FraudProofHelpers {
                 stateRoot,
                 txs,
                 i,
-                batchProofs.accountProofs[i].from
+                accountProofs[i]
             );
 
             if (!isTxValid) {

--- a/contracts/BurnExecution.sol
+++ b/contracts/BurnExecution.sol
@@ -13,7 +13,7 @@ contract BurnExecution is FraudProofHelpers {
     function processBurnExecutionBatch(
         bytes32 stateRoot,
         bytes memory txs,
-        Types.BatchValidationProofs memory batchProofs,
+        Types.AccountMerkleProof[] memory accountProofs,
         bytes32 expectedTxHashCommitment
     )
         public
@@ -43,7 +43,7 @@ contract BurnExecution is FraudProofHelpers {
                 stateRoot,
                 txs,
                 i,
-                batchProofs.accountProofs[i].from
+                accountProofs[i]
             );
 
             if (!isTxValid) {

--- a/contracts/CreateAccount.sol
+++ b/contracts/CreateAccount.sol
@@ -18,7 +18,7 @@ contract CreateAccount is FraudProofHelpers {
     function processCreateAccountBatch(
         bytes32 stateRoot,
         bytes memory txs,
-        Types.BatchValidationProofs memory batchProofs
+        Types.AccountMerkleProof[] memory accountProofs
     ) public view returns (bytes32, bool) {
         uint256 length = txs.create_size();
 
@@ -30,7 +30,7 @@ contract CreateAccount is FraudProofHelpers {
                 stateRoot,
                 txs,
                 i,
-                batchProofs.accountProofs[i].to
+                accountProofs[i]
             );
 
             if (!isTxValid) {

--- a/contracts/airdrop.sol
+++ b/contracts/airdrop.sol
@@ -13,7 +13,7 @@ contract Airdrop is FraudProofHelpers {
     function processAirdropBatch(
         bytes32 stateRoot,
         bytes memory txs,
-        Types.BatchValidationProofs memory batchProofs,
+        Types.AccountMerkleProof[] memory accountProofs,
         bytes32 expectedTxHashCommitment
     )
         public
@@ -41,7 +41,8 @@ contract Airdrop is FraudProofHelpers {
                 stateRoot,
                 txs,
                 i,
-                batchProofs.accountProofs[i]
+                accountProofs[i * 2],
+                accountProofs[i * 2 + 1]
             );
 
             if (!isTxValid) {
@@ -62,7 +63,8 @@ contract Airdrop is FraudProofHelpers {
         bytes32 _balanceRoot,
         bytes memory txs,
         uint256 i,
-        Types.AccountProofs memory accountProofs
+        Types.AccountMerkleProof memory fromAccountProof,
+        Types.AccountMerkleProof memory toAccountProof
     )
         public
         pure
@@ -76,15 +78,15 @@ contract Airdrop is FraudProofHelpers {
     {
         Types.ErrorCode err_code = validateTxBasic(
             txs.transfer_amountOf(i),
-            accountProofs.from.account
+            fromAccountProof.account
         );
         if (err_code != Types.ErrorCode.NoError)
             return (ZERO_BYTES32, "", "", err_code, false);
 
         // account holds the token type in the tx
         if (
-            accountProofs.from.account.tokenType !=
-            accountProofs.to.account.tokenType
+            fromAccountProof.account.tokenType !=
+            toAccountProof.account.tokenType
         )
             // invalid state transition
             // needs to be slashed because the submitted transaction
@@ -101,13 +103,9 @@ contract Airdrop is FraudProofHelpers {
         bytes memory new_from_account;
         bytes memory new_to_account;
 
-        (new_from_account, newRoot) = ApplyAirdropTx(
-            accountProofs.from,
-            txs,
-            i
-        );
+        (new_from_account, newRoot) = ApplyAirdropTx(fromAccountProof, txs, i);
 
-        (new_to_account, newRoot) = ApplyAirdropTx(accountProofs.to, txs, i);
+        (new_to_account, newRoot) = ApplyAirdropTx(toAccountProof, txs, i);
 
         return (
             newRoot,

--- a/contracts/interfaces/IReddit.sol
+++ b/contracts/interfaces/IReddit.sol
@@ -47,7 +47,8 @@ interface IReddit {
         bytes32 _balanceRoot,
         bytes calldata txs,
         uint256 i,
-        Types.AccountProofs calldata accountProofs
+        Types.AccountMerkleProof calldata fromAccountProof,
+        Types.AccountMerkleProof calldata toAccountProof
     )
         external
         view
@@ -76,7 +77,8 @@ interface IReddit {
     function processTx(
         bytes32 _balanceRoot,
         Tx.Transfer calldata _tx,
-        Types.AccountProofs calldata accountProofs
+        Types.AccountMerkleProof calldata fromAccountProof,
+        Types.AccountMerkleProof calldata toAccountProof
     )
         external
         view
@@ -139,7 +141,7 @@ interface IReddit {
     function processCreateAccountBatch(
         bytes32 initialStateRoot,
         bytes calldata txs,
-        Types.BatchValidationProofs calldata batchProofs,
+        Types.AccountMerkleProof[] calldata accountProofs,
         bytes32 expectedTxRoot
     )
         external
@@ -153,7 +155,7 @@ interface IReddit {
     function processAirdropBatch(
         bytes32 initialStateRoot,
         bytes calldata txs,
-        Types.BatchValidationProofs calldata batchProofs,
+        Types.AccountMerkleProof[] calldata accountProofs,
         bytes32 expectedTxRoot
     )
         external
@@ -167,7 +169,7 @@ interface IReddit {
     function processTransferBatch(
         bytes32 initialStateRoot,
         bytes calldata txs,
-        Types.BatchValidationProofs calldata batchProofs,
+        Types.AccountMerkleProof[] calldata accountProofs,
         bytes32 expectedTxRoot
     )
         external
@@ -181,7 +183,7 @@ interface IReddit {
     function processBurnConsentBatch(
         bytes32 initialStateRoot,
         bytes calldata txs,
-        Types.BatchValidationProofs calldata batchProofs,
+        Types.AccountMerkleProof[] calldata accountProofs,
         bytes32 expectedTxRoot
     )
         external
@@ -195,7 +197,7 @@ interface IReddit {
     function processBurnExecutionBatch(
         bytes32 initialStateRoot,
         bytes calldata txs,
-        Types.BatchValidationProofs calldata batchProofs,
+        Types.AccountMerkleProof[] calldata accountProofs,
         bytes32 expectedTxRoot
     )
         external

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -105,15 +105,6 @@ library Types {
         bytes32[] siblings;
     }
 
-    struct AccountProofs {
-        AccountMerkleProof from;
-        AccountMerkleProof to;
-    }
-
-    struct BatchValidationProofs {
-        AccountProofs[] accountProofs;
-    }
-
     struct TransactionMerkleProof {
         Transfer _tx;
         bytes32[] siblings;

--- a/contracts/rollup.sol
+++ b/contracts/rollup.sol
@@ -21,7 +21,7 @@ interface IRollupReddit {
     function processBatch(
         bytes32 initialStateRoot,
         bytes calldata _txs,
-        Types.BatchValidationProofs calldata batchProofs,
+        Types.AccountMerkleProof[] calldata accountProofs,
         bytes32 expectedTxHashCommitment,
         Types.Usage batchType
     )
@@ -334,7 +334,7 @@ contract Rollup is RollupHelpers {
         uint256 _batch_id,
         Types.CommitmentInclusionProof memory commitmentMP,
         bytes memory txs,
-        Types.BatchValidationProofs memory batchProofs
+        Types.AccountMerkleProof[] memory accountProofs
     ) public {
         {
             // check if batch is disputable
@@ -384,7 +384,7 @@ contract Rollup is RollupHelpers {
             .processBatch(
             commitmentMP.commitment.stateRoot,
             txs,
-            batchProofs,
+            accountProofs,
             commitmentMP.commitment.txHashCommitment,
             commitmentMP.commitment.batchType
         );

--- a/contracts/rollupReddit.sol
+++ b/contracts/rollupReddit.sol
@@ -124,7 +124,8 @@ contract RollupReddit {
         bytes32 _balanceRoot,
         bytes memory sig,
         bytes memory txBytes,
-        Types.AccountProofs memory accountProofs
+        Types.AccountMerkleProof memory fromAccountProof,
+        Types.AccountMerkleProof memory toAccountProof
     )
         public
         view
@@ -138,7 +139,14 @@ contract RollupReddit {
     {
         bytes memory txs = RollupUtils.CompressAirdropFromEncoded(txBytes, sig);
         // Validate ECDSA sig
-        return airdrop.processAirdropTx(_balanceRoot, txs, 0, accountProofs);
+        return
+            airdrop.processAirdropTx(
+                _balanceRoot,
+                txs,
+                0,
+                fromAccountProof,
+                toAccountProof
+            );
     }
 
     //
@@ -162,7 +170,8 @@ contract RollupReddit {
         bytes32 _balanceRoot,
         bytes memory sig,
         bytes memory txBytes,
-        Types.AccountProofs memory accountProofs
+        Types.AccountMerkleProof memory fromAccountProof,
+        Types.AccountMerkleProof memory toAccountProof
     )
         public
         view
@@ -176,7 +185,13 @@ contract RollupReddit {
     {
         Tx.Transfer memory _tx = txBytes.transfer_fromEncoded();
         // Validate BLS sig
-        return transfer.processTx(_balanceRoot, _tx, accountProofs);
+        return
+            transfer.processTx(
+                _balanceRoot,
+                _tx,
+                fromAccountProof,
+                toAccountProof
+            );
     }
 
     //
@@ -256,7 +271,7 @@ contract RollupReddit {
     function processBatch(
         bytes32 initialStateRoot,
         bytes memory txs,
-        Types.BatchValidationProofs memory batchProofs,
+        Types.AccountMerkleProof[] memory accountProofs,
         bytes32 expectedTxHashCommitment,
         Types.Usage batchType
     )
@@ -273,7 +288,7 @@ contract RollupReddit {
                 createAccount.processCreateAccountBatch(
                     initialStateRoot,
                     txs,
-                    batchProofs,
+                    accountProofs,
                     expectedTxHashCommitment
                 );
         } else if (batchType == Types.Usage.Airdrop) {
@@ -281,7 +296,7 @@ contract RollupReddit {
                 airdrop.processAirdropBatch(
                     initialStateRoot,
                     txs,
-                    batchProofs,
+                    accountProofs,
                     expectedTxHashCommitment
                 );
         } else if (batchType == Types.Usage.Transfer) {
@@ -289,7 +304,7 @@ contract RollupReddit {
                 transfer.processTransferBatch(
                     initialStateRoot,
                     txs,
-                    batchProofs,
+                    accountProofs,
                     expectedTxHashCommitment
                 );
         } else if (batchType == Types.Usage.BurnConsent) {
@@ -297,7 +312,7 @@ contract RollupReddit {
                 burnConsent.processBurnConsentBatch(
                     initialStateRoot,
                     txs,
-                    batchProofs,
+                    accountProofs,
                     expectedTxHashCommitment
                 );
         } else if (batchType == Types.Usage.BurnExecution) {
@@ -305,7 +320,7 @@ contract RollupReddit {
                 burnExecution.processBurnExecutionBatch(
                     initialStateRoot,
                     txs,
-                    batchProofs,
+                    accountProofs,
                     expectedTxHashCommitment
                 );
         } else {

--- a/contracts/test/TestTransfer.sol
+++ b/contracts/test/TestTransfer.sol
@@ -34,7 +34,8 @@ contract TestTransfer is Transfer {
     function testProcessTx(
         bytes32 _balanceRoot,
         Tx.Transfer memory _tx,
-        Types.AccountProofs memory accountProofs
+        Types.AccountMerkleProof memory fromAccountProof,
+        Types.AccountMerkleProof memory toAccountProof
     )
         public
         pure
@@ -46,6 +47,6 @@ contract TestTransfer is Transfer {
             bool
         )
     {
-        return processTx(_balanceRoot, _tx, accountProofs);
+        return processTx(_balanceRoot, _tx, fromAccountProof, toAccountProof);
     }
 }

--- a/test/Rollup.spec.ts
+++ b/test/Rollup.spec.ts
@@ -128,23 +128,17 @@ describe("Rollup", async function() {
             witness: tree.witness(0).nodes
         };
 
-        await rollup.disputeBatch(batchId, commitmentMP, txs, {
-            accountProofs: [
-                {
-                    from: {
-                        pathToAccount: Alice.stateID,
-                        account: proof.senderAccount,
-                        siblings: proof.senderWitness.map(ethers.utils.arrayify)
-                    },
-                    to: {
-                        pathToAccount: Bob.stateID,
-                        account: proof.receiverAccount,
-                        siblings: proof.receiverWitness.map(
-                            ethers.utils.arrayify
-                        )
-                    }
-                }
-            ]
-        });
+        await rollup.disputeBatch(batchId, commitmentMP, txs, [
+            {
+                pathToAccount: Alice.stateID,
+                account: proof.senderAccount,
+                siblings: proof.senderWitness.map(ethers.utils.arrayify)
+            },
+            {
+                pathToAccount: Bob.stateID,
+                account: proof.receiverAccount,
+                siblings: proof.receiverWitness.map(ethers.utils.arrayify)
+            }
+        ]);
     });
 });

--- a/test/rollup_transfer.test.ts
+++ b/test/rollup_transfer.test.ts
@@ -152,23 +152,24 @@ describe("Rollup Transfer Commitment", () => {
                 fee,
                 sender.nonce
             );
-            const pubkeyWitness = registry.witness(sender.accountID);
             const preRoot = stateTree.root;
             const proof = stateTree.applyTxTransfer(tx);
             const postRoot = stateTree.root;
 
-            const result = await rollup.testProcessTx(preRoot, tx.extended(), {
-                from: {
+            const result = await rollup.testProcessTx(
+                preRoot,
+                tx.extended(),
+                {
                     pathToAccount: sender.stateID,
                     account: proof.senderAccount,
                     siblings: proof.senderWitness
                 },
-                to: {
+                {
                     pathToAccount: receiver.stateID,
                     account: proof.receiverAccount,
                     siblings: proof.receiverWitness
                 }
-            });
+            );
             assert.equal(result[0], postRoot, "mismatch processed stateroot");
         }
     });


### PR DESCRIPTION
Should merge after #193 

Remove BatchValidationProofs and AccountProofs.
Use only AccountMerkleProof[]. 

This is more flexible in these cases:
- When we don't have exactly `from` and `to` account to pass.
- When we need an extra account for fee.