### PR TITLE
Remove expectedTxHashCommitment check

### DIFF
--- a/contracts/BurnConsent.sol
+++ b/contracts/BurnConsent.sol
@@ -13,25 +13,9 @@ contract BurnConsent is FraudProofHelpers {
     function processBurnConsentBatch(
         bytes32 stateRoot,
         bytes memory txs,
-        Types.AccountMerkleProof[] memory accountProofs,
-        bytes32 expectedTxHashCommitment
-    )
-        public
-        pure
-        returns (
-            bytes32,
-            bytes32,
-            bool
-        )
-    {
+        Types.AccountMerkleProof[] memory accountProofs
+    ) public pure returns (bytes32, bool) {
         uint256 length = txs.burnConsent_size();
-        bytes32 actualTxHashCommitment = keccak256(txs);
-        if (expectedTxHashCommitment != ZERO_BYTES32) {
-            require(
-                actualTxHashCommitment == expectedTxHashCommitment,
-                "Invalid dispute, tx root doesn't match"
-            );
-        }
 
         bool isTxValid;
         for (uint256 i = 0; i < length; i++) {
@@ -49,7 +33,7 @@ contract BurnConsent is FraudProofHelpers {
             }
         }
 
-        return (stateRoot, actualTxHashCommitment, !isTxValid);
+        return (stateRoot, !isTxValid);
     }
 
     function ApplyBurnConsentTx(

--- a/contracts/BurnExecution.sol
+++ b/contracts/BurnExecution.sol
@@ -13,26 +13,9 @@ contract BurnExecution is FraudProofHelpers {
     function processBurnExecutionBatch(
         bytes32 stateRoot,
         bytes memory txs,
-        Types.AccountMerkleProof[] memory accountProofs,
-        bytes32 expectedTxHashCommitment
-    )
-        public
-        view
-        returns (
-            bytes32,
-            bytes32,
-            bool
-        )
-    {
+        Types.AccountMerkleProof[] memory accountProofs
+    ) public view returns (bytes32, bool) {
         uint256 length = txs.burnExecution_size();
-
-        bytes32 actualTxHashCommitment = keccak256(txs);
-        if (expectedTxHashCommitment != ZERO_BYTES32) {
-            require(
-                actualTxHashCommitment == expectedTxHashCommitment,
-                "Invalid dispute, tx root doesn't match"
-            );
-        }
 
         bool isTxValid;
 
@@ -51,7 +34,7 @@ contract BurnExecution is FraudProofHelpers {
             }
         }
 
-        return (stateRoot, actualTxHashCommitment, !isTxValid);
+        return (stateRoot, !isTxValid);
     }
 
     function ApplyBurnExecutionTx(

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -95,26 +95,9 @@ contract Transfer is FraudProofHelpers {
     function processTransferBatch(
         bytes32 stateRoot,
         bytes memory txs,
-        Types.AccountMerkleProof[] memory accountProofs,
-        bytes32 expectedTxHashCommitment
-    )
-        public
-        pure
-        returns (
-            bytes32,
-            bytes32,
-            bool
-        )
-    {
+        Types.AccountMerkleProof[] memory accountProofs
+    ) public pure returns (bytes32, bool) {
         uint256 length = txs.transfer_size();
-
-        bytes32 actualTxHashCommitment = keccak256(txs);
-        if (expectedTxHashCommitment != ZERO_BYTES32) {
-            require(
-                actualTxHashCommitment == expectedTxHashCommitment,
-                "Invalid dispute, tx root doesn't match"
-            );
-        }
 
         bool isTxValid;
 
@@ -133,7 +116,7 @@ contract Transfer is FraudProofHelpers {
             }
         }
 
-        return (stateRoot, actualTxHashCommitment, !isTxValid);
+        return (stateRoot, !isTxValid);
     }
 
     /**

--- a/contracts/airdrop.sol
+++ b/contracts/airdrop.sol
@@ -13,26 +13,9 @@ contract Airdrop is FraudProofHelpers {
     function processAirdropBatch(
         bytes32 stateRoot,
         bytes memory txs,
-        Types.AccountMerkleProof[] memory accountProofs,
-        bytes32 expectedTxHashCommitment
-    )
-        public
-        pure
-        returns (
-            bytes32,
-            bytes32,
-            bool
-        )
-    {
+        Types.AccountMerkleProof[] memory accountProofs
+    ) public pure returns (bytes32, bool) {
         uint256 length = txs.transfer_size();
-
-        bytes32 actualTxHashCommitment = keccak256(txs);
-        if (expectedTxHashCommitment != ZERO_BYTES32) {
-            require(
-                actualTxHashCommitment == expectedTxHashCommitment,
-                "Invalid dispute, tx root doesn't match"
-            );
-        }
         bool isTxValid;
         for (uint256 i = 0; i < length; i++) {
             // call process tx update for every transaction to check if any
@@ -49,7 +32,7 @@ contract Airdrop is FraudProofHelpers {
                 break;
             }
         }
-        return (stateRoot, actualTxHashCommitment, !isTxValid);
+        return (stateRoot, !isTxValid);
     }
 
     /**

--- a/contracts/interfaces/IReddit.sol
+++ b/contracts/interfaces/IReddit.sol
@@ -141,70 +141,30 @@ interface IReddit {
     function processCreateAccountBatch(
         bytes32 initialStateRoot,
         bytes calldata txs,
-        Types.AccountMerkleProof[] calldata accountProofs,
-        bytes32 expectedTxRoot
-    )
-        external
-        view
-        returns (
-            bytes32,
-            bytes32,
-            bool
-        );
+        Types.AccountMerkleProof[] calldata accountProofs
+    ) external view returns (bytes32, bool);
 
     function processAirdropBatch(
         bytes32 initialStateRoot,
         bytes calldata txs,
-        Types.AccountMerkleProof[] calldata accountProofs,
-        bytes32 expectedTxRoot
-    )
-        external
-        view
-        returns (
-            bytes32,
-            bytes32,
-            bool
-        );
+        Types.AccountMerkleProof[] calldata accountProofs
+    ) external view returns (bytes32, bool);
 
     function processTransferBatch(
         bytes32 initialStateRoot,
         bytes calldata txs,
-        Types.AccountMerkleProof[] calldata accountProofs,
-        bytes32 expectedTxRoot
-    )
-        external
-        view
-        returns (
-            bytes32,
-            bytes32,
-            bool
-        );
+        Types.AccountMerkleProof[] calldata accountProofs
+    ) external view returns (bytes32, bool);
 
     function processBurnConsentBatch(
         bytes32 initialStateRoot,
         bytes calldata txs,
-        Types.AccountMerkleProof[] calldata accountProofs,
-        bytes32 expectedTxRoot
-    )
-        external
-        view
-        returns (
-            bytes32,
-            bytes32,
-            bool
-        );
+        Types.AccountMerkleProof[] calldata accountProofs
+    ) external view returns (bytes32, bool);
 
     function processBurnExecutionBatch(
         bytes32 initialStateRoot,
         bytes calldata txs,
-        Types.AccountMerkleProof[] calldata accountProofs,
-        bytes32 expectedTxRoot
-    )
-        external
-        view
-        returns (
-            bytes32,
-            bytes32,
-            bool
-        );
+        Types.AccountMerkleProof[] calldata accountProofs
+    ) external view returns (bytes32, bool);
 }

--- a/contracts/libs/RollupUtils.sol
+++ b/contracts/libs/RollupUtils.sol
@@ -10,15 +10,15 @@ library RollupUtils {
     function CommitmentToHash(
         bytes32 stateRoot,
         bytes32 accountRoot,
-        bytes memory txs,
         uint256[2] memory signature,
+        bytes memory txs,
         // Typechain can't parse enum for library.
         // See https://github.com/ethereum-ts/TypeChain/issues/216
         uint8 batchType
     ) public pure returns (bytes32) {
         return
             keccak256(
-                abi.encode(stateRoot, accountRoot, txs, signature, batchType)
+                abi.encode(stateRoot, accountRoot, signature, txs, batchType)
             );
     }
 

--- a/contracts/libs/RollupUtils.sol
+++ b/contracts/libs/RollupUtils.sol
@@ -10,7 +10,7 @@ library RollupUtils {
     function CommitmentToHash(
         bytes32 stateRoot,
         bytes32 accountRoot,
-        bytes32 txCommitment,
+        bytes memory txs,
         uint256[2] memory signature,
         // Typechain can't parse enum for library.
         // See https://github.com/ethereum-ts/TypeChain/issues/216
@@ -18,13 +18,7 @@ library RollupUtils {
     ) public pure returns (bytes32) {
         return
             keccak256(
-                abi.encode(
-                    stateRoot,
-                    accountRoot,
-                    txCommitment,
-                    signature,
-                    batchType
-                )
+                abi.encode(stateRoot, accountRoot, txs, signature, batchType)
             );
     }
 

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -36,8 +36,8 @@ library Types {
     struct Commitment {
         bytes32 stateRoot;
         bytes32 accountRoot;
-        bytes txs;
         uint256[2] signature;
+        bytes txs;
         Usage batchType;
     }
 

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -36,7 +36,7 @@ library Types {
     struct Commitment {
         bytes32 stateRoot;
         bytes32 accountRoot;
-        bytes32 txHashCommitment;
+        bytes txs;
         uint256[2] signature;
         Usage batchType;
     }

--- a/contracts/rollup.sol
+++ b/contracts/rollup.sol
@@ -208,8 +208,8 @@ contract Rollup is RollupHelpers {
         bytes32 genesisCommitment = RollupUtils.CommitmentToHash(
             genesisStateRoot,
             accountRegistry.root(),
-            "",
             ZERO_AGG_SIG,
+            "",
             uint8(Types.Usage.Genesis)
         );
         Types.Batch memory newBatch = Types.Batch({
@@ -243,8 +243,8 @@ contract Rollup is RollupHelpers {
                 RollupUtils.CommitmentToHash(
                     updatedRoots[i],
                     accountRegistry.root(),
-                    txs[i],
                     signatures[i],
+                    txs[i],
                     uint8(batchType)
                 )
             );
@@ -291,8 +291,8 @@ contract Rollup is RollupHelpers {
         bytes32 depositCommitment = RollupUtils.CommitmentToHash(
             newRoot,
             accountRegistry.root(),
-            "",
             ZERO_AGG_SIG,
+            "",
             uint8(Types.Usage.Deposit)
         );
 
@@ -350,8 +350,8 @@ contract Rollup is RollupHelpers {
                     RollupUtils.CommitmentToHash(
                         commitmentMP.commitment.stateRoot,
                         commitmentMP.commitment.accountRoot,
-                        commitmentMP.commitment.txs,
                         commitmentMP.commitment.signature,
+                        commitmentMP.commitment.txs,
                         uint8(commitmentMP.commitment.batchType)
                     ),
                     commitmentMP.pathToCommitment,
@@ -422,8 +422,8 @@ contract Rollup is RollupHelpers {
                 RollupUtils.CommitmentToHash(
                     commitmentProof.commitment.stateRoot,
                     commitmentProof.commitment.accountRoot,
-                    txs,
                     commitmentProof.commitment.signature,
+                    txs,
                     uint8(commitmentProof.commitment.batchType)
                 ),
                 commitmentProof.pathToCommitment,

--- a/contracts/rollupReddit.sol
+++ b/contracts/rollupReddit.sol
@@ -272,56 +272,42 @@ contract RollupReddit {
         bytes32 initialStateRoot,
         bytes memory txs,
         Types.AccountMerkleProof[] memory accountProofs,
-        bytes32 expectedTxHashCommitment,
         Types.Usage batchType
-    )
-        public
-        view
-        returns (
-            bytes32,
-            bytes32,
-            bool
-        )
-    {
+    ) public view returns (bytes32, bool) {
         if (batchType == Types.Usage.CreateAccount) {
             return
                 createAccount.processCreateAccountBatch(
                     initialStateRoot,
                     txs,
-                    accountProofs,
-                    expectedTxHashCommitment
+                    accountProofs
                 );
         } else if (batchType == Types.Usage.Airdrop) {
             return
                 airdrop.processAirdropBatch(
                     initialStateRoot,
                     txs,
-                    accountProofs,
-                    expectedTxHashCommitment
+                    accountProofs
                 );
         } else if (batchType == Types.Usage.Transfer) {
             return
                 transfer.processTransferBatch(
                     initialStateRoot,
                     txs,
-                    accountProofs,
-                    expectedTxHashCommitment
+                    accountProofs
                 );
         } else if (batchType == Types.Usage.BurnConsent) {
             return
                 burnConsent.processBurnConsentBatch(
                     initialStateRoot,
                     txs,
-                    accountProofs,
-                    expectedTxHashCommitment
+                    accountProofs
                 );
         } else if (batchType == Types.Usage.BurnExecution) {
             return
                 burnExecution.processBurnExecutionBatch(
                     initialStateRoot,
                     txs,
-                    accountProofs,
-                    expectedTxHashCommitment
+                    accountProofs
                 );
         } else {
             revert("Invalid BatchType to dispute");

--- a/test/Rollup.spec.ts
+++ b/test/Rollup.spec.ts
@@ -82,7 +82,7 @@ describe("Rollup", async function() {
         const commitment = {
             stateRoot,
             accountRoot: root,
-            txHashCommitment: ethers.utils.solidityKeccak256(["bytes"], [txs]),
+            txs,
             signature: aggregatedSignature0,
             batchType: Usage.Transfer
         };
@@ -99,18 +99,18 @@ describe("Rollup", async function() {
         const leaf = await rollupUtils.CommitmentToHash(
             commitment.stateRoot,
             commitment.accountRoot,
-            commitment.txHashCommitment,
+            commitment.txs,
             aggregatedSignature0,
             commitment.batchType
         );
         const abiCoder = ethers.utils.defaultAbiCoder;
         const hash = ethers.utils.keccak256(
             abiCoder.encode(
-                ["bytes32", "bytes32", "bytes32", "uint256[2]", "uint8"],
+                ["bytes32", "bytes32", "bytes", "uint256[2]", "uint8"],
                 [
                     commitment.stateRoot,
                     commitment.accountRoot,
-                    commitment.txHashCommitment,
+                    commitment.txs,
                     commitment.signature,
                     commitment.batchType
                 ]
@@ -130,7 +130,7 @@ describe("Rollup", async function() {
             witness: tree.witness(0).nodes
         };
 
-        await rollup.disputeBatch(batchId, commitmentMP, txs, [
+        await rollup.disputeBatch(batchId, commitmentMP, [
             {
                 pathToAccount: Alice.stateID,
                 account: proof.senderAccount,

--- a/test/Rollup.spec.ts
+++ b/test/Rollup.spec.ts
@@ -82,8 +82,8 @@ describe("Rollup", async function() {
         const commitment = {
             stateRoot,
             accountRoot: root,
-            txs,
             signature: aggregatedSignature0,
+            txs,
             batchType: Usage.Transfer
         };
         const depth = 1; // Math.log2(commitmentLength + 1)
@@ -99,19 +99,19 @@ describe("Rollup", async function() {
         const leaf = await rollupUtils.CommitmentToHash(
             commitment.stateRoot,
             commitment.accountRoot,
+            commitment.signature,
             commitment.txs,
-            aggregatedSignature0,
             commitment.batchType
         );
         const abiCoder = ethers.utils.defaultAbiCoder;
         const hash = ethers.utils.keccak256(
             abiCoder.encode(
-                ["bytes32", "bytes32", "bytes", "uint256[2]", "uint8"],
+                ["bytes32", "bytes32", "uint256[2]", "bytes", "uint8"],
                 [
                     commitment.stateRoot,
                     commitment.accountRoot,
-                    commitment.txs,
                     commitment.signature,
+                    commitment.txs,
                     commitment.batchType
                 ]
             )


### PR DESCRIPTION
We already check the hash of the whole commitment, no need to check the hash of the committed txs again.
