### PR TITLE
Misc cleanup in Rollup.sol

### DIFF
--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -17,10 +17,9 @@ contract MassMigration is FraudProofHelpers {
      * */
     function processMassMigsBatch(
         Types.MMCommitment memory commitment,
-        bytes memory txs,
         Types.AccountMerkleProof[] memory accountProofs
     ) public view returns (bytes32, bool) {
-        uint256 length = txs.massMigration_size();
+        uint256 length = commitment.txs.massMigration_size();
 
         bool isTxValid;
         // contains a bunch of variables to bypass STD
@@ -29,7 +28,7 @@ contract MassMigration is FraudProofHelpers {
         Tx.MassMigration memory _tx;
 
         for (uint256 i = 0; i < length; i++) {
-            _tx = txs.massMigration_decode(i);
+            _tx = commitment.txs.massMigration_decode(i);
 
             // ensure the transaction is to burn account
             if (_tx.toIndex != BURN_STATE_INDEX) {

--- a/contracts/Rollup.sol
+++ b/contracts/Rollup.sol
@@ -546,8 +546,7 @@ contract Rollup is RollupHelpers {
     function disputeSignature(
         uint256 batchID,
         Types.CommitmentInclusionProof memory commitmentProof,
-        Types.SignatureProof memory signatureProof,
-        bytes memory txs
+        Types.SignatureProof memory signatureProof
     ) public {
         {
             // check if batch is disputable
@@ -577,7 +576,7 @@ contract Rollup is RollupHelpers {
             commitmentProof.commitment.stateRoot,
             commitmentProof.commitment.accountRoot,
             signatureProof,
-            txs
+            commitmentProof.commitment.txs
         );
 
         if (errCode != Types.ErrorCode.NoError) {

--- a/contracts/Rollup.sol
+++ b/contracts/Rollup.sol
@@ -28,7 +28,6 @@ interface IRollupReddit {
 
     function processMMBatch(
         Types.MMCommitment calldata commitment,
-        bytes calldata txs,
         Types.AccountMerkleProof[] calldata accountProofs
     ) external view returns (bytes32, bool);
 
@@ -492,7 +491,6 @@ contract Rollup is RollupHelpers {
         bool isDisputeValid;
         (updatedBalanceRoot, isDisputeValid) = rollupReddit.processMMBatch(
             commitmentMP.commitment,
-            commitmentMP.commitment.txs,
             accountProofs
         );
 

--- a/contracts/Rollup.sol
+++ b/contracts/Rollup.sol
@@ -339,7 +339,6 @@ contract Rollup is RollupHelpers {
         uint256[2][] calldata aggregatedSignatures,
         Types.MassMigrationMetaInfo[] calldata MMInfo
     ) external payable onlyCoordinator {
-        // require(msg.value >= STAKE_AMOUNT, "Not enough stake committed");
         bytes32[] memory commitments = new bytes32[](updatedRoots.length);
         bytes32 pubkeyTreeRoot = accountRegistry.root();
         for (uint256 i = 0; i < updatedRoots.length; i++) {

--- a/contracts/Rollup.sol
+++ b/contracts/Rollup.sol
@@ -75,6 +75,7 @@ contract RollupSetup {
             nameRegistry.getContractDetails(ParamManager.POB())
         );
         assert(msg.sender == pobContract.getCoordinator());
+        require(msg.value >= STAKE_AMOUNT, "Not enough stake committed");
         _;
     }
 
@@ -280,7 +281,6 @@ contract Rollup is RollupHelpers {
         Types.Submission[] calldata submissions,
         Types.Usage batchType
     ) external payable onlyCoordinator {
-        // require(msg.value >= STAKE_AMOUNT, "Not enough stake committed");
         bytes32[] memory commitments = new bytes32[](submissions.length);
         bytes32 pubkeyTreeRoot = accountRegistry.root();
         for (uint256 i = 0; i < submissions.length; i++) {
@@ -364,11 +364,6 @@ contract Rollup is RollupHelpers {
             _subTreeDepth,
             _zero_account_mp,
             getLatestBalanceTreeRoot()
-        );
-
-        require(
-            msg.value >= governance.STAKE_AMOUNT(),
-            "Not enough stake committed"
         );
 
         bytes32 newRoot = merkleUtils.updateLeafWithSiblings(

--- a/contracts/Rollup.sol
+++ b/contracts/Rollup.sol
@@ -99,7 +99,7 @@ contract RollupSetup {
         );
 
         require(
-            (_batch_id < invalidBatchMarker || invalidBatchMarker == 0),
+            _batch_id < invalidBatchMarker || invalidBatchMarker == 0,
             "Already successfully disputed. Roll back in process"
         );
         _;
@@ -455,29 +455,11 @@ contract Rollup is RollupHelpers {
         Types.MMCommitmentInclusionProof memory commitmentMP,
         bytes memory txs,
         Types.AccountMerkleProof[] memory accountProofs
-    ) public {
-        {
-            // check if batch is disputable
-            require(
-                !batches[_batch_id].withdrawn,
-                "No point dispute a withdrawn batch"
-            );
-            require(
-                block.number < batches[_batch_id].finalisesOn,
-                "Batch already finalised"
-            );
-
-            require(
-                (_batch_id < invalidBatchMarker || invalidBatchMarker == 0),
-                "Already successfully disputed. Roll back in process"
-            );
-
-            require(
-                txs.length != 0,
-                "Cannot dispute blocks with no transaction"
-            );
-        }
-
+    ) public isDisputable(_batch_id){
+        require(
+            txs.length != 0,
+            "Cannot dispute blocks with no transaction"
+        );
         // verify is the commitment exits in the batch
         {
             require(
@@ -563,23 +545,7 @@ contract Rollup is RollupHelpers {
         Types.MMCommitmentInclusionProof memory commitmentProof,
         Types.SignatureProof memory signatureProof,
         bytes memory txs
-    ) public {
-        {
-            // check if batch is disputable
-            require(
-                !batches[batchID].withdrawn,
-                "No point dispute a withdrawn batch"
-            );
-            require(
-                block.number < batches[batchID].finalisesOn,
-                "Batch already finalised"
-            );
-
-            require(
-                batchID < invalidBatchMarker || invalidBatchMarker == 0,
-                "Already successfully disputed. Roll back in process"
-            );
-        }
+    ) public isDisputable(batchID) {
         // verify is the commitment exits in the batch
         require(
             merkleUtils.verifyLeaf(

--- a/contracts/Rollup.sol
+++ b/contracts/Rollup.sol
@@ -453,11 +453,10 @@ contract Rollup is RollupHelpers {
     function disputeMMBatch(
         uint256 _batch_id,
         Types.MMCommitmentInclusionProof memory commitmentMP,
-        bytes memory txs,
         Types.AccountMerkleProof[] memory accountProofs
     ) public isDisputable(_batch_id){
         require(
-            txs.length != 0,
+            commitmentMP.commitment.txs.length != 0,
             "Cannot dispute blocks with no transaction"
         );
         // verify is the commitment exits in the batch
@@ -468,7 +467,7 @@ contract Rollup is RollupHelpers {
                     RollupUtils.MMCommitmentToHash(
                         commitmentMP.commitment.stateRoot,
                         commitmentMP.commitment.accountRoot,
-                        txs,
+                        commitmentMP.commitment.txs,
                         commitmentMP.commitment.massMigrationMetaInfo.tokenID,
                         commitmentMP.commitment.massMigrationMetaInfo.amount,
                         commitmentMP
@@ -492,7 +491,7 @@ contract Rollup is RollupHelpers {
         bool isDisputeValid;
         (updatedBalanceRoot, isDisputeValid) = rollupReddit.processMMBatch(
             commitmentMP.commitment,
-            txs,
+            commitmentMP.commitment.txs,
             accountProofs
         );
 

--- a/contracts/Rollup.sol
+++ b/contracts/Rollup.sol
@@ -543,8 +543,7 @@ contract Rollup is RollupHelpers {
     function disputeSignatureinMM(
         uint256 batchID,
         Types.MMCommitmentInclusionProof memory commitmentProof,
-        Types.SignatureProof memory signatureProof,
-        bytes memory txs
+        Types.SignatureProof memory signatureProof
     ) public isDisputable(batchID) {
         // verify is the commitment exits in the batch
         require(
@@ -558,7 +557,7 @@ contract Rollup is RollupHelpers {
             commitmentProof.commitment.stateRoot,
             commitmentProof.commitment.accountRoot,
             signatureProof,
-            txs
+            commitmentProof.commitment.txs
         );
 
         if (errCode != Types.ErrorCode.NoError) {

--- a/contracts/RollupReddit.sol
+++ b/contracts/RollupReddit.sol
@@ -327,10 +327,9 @@ contract RollupReddit {
 
     function processMMBatch(
         Types.MMCommitment memory commitment,
-        bytes memory txs,
         Types.AccountMerkleProof[] memory accountProofs
     ) public view returns (bytes32, bool) {
         // call mass mig contract
-        return massMigs.processMassMigsBatch(commitment, txs, accountProofs);
+        return massMigs.processMassMigsBatch(commitment, accountProofs);
     }
 }

--- a/test/MassMigration.test.ts
+++ b/test/MassMigration.test.ts
@@ -10,7 +10,6 @@ import * as mcl from "../ts/mcl";
 import { Tree, Hasher } from "../ts/tree";
 import { allContracts } from "../ts/allContractsInterfaces";
 import { assert } from "chai";
-import { parseEvents } from "../ts/utils";
 
 const DOMAIN =
     "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
@@ -76,7 +75,7 @@ describe("Mass Migrations", async function() {
         const commitment = {
             stateRoot,
             accountRoot: root,
-            txs: txs,
+            txs,
             massMigrationMetaInfo: MMInfo,
             signature: aggregatedSignature0,
             batchType: Usage.MassMigration
@@ -168,7 +167,7 @@ describe("Mass Migrations", async function() {
             siblings: tree.witness(0).nodes
         };
 
-        await rollup.disputeMMBatch(batchId, commitmentMP, txs, [
+        await rollup.disputeMMBatch(batchId, commitmentMP, [
             {
                 pathToAccount: Alice.stateID,
                 account: proof.account,

--- a/test/MassMigration.test.ts
+++ b/test/MassMigration.test.ts
@@ -80,17 +80,13 @@ describe("Mass Migrations", async function() {
             signature: aggregatedSignature0,
             batchType: Usage.MassMigration
         };
-        const result = await contracts.rollupReddit.processMMBatch(
-            commitment,
-            txs,
-            [
-                {
-                    pathToAccount: Alice.stateID,
-                    account: proof.account,
-                    siblings: proof.witness
-                }
-            ]
-        );
+        const result = await contracts.rollupReddit.processMMBatch(commitment, [
+            {
+                pathToAccount: Alice.stateID,
+                account: proof.account,
+                siblings: proof.witness
+            }
+        ]);
 
         await rollup.submitBatchWithMM(
             [txs],

--- a/ts/tx.ts
+++ b/ts/tx.ts
@@ -1,7 +1,6 @@
 import { Tree } from "./tree";
 import { ethers } from "ethers";
 import { paddedHex, randomNum } from "./utils";
-import { Usage } from "../ts/interfaces";
 
 const amountLen = 4;
 const feeLen = 4;


### PR DESCRIPTION

- extract `checkInclusion` so we don't expand CommitmentInclusionProof everytime.
- add `isDisputable` modifier for all dispute check
- move STAKE_AMOUNT check to onlyCoordinator modifier, they should come together. 
- remove the redundant txs arg in disputeSignature