### PR TITLE
refactored utils

### DIFF
--- a/contracts/ClientUtils.sol
+++ b/contracts/ClientUtils.sol
@@ -1,0 +1,203 @@
+pragma solidity ^0.5.15;
+pragma experimental ABIEncoderV2;
+
+import { Tx } from "./libs/Tx.sol";
+import { Types } from "./libs/Types.sol";
+import { RollupUtils } from "./libs/RollupUtils.sol";
+
+contract ClientUtils {
+    function CommitmentToHash(
+        bytes32 stateRoot,
+        bytes32 accountRoot,
+        uint256[2] memory signature,
+        bytes memory txs,
+        uint256 tokenType,
+        uint256 feeReceiver,
+        uint8 batchType
+    ) public pure returns (bytes32) {
+        return
+            RollupUtils.CommitmentToHash(
+                stateRoot,
+                accountRoot,
+                signature,
+                txs,
+                tokenType,
+                feeReceiver,
+                batchType
+            );
+    }
+
+    function MMCommitmentToHash(
+        bytes32 stateRoot,
+        bytes32 accountRoot,
+        bytes memory txs,
+        uint256 tokenID,
+        uint256 amount,
+        bytes32 withdrawRoot,
+        uint256 targetSpokeID,
+        uint256[2] memory aggregatedSignature
+    ) public pure returns (bytes32) {
+        return
+            RollupUtils.MMCommitmentToHash(
+                stateRoot,
+                accountRoot,
+                txs,
+                tokenID,
+                amount,
+                withdrawRoot,
+                targetSpokeID,
+                aggregatedSignature
+            );
+    }
+
+    // ---------- Account Related Utils -------------------
+
+    // AccountFromBytes decodes the bytes to account
+    function AccountFromBytes(bytes memory accountBytes)
+        public
+        pure
+        returns (
+            uint256 ID,
+            uint256 balance,
+            uint256 nonce,
+            uint256 tokenType,
+            uint256 burn,
+            uint256 lastBurn
+        )
+    {
+        return RollupUtils.AccountFromBytes(accountBytes);
+    }
+
+    //
+    // BytesFromAccount and BytesFromAccountDeconstructed do the same thing i.e encode account to bytes
+    //
+    function BytesFromAccount(Types.UserAccount memory account)
+        public
+        pure
+        returns (bytes memory data)
+    {
+        return RollupUtils.BytesFromAccount(account);
+    }
+
+    function HashFromAccount(Types.UserAccount memory account)
+        public
+        pure
+        returns (bytes32)
+    {
+        return RollupUtils.HashFromAccount(account);
+    }
+
+    /**
+     * @notice Calculates the address from the pubkey
+     * @param pub is the pubkey
+     * @return Returns the address that has been calculated from the pubkey
+     */
+    function calculateAddress(bytes memory pub)
+        public
+        pure
+        returns (address addr)
+    {
+        return RollupUtils.calculateAddress(pub);
+    }
+
+    function GetGenesisLeaves() public pure returns (bytes32[2] memory leaves) {
+        return RollupUtils.GetGenesisLeaves();
+    }
+
+    function GetGenesisDataBlocks()
+        public
+        pure
+        returns (bytes[2] memory dataBlocks)
+    {
+        return RollupUtils.GetGenesisDataBlocks();
+    }
+
+    // ---------- Tx Related Utils -------------------
+
+    function TransferToBytes(Types.Transfer memory _tx)
+        public
+        pure
+        returns (bytes memory)
+    {
+        return RollupUtils.ToBytes(_tx);
+    }
+
+    function MMToBytes(Types.MassMigration memory _tx)
+        public
+        pure
+        returns (bytes memory)
+    {
+        return RollupUtils.ToBytes(_tx);
+    }
+
+    function FromBytesToTransfer(bytes calldata txBytes)
+        external
+        pure
+        returns (Types.Transfer memory)
+    {
+        return RollupUtils.FromBytesToTransfer(txBytes);
+    }
+
+    function FromBytesToMassMigration(bytes memory txBytes)
+        public
+        pure
+        returns (Types.MassMigration memory transaction)
+    {
+        return RollupUtils.FromBytesToMassMigration(txBytes);
+    }
+
+    function getTransferSignBytes(Types.Transfer memory _tx)
+        public
+        pure
+        returns (bytes32)
+    {
+        return RollupUtils.getTxSignBytes(_tx);
+    }
+
+    function getMassMigrationSignBytes(Types.MassMigration memory _tx)
+        public
+        pure
+        returns (bytes32)
+    {
+        return RollupUtils.getTxSignBytes(_tx);
+    }
+
+    function DecompressTransfers(bytes memory txs)
+        public
+        pure
+        returns (Tx.Transfer[] memory)
+    {
+        return RollupUtils.DecompressTransfers(txs);
+    }
+
+    function HashFromTx(Types.Transfer memory _tx)
+        public
+        pure
+        returns (bytes32)
+    {
+        return RollupUtils.HashFromTx(_tx);
+    }
+
+    function CompressTransferFromEncoded(bytes memory txBytes, bytes memory sig)
+        public
+        pure
+        returns (bytes memory)
+    {
+        return RollupUtils.CompressTransferFromEncoded(txBytes, sig);
+    }
+
+    function CompressManyTransferFromEncoded(
+        bytes[] memory txBytes,
+        bytes[] memory sigs
+    ) public pure returns (bytes memory) {
+        return RollupUtils.CompressManyTransferFromEncoded(txBytes, sigs);
+    }
+
+    function DecompressManyTransfer(bytes memory txs)
+        public
+        pure
+        returns (Tx.Transfer[] memory structTxs)
+    {
+        return RollupUtils.DecompressManyTransfer(txs);
+    }
+}

--- a/contracts/libs/ParamManager.sol
+++ b/contracts/libs/ParamManager.sol
@@ -61,6 +61,10 @@ library ParamManager {
         return keccak256("vault");
     }
 
+    function CLIENT_UTILS() public pure returns (bytes32) {
+        return keccak256("client_utils");
+    }
+
     bytes32 public constant _CHAIN_ID = keccak256("hubble-123");
 
     function CHAIN_ID() public pure returns (bytes32) {

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -88,6 +88,17 @@ library Types {
         uint256 fee;
     }
 
+    struct MassMigration {
+        uint256 txType;
+        uint256 fromIndex;
+        uint256 toIndex;
+        uint256 spokeID;
+        uint256 tokenType;
+        uint256 nonce;
+        uint256 amount;
+        uint256 fee;
+    }
+
     // UserAccount contains the actual data stored in the leaf of balance tree
     struct UserAccount {
         // ID is the path to the pubkey in the PDA tree

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,11 @@
       "integrity": "sha512-JSvpj1iNMFjK6K+uVl4unqMoa9rf5jopb8cya5UGBWz23Nw8hSNT7efgUx4BTlAPAgpNlEioUfeTyQ6J9ZvTVw==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.5.2",
-        "eth-ens-namehash": "^2.0.8",
-        "solc": "^0.4.20",
+        "bluebird": "3.7.2",
+        "eth-ens-namehash": "2.0.8",
+        "solc": "0.4.26",
         "testrpc": "0.0.1",
-        "web3-utils": "^1.0.0-beta.31"
+        "web3-utils": "1.2.9"
       },
       "dependencies": {
         "ansi-regex": {
@@ -35,9 +35,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           }
         },
         "fs-extra": {
@@ -46,11 +46,11 @@
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "rimraf": "^2.2.8"
+            "graceful-fs": "4.2.4",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1",
+            "path-is-absolute": "1.0.1",
+            "rimraf": "2.7.1"
           }
         },
         "get-caller-file": {
@@ -65,7 +65,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "jsonfile": {
@@ -74,7 +74,7 @@
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.2.4"
           }
         },
         "require-from-string": {
@@ -95,11 +95,11 @@
           "integrity": "sha512-o+c6FpkiHd+HPjmjEVpQgH7fqZ14tJpXhho+/bQXlXbliLIS/xjXb42Vxh+qQY1WCSTMQ0+a5vR9vi0MfhU6mA==",
           "dev": true,
           "requires": {
-            "fs-extra": "^0.30.0",
-            "memorystream": "^0.3.1",
-            "require-from-string": "^1.1.0",
-            "semver": "^5.3.0",
-            "yargs": "^4.7.1"
+            "fs-extra": "0.30.0",
+            "memorystream": "0.3.1",
+            "require-from-string": "1.2.1",
+            "semver": "5.7.1",
+            "yargs": "4.8.1"
           }
         },
         "string-width": {
@@ -108,9 +108,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "strip-ansi": {
@@ -119,7 +119,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "which-module": {
@@ -134,8 +134,8 @@
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
           }
         },
         "y18n": {
@@ -150,20 +150,20 @@
           "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
           "dev": true,
           "requires": {
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "lodash.assign": "^4.0.3",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.1",
-            "which-module": "^1.0.0",
-            "window-size": "^0.2.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^2.4.1"
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.3",
+            "lodash.assign": "4.2.0",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "window-size": "0.2.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "2.4.1"
           }
         },
         "yargs-parser": {
@@ -172,8 +172,8 @@
           "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "lodash.assign": "^4.0.6"
+            "camelcase": "3.0.0",
+            "lodash.assign": "4.2.0"
           }
         }
       }
@@ -190,8 +190,8 @@
       "integrity": "sha512-erBoZoseFXZPEEbv9GHqJKjGAG4u1m/NzTRvXUGFDngdZYsBzMDTVU63vIrGVlVu3Cu7Wd5KfdhYib+/iH2xcQ==",
       "dev": true,
       "requires": {
-        "@ethereum-waffle/provider": "^3.1.0",
-        "ethers": "^5.0.0"
+        "@ethereum-waffle/provider": "3.1.0",
+        "ethers": "5.0.13"
       }
     },
     "@ethereum-waffle/compiler": {
@@ -200,14 +200,14 @@
       "integrity": "sha512-qFwy9OHbbvltns4tz12mpbSryg8rCpATsdjM+PtSSXSJ7s04fcDlKWJgFERE3jsxE7GMGH8mfr4e7Jqncxxh7w==",
       "dev": true,
       "requires": {
-        "@resolver-engine/imports": "^0.3.3",
-        "@resolver-engine/imports-fs": "^0.3.3",
-        "@types/mkdirp": "^0.5.2",
-        "@types/node-fetch": "^2.5.5",
-        "ethers": "^5.0.1",
-        "mkdirp": "^0.5.1",
-        "node-fetch": "^2.6.0",
-        "solc": "^0.6.3"
+        "@resolver-engine/imports": "0.3.3",
+        "@resolver-engine/imports-fs": "0.3.3",
+        "@types/mkdirp": "0.5.2",
+        "@types/node-fetch": "2.5.7",
+        "ethers": "5.0.13",
+        "mkdirp": "0.5.5",
+        "node-fetch": "2.6.0",
+        "solc": "0.6.12"
       },
       "dependencies": {
         "commander": {
@@ -222,11 +222,11 @@
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "rimraf": "^2.2.8"
+            "graceful-fs": "4.2.4",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1",
+            "path-is-absolute": "1.0.1",
+            "rimraf": "2.7.1"
           }
         },
         "jsonfile": {
@@ -235,7 +235,7 @@
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.2.4"
           }
         },
         "node-fetch": {
@@ -250,13 +250,13 @@
           "integrity": "sha512-Lm0Ql2G9Qc7yPP2Ba+WNmzw2jwsrd3u4PobHYlSOxaut3TtUbj9+5ZrT6f4DUpNPEoBaFUOEg9Op9C0mk7ge9g==",
           "dev": true,
           "requires": {
-            "command-exists": "^1.2.8",
+            "command-exists": "1.2.9",
             "commander": "3.0.2",
-            "fs-extra": "^0.30.0",
+            "fs-extra": "0.30.0",
             "js-sha3": "0.8.0",
-            "memorystream": "^0.3.1",
-            "require-from-string": "^2.0.0",
-            "semver": "^5.5.0",
+            "memorystream": "0.3.1",
+            "require-from-string": "2.0.2",
+            "semver": "5.7.1",
             "tmp": "0.0.33"
           }
         }
@@ -268,9 +268,9 @@
       "integrity": "sha512-Q0/MUBJQsiPseZv0Sv/GFOVdWGn0wRChWtUd30r94qlcM7OqmXLdx4YQSMGu7BhRPdp2DQE2CYMFTKjiznfRkA==",
       "dev": true,
       "requires": {
-        "@ensdomains/ens": "^0.4.4",
-        "@ensdomains/resolver": "^0.2.4",
-        "ethers": "^5.0.1"
+        "@ensdomains/ens": "0.4.5",
+        "@ensdomains/resolver": "0.2.4",
+        "ethers": "5.0.13"
       }
     },
     "@ethereum-waffle/mock-contract": {
@@ -279,8 +279,8 @@
       "integrity": "sha512-mhvyb9P5aM7D2qHmaAH2ONbR95L7pVveRR9s7zfcxYdzJP0KCjy2IZfPmhOZDe/lW1tXuM3m/OL+oHfKTRYbdw==",
       "dev": true,
       "requires": {
-        "@ethersproject/abi": "^5.0.1",
-        "ethers": "^5.0.1"
+        "@ethersproject/abi": "5.0.3",
+        "ethers": "5.0.13"
       },
       "dependencies": {
         "@ethersproject/abi": {
@@ -289,15 +289,15 @@
           "integrity": "sha512-fSSs4sgaf5R1955QSpYXW2YkrYBgyOSyENyyMEyJwxTsKJKQPaReTQXafyeRc8ZLi3/2uzeqakH09r0S1hlFng==",
           "dev": true,
           "requires": {
-            "@ethersproject/address": "^5.0.3",
-            "@ethersproject/bignumber": "^5.0.6",
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/constants": "^5.0.3",
-            "@ethersproject/hash": "^5.0.3",
-            "@ethersproject/keccak256": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/properties": "^5.0.3",
-            "@ethersproject/strings": "^5.0.3"
+            "@ethersproject/address": "5.0.3",
+            "@ethersproject/bignumber": "5.0.6",
+            "@ethersproject/bytes": "5.0.4",
+            "@ethersproject/constants": "5.0.3",
+            "@ethersproject/hash": "5.0.3",
+            "@ethersproject/keccak256": "5.0.3",
+            "@ethersproject/logger": "5.0.5",
+            "@ethersproject/properties": "5.0.3",
+            "@ethersproject/strings": "5.0.3"
           }
         },
         "@ethersproject/address": {
@@ -306,12 +306,12 @@
           "integrity": "sha512-LMmLxL1wTNtvwgm/eegcaxtG/W7vHXKzHGUkK9KZEI9W+SfHrpT7cGX+hBcatcUXPANjS3TmOaQ+mq5JU5sGTw==",
           "dev": true,
           "requires": {
-            "@ethersproject/bignumber": "^5.0.6",
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/keccak256": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/rlp": "^5.0.3",
-            "bn.js": "^4.4.0"
+            "@ethersproject/bignumber": "5.0.6",
+            "@ethersproject/bytes": "5.0.4",
+            "@ethersproject/keccak256": "5.0.3",
+            "@ethersproject/logger": "5.0.5",
+            "@ethersproject/rlp": "5.0.3",
+            "bn.js": "4.11.9"
           },
           "dependencies": {
             "bn.js": {
@@ -328,9 +328,9 @@
           "integrity": "sha512-fLilYOSH3DJXBrimx7PwrJdY/zAI5MGp229Mvhtcur76Lgt4qNWu9HTiwMGHP01Tkm3YP5gweF83GrQrA2tYUA==",
           "dev": true,
           "requires": {
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/logger": "^5.0.5",
-            "bn.js": "^4.4.0"
+            "@ethersproject/bytes": "5.0.4",
+            "@ethersproject/logger": "5.0.5",
+            "bn.js": "4.11.9"
           },
           "dependencies": {
             "bn.js": {
@@ -347,7 +347,7 @@
           "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
           "dev": true,
           "requires": {
-            "@ethersproject/logger": "^5.0.5"
+            "@ethersproject/logger": "5.0.5"
           }
         },
         "@ethersproject/constants": {
@@ -356,7 +356,7 @@
           "integrity": "sha512-iN7KBrA0zNFybDyrkcAPOcyU3CHXYFMd+KM2Jr07Kjg+DVB5wPpEXsOdd/K1KWFsFtGfNdPZ7QP8siLtCePXrQ==",
           "dev": true,
           "requires": {
-            "@ethersproject/bignumber": "^5.0.6"
+            "@ethersproject/bignumber": "5.0.6"
           }
         },
         "@ethersproject/hash": {
@@ -365,10 +365,10 @@
           "integrity": "sha512-KSnJyL0G9lxbOK0UPrUcaYTc/RidrX8c+kn7xnEpTmSGxqlndw4BzvQcRgYt31bOIwuFtwlWvOo6AN2tJgdQtA==",
           "dev": true,
           "requires": {
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/keccak256": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5",
-            "@ethersproject/strings": "^5.0.3"
+            "@ethersproject/bytes": "5.0.4",
+            "@ethersproject/keccak256": "5.0.3",
+            "@ethersproject/logger": "5.0.5",
+            "@ethersproject/strings": "5.0.3"
           }
         },
         "@ethersproject/keccak256": {
@@ -377,7 +377,7 @@
           "integrity": "sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==",
           "dev": true,
           "requires": {
-            "@ethersproject/bytes": "^5.0.4",
+            "@ethersproject/bytes": "5.0.4",
             "js-sha3": "0.5.7"
           }
         },
@@ -393,7 +393,7 @@
           "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
           "dev": true,
           "requires": {
-            "@ethersproject/logger": "^5.0.5"
+            "@ethersproject/logger": "5.0.5"
           }
         },
         "@ethersproject/rlp": {
@@ -402,8 +402,8 @@
           "integrity": "sha512-Hz4yyA/ilGafASAqtTlLWkA/YqwhQmhbDAq2LSIp1AJNx+wtbKWFAKSckpeZ+WG/xZmT+fw5OFKK7a5IZ4DR5g==",
           "dev": true,
           "requires": {
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/logger": "^5.0.5"
+            "@ethersproject/bytes": "5.0.4",
+            "@ethersproject/logger": "5.0.5"
           }
         },
         "@ethersproject/strings": {
@@ -412,9 +412,9 @@
           "integrity": "sha512-8kEx3+Z6cMn581yh093qnaSa8H7XzmLn6g8YFDHUpzXM7+bvXvnL2ciHrJ+EbvaMQZpej6nNtl0nm7XF4PmQHA==",
           "dev": true,
           "requires": {
-            "@ethersproject/bytes": "^5.0.4",
-            "@ethersproject/constants": "^5.0.3",
-            "@ethersproject/logger": "^5.0.5"
+            "@ethersproject/bytes": "5.0.4",
+            "@ethersproject/constants": "5.0.3",
+            "@ethersproject/logger": "5.0.5"
           }
         },
         "js-sha3": {
@@ -431,11 +431,11 @@
       "integrity": "sha512-MPlmtYWVEjObSrneZQKHprRe00Da768IdT1+hyWq5x6uXluYdqo5hZc9LVNTd2f9WfHasZ8YWZLUC/wsEb86ig==",
       "dev": true,
       "requires": {
-        "@ethereum-waffle/ens": "^3.1.0",
-        "ethers": "^5.0.1",
-        "ganache-core": "^2.10.2",
-        "patch-package": "^6.2.2",
-        "postinstall-postinstall": "^2.1.0"
+        "@ethereum-waffle/ens": "3.1.0",
+        "ethers": "5.0.13",
+        "ganache-core": "2.11.2",
+        "patch-package": "6.2.2",
+        "postinstall-postinstall": "2.1.0"
       }
     },
     "@ethersproject/abi": {
@@ -444,15 +444,15 @@
       "integrity": "sha512-FNx6UMm0LnmCMFzN3urohFwZpjbUHPvc/O60h4qkF4yiJxLJ/G7QOSPjkHQ/q/QibagR4S7OKQawRy0NcvWa9w==",
       "dev": true,
       "requires": {
-        "@ethersproject/address": "^5.0.4",
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.4",
-        "@ethersproject/hash": "^5.0.4",
-        "@ethersproject/keccak256": "^5.0.3",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/strings": "^5.0.4"
+        "@ethersproject/address": "5.0.4",
+        "@ethersproject/bignumber": "5.0.7",
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/constants": "5.0.4",
+        "@ethersproject/hash": "5.0.4",
+        "@ethersproject/keccak256": "5.0.3",
+        "@ethersproject/logger": "5.0.5",
+        "@ethersproject/properties": "5.0.3",
+        "@ethersproject/strings": "5.0.4"
       }
     },
     "@ethersproject/abstract-provider": {
@@ -461,13 +461,13 @@
       "integrity": "sha512-EOCHUTS8jOE3WZlA1pq9b/vQwKDyDzMy4gXeAv0wZecH1kwUkD0++x8avxeSYoWI+aJn62P1FVV9B6r9pM56kQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/networks": "^5.0.3",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/transactions": "^5.0.5",
-        "@ethersproject/web": "^5.0.6"
+        "@ethersproject/bignumber": "5.0.7",
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/logger": "5.0.5",
+        "@ethersproject/networks": "5.0.3",
+        "@ethersproject/properties": "5.0.3",
+        "@ethersproject/transactions": "5.0.5",
+        "@ethersproject/web": "5.0.6"
       }
     },
     "@ethersproject/abstract-signer": {
@@ -476,11 +476,11 @@
       "integrity": "sha512-pQTDZwOhz2zINC27xfVah7EVv1A9qza1SShmqFjljZo4C9liYf/kSeWCLKkEbpbJNUVUHAbXBwV4N0XBv1xRYA==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-provider": "^5.0.4",
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/properties": "^5.0.3"
+        "@ethersproject/abstract-provider": "5.0.4",
+        "@ethersproject/bignumber": "5.0.7",
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/logger": "5.0.5",
+        "@ethersproject/properties": "5.0.3"
       }
     },
     "@ethersproject/address": {
@@ -489,12 +489,12 @@
       "integrity": "sha512-CIjAeG6zNehbpJTi0sgwUvaH2ZICiAV9XkCBaFy5tjuEVFpQNeqd6f+B7RowcNO7Eut+QbhcQ5CVLkmP5zhL9A==",
       "dev": true,
       "requires": {
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/keccak256": "^5.0.3",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/rlp": "^5.0.3",
-        "bn.js": "^4.4.0"
+        "@ethersproject/bignumber": "5.0.7",
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/keccak256": "5.0.3",
+        "@ethersproject/logger": "5.0.5",
+        "@ethersproject/rlp": "5.0.3",
+        "bn.js": "4.11.9"
       },
       "dependencies": {
         "bn.js": {
@@ -511,7 +511,7 @@
       "integrity": "sha512-sFq+/UwGCQsLxMvp7yO7yGWni87QXoV3C3IfjqUSY2BHkbZbCDm+PxZviUkiKf+edYZ2Glp0XnY7CgKSYUN9qw==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.0.4"
+        "@ethersproject/bytes": "5.0.4"
       }
     },
     "@ethersproject/basex": {
@@ -520,8 +520,8 @@
       "integrity": "sha512-EvoER+OXsMAZlvbC0M/9UTxjvbBvTccYCI+uCAhXw+eS1+SUdD4v7ekAFpVX78rPLrLZB1vChKMm6vPHIu3WRA==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/properties": "^5.0.3"
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/properties": "5.0.3"
       }
     },
     "@ethersproject/bignumber": {
@@ -530,9 +530,9 @@
       "integrity": "sha512-wwKgDJ+KA7IpgJwc8Fc0AjKIRuDskKA2cque29/+SgII9/1K/38JpqVNPKIovkLwTC2DDofIyzHcxeaKpMFouQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
-        "bn.js": "^4.4.0"
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/logger": "5.0.5",
+        "bn.js": "4.11.9"
       },
       "dependencies": {
         "bn.js": {
@@ -549,7 +549,7 @@
       "integrity": "sha512-9R6A6l9JN8x1U4s1dJCR+9h3MZTT3xQofr/Xx8wbDvj6NnY4CbBB0o8ZgHXvR74yV90pY2EzCekpkMBJnRzkSw==",
       "dev": true,
       "requires": {
-        "@ethersproject/logger": "^5.0.5"
+        "@ethersproject/logger": "5.0.5"
       }
     },
     "@ethersproject/constants": {
@@ -558,7 +558,7 @@
       "integrity": "sha512-Df32lcXDHPgZRPgp1dgmByNbNe4Ki1QoXR+wU61on5nggQGTqWR1Bb7pp9VtI5Go9kyE/JflFc4Te6o9MvYt8A==",
       "dev": true,
       "requires": {
-        "@ethersproject/bignumber": "^5.0.7"
+        "@ethersproject/bignumber": "5.0.7"
       }
     },
     "@ethersproject/contracts": {
@@ -567,15 +567,15 @@
       "integrity": "sha512-gfOZNgLiO9e1D/hmQ4sEyqoolw6jDFVfqirGJv3zyFKNyX+lAXLN7YAZnnWVmp4GU1jiMtSqQKjpWp7r6ihs3Q==",
       "dev": true,
       "requires": {
-        "@ethersproject/abi": "^5.0.5",
-        "@ethersproject/abstract-provider": "^5.0.4",
-        "@ethersproject/abstract-signer": "^5.0.4",
-        "@ethersproject/address": "^5.0.4",
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/properties": "^5.0.3"
+        "@ethersproject/abi": "5.0.5",
+        "@ethersproject/abstract-provider": "5.0.4",
+        "@ethersproject/abstract-signer": "5.0.4",
+        "@ethersproject/address": "5.0.4",
+        "@ethersproject/bignumber": "5.0.7",
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/constants": "5.0.4",
+        "@ethersproject/logger": "5.0.5",
+        "@ethersproject/properties": "5.0.3"
       }
     },
     "@ethersproject/hash": {
@@ -584,10 +584,10 @@
       "integrity": "sha512-VCs/bFBU8AQFhHcT1cQH6x7a4zjulR6fJmAOcPxUgrN7bxOQ7QkpBKF+YCDJhFtkLdaljIsr/r831TuWU4Ysfg==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/keccak256": "^5.0.3",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/strings": "^5.0.4"
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/keccak256": "5.0.3",
+        "@ethersproject/logger": "5.0.5",
+        "@ethersproject/strings": "5.0.4"
       }
     },
     "@ethersproject/hdnode": {
@@ -596,18 +596,18 @@
       "integrity": "sha512-eHmpNLvasfB4xbmQUvKXOsGF4ekjIKJH/eZm7fc6nIdMci9u5ERooSSRLjs9Dsa5QuJf6YD4DbqeJsT71n47iw==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-signer": "^5.0.4",
-        "@ethersproject/basex": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/pbkdf2": "^5.0.3",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/sha2": "^5.0.3",
-        "@ethersproject/signing-key": "^5.0.4",
-        "@ethersproject/strings": "^5.0.4",
-        "@ethersproject/transactions": "^5.0.5",
-        "@ethersproject/wordlists": "^5.0.4"
+        "@ethersproject/abstract-signer": "5.0.4",
+        "@ethersproject/basex": "5.0.3",
+        "@ethersproject/bignumber": "5.0.7",
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/logger": "5.0.5",
+        "@ethersproject/pbkdf2": "5.0.3",
+        "@ethersproject/properties": "5.0.3",
+        "@ethersproject/sha2": "5.0.3",
+        "@ethersproject/signing-key": "5.0.4",
+        "@ethersproject/strings": "5.0.4",
+        "@ethersproject/transactions": "5.0.5",
+        "@ethersproject/wordlists": "5.0.4"
       }
     },
     "@ethersproject/json-wallets": {
@@ -616,17 +616,17 @@
       "integrity": "sha512-BPCfyGdwOUSp6+xA59IaZ/2pUWrUOL5Z9HuCh8YLsJzkuyBJQN0j+z/PmhIiZ7X8ilhuE+pRUwXb42U/R39fig==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-signer": "^5.0.4",
-        "@ethersproject/address": "^5.0.4",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/hdnode": "^5.0.4",
-        "@ethersproject/keccak256": "^5.0.3",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/pbkdf2": "^5.0.3",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/random": "^5.0.3",
-        "@ethersproject/strings": "^5.0.4",
-        "@ethersproject/transactions": "^5.0.5",
+        "@ethersproject/abstract-signer": "5.0.4",
+        "@ethersproject/address": "5.0.4",
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/hdnode": "5.0.4",
+        "@ethersproject/keccak256": "5.0.3",
+        "@ethersproject/logger": "5.0.5",
+        "@ethersproject/pbkdf2": "5.0.3",
+        "@ethersproject/properties": "5.0.3",
+        "@ethersproject/random": "5.0.3",
+        "@ethersproject/strings": "5.0.4",
+        "@ethersproject/transactions": "5.0.5",
         "aes-js": "3.0.0",
         "scrypt-js": "3.0.1"
       }
@@ -637,7 +637,7 @@
       "integrity": "sha512-VhW3mgZMBZlETV6AyOmjNeNG+Pg68igiKkPpat8/FZl0CKnfgQ+KZQZ/ee1vT+X0IUM8/djqnei6btmtbA27Ug==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
+        "@ethersproject/bytes": "5.0.4",
         "js-sha3": "0.5.7"
       },
       "dependencies": {
@@ -661,7 +661,7 @@
       "integrity": "sha512-Gjpejul6XFetJXyvHCd37IiCC00203kYGU9sMaRMZcAcYKszCkbOeo/Q7Mmdr/fS7YBbB5iTOahDJWiRLu/b7A==",
       "dev": true,
       "requires": {
-        "@ethersproject/logger": "^5.0.5"
+        "@ethersproject/logger": "5.0.5"
       }
     },
     "@ethersproject/pbkdf2": {
@@ -670,8 +670,8 @@
       "integrity": "sha512-asc+YgJn7v7GKWYXGz3GM1d9XYI2HvdCw1cLEow2niEC9BfYA29rr1exz100zISk95GIU1YP2zV//zHsMtWE5Q==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/sha2": "^5.0.3"
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/sha2": "5.0.3"
       }
     },
     "@ethersproject/properties": {
@@ -680,7 +680,7 @@
       "integrity": "sha512-wLCSrbywkQgTO6tIF9ZdKsH9AIxPEqAJF/z5xcPkz1DK4mMAZgAXRNw1MrKYhyb+7CqNHbj3vxenNKFavGY/IA==",
       "dev": true,
       "requires": {
-        "@ethersproject/logger": "^5.0.5"
+        "@ethersproject/logger": "5.0.5"
       }
     },
     "@ethersproject/providers": {
@@ -689,23 +689,23 @@
       "integrity": "sha512-nSObVCmcbw0Cbuhg75cCAZtvfaWWx2mcFqqS+9M5G/OAQbcNtqXA7z5hGSBSfapAtLFwzoUiJ8oW7iRTXtT3yQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-provider": "^5.0.4",
-        "@ethersproject/abstract-signer": "^5.0.4",
-        "@ethersproject/address": "^5.0.4",
-        "@ethersproject/basex": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.4",
-        "@ethersproject/hash": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/networks": "^5.0.3",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/random": "^5.0.3",
-        "@ethersproject/rlp": "^5.0.3",
-        "@ethersproject/sha2": "^5.0.3",
-        "@ethersproject/strings": "^5.0.4",
-        "@ethersproject/transactions": "^5.0.5",
-        "@ethersproject/web": "^5.0.6",
+        "@ethersproject/abstract-provider": "5.0.4",
+        "@ethersproject/abstract-signer": "5.0.4",
+        "@ethersproject/address": "5.0.4",
+        "@ethersproject/basex": "5.0.3",
+        "@ethersproject/bignumber": "5.0.7",
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/constants": "5.0.4",
+        "@ethersproject/hash": "5.0.4",
+        "@ethersproject/logger": "5.0.5",
+        "@ethersproject/networks": "5.0.3",
+        "@ethersproject/properties": "5.0.3",
+        "@ethersproject/random": "5.0.3",
+        "@ethersproject/rlp": "5.0.3",
+        "@ethersproject/sha2": "5.0.3",
+        "@ethersproject/strings": "5.0.4",
+        "@ethersproject/transactions": "5.0.5",
+        "@ethersproject/web": "5.0.6",
         "bech32": "1.1.4",
         "ws": "7.2.3"
       },
@@ -724,8 +724,8 @@
       "integrity": "sha512-pEhWRbgNeAY1oYk4nIsEtCTh9TtLsivIDbOX11n+DLZLYM3c8qCLxThXtsHwVsMs1JHClZr5auYC4YxtVVzO/A==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5"
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/logger": "5.0.5"
       }
     },
     "@ethersproject/rlp": {
@@ -734,8 +734,8 @@
       "integrity": "sha512-Hz4yyA/ilGafASAqtTlLWkA/YqwhQmhbDAq2LSIp1AJNx+wtbKWFAKSckpeZ+WG/xZmT+fw5OFKK7a5IZ4DR5g==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5"
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/logger": "5.0.5"
       }
     },
     "@ethersproject/sha2": {
@@ -744,8 +744,8 @@
       "integrity": "sha512-B1U9UkgxhUlC1J4sFUL2GwTo33bM2i/aaD3aiYdTh1FEXtGfqYA89KN1DJ83n+Em8iuvyiBRk6u30VmgqlHeHA==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/logger": "5.0.5",
         "hash.js": "1.1.3"
       },
       "dependencies": {
@@ -755,8 +755,8 @@
           "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.0"
+            "inherits": "2.0.4",
+            "minimalistic-assert": "1.0.1"
           }
         }
       }
@@ -767,9 +767,9 @@
       "integrity": "sha512-I6pJoga1IvhtjYK5yXzCjs4ZpxrVbt9ZRAlpEw0SW9UuV020YfJH5EIVEGR2evdRceS3nAQIggqbsXSkP8Y1Dg==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/properties": "^5.0.3",
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/logger": "5.0.5",
+        "@ethersproject/properties": "5.0.3",
         "elliptic": "6.5.3"
       }
     },
@@ -779,11 +779,11 @@
       "integrity": "sha512-cUq1l8A+AgRkIItRoztC98Qx7b0bMNMzKX817fszDuGNsT2POAyP5knvuEt4Fx4IBcJREXoOjsGYFfjyK5Sa+w==",
       "dev": true,
       "requires": {
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/keccak256": "^5.0.3",
-        "@ethersproject/sha2": "^5.0.3",
-        "@ethersproject/strings": "^5.0.4"
+        "@ethersproject/bignumber": "5.0.7",
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/keccak256": "5.0.3",
+        "@ethersproject/sha2": "5.0.3",
+        "@ethersproject/strings": "5.0.4"
       }
     },
     "@ethersproject/strings": {
@@ -792,9 +792,9 @@
       "integrity": "sha512-azXFHaNkDXzefhr4LVVzzDMFwj3kH9EOKlATu51HjxabQafuUyVLPFgmxRFmCynnAi0Bmmp7nr+qK1pVDgRDLQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5"
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/constants": "5.0.4",
+        "@ethersproject/logger": "5.0.5"
       }
     },
     "@ethersproject/transactions": {
@@ -803,15 +803,15 @@
       "integrity": "sha512-1Ga/QmbcB74DItggP8/DK1tggu4ErEvwTkIwIlUXUcvIAuRNXXE7kgQhlp+w1xA/SAQFhv56SqCoyqPiiLCvVA==",
       "dev": true,
       "requires": {
-        "@ethersproject/address": "^5.0.4",
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.4",
-        "@ethersproject/keccak256": "^5.0.3",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/rlp": "^5.0.3",
-        "@ethersproject/signing-key": "^5.0.4"
+        "@ethersproject/address": "5.0.4",
+        "@ethersproject/bignumber": "5.0.7",
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/constants": "5.0.4",
+        "@ethersproject/keccak256": "5.0.3",
+        "@ethersproject/logger": "5.0.5",
+        "@ethersproject/properties": "5.0.3",
+        "@ethersproject/rlp": "5.0.3",
+        "@ethersproject/signing-key": "5.0.4"
       }
     },
     "@ethersproject/units": {
@@ -820,9 +820,9 @@
       "integrity": "sha512-80d6skjDgiHLdbKOA9FVpzyMEPwbif40PbGd970JvcecVf48VjB09fUu37d6duG8DhRVyefRdX8nuVQLzcGGPw==",
       "dev": true,
       "requires": {
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/constants": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5"
+        "@ethersproject/bignumber": "5.0.7",
+        "@ethersproject/constants": "5.0.4",
+        "@ethersproject/logger": "5.0.5"
       }
     },
     "@ethersproject/wallet": {
@@ -831,21 +831,21 @@
       "integrity": "sha512-h/3mdy6HZVketHbs6ZP/WjHDz+rtTIE3qZrko2MVeafjgDcYWaHcVmhsPq4LGqxginhr191a4dkJDNeQrQZWOw==",
       "dev": true,
       "requires": {
-        "@ethersproject/abstract-provider": "^5.0.4",
-        "@ethersproject/abstract-signer": "^5.0.4",
-        "@ethersproject/address": "^5.0.4",
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/hash": "^5.0.4",
-        "@ethersproject/hdnode": "^5.0.4",
-        "@ethersproject/json-wallets": "^5.0.6",
-        "@ethersproject/keccak256": "^5.0.3",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/random": "^5.0.3",
-        "@ethersproject/signing-key": "^5.0.4",
-        "@ethersproject/transactions": "^5.0.5",
-        "@ethersproject/wordlists": "^5.0.4"
+        "@ethersproject/abstract-provider": "5.0.4",
+        "@ethersproject/abstract-signer": "5.0.4",
+        "@ethersproject/address": "5.0.4",
+        "@ethersproject/bignumber": "5.0.7",
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/hash": "5.0.4",
+        "@ethersproject/hdnode": "5.0.4",
+        "@ethersproject/json-wallets": "5.0.6",
+        "@ethersproject/keccak256": "5.0.3",
+        "@ethersproject/logger": "5.0.5",
+        "@ethersproject/properties": "5.0.3",
+        "@ethersproject/random": "5.0.3",
+        "@ethersproject/signing-key": "5.0.4",
+        "@ethersproject/transactions": "5.0.5",
+        "@ethersproject/wordlists": "5.0.4"
       }
     },
     "@ethersproject/web": {
@@ -854,11 +854,11 @@
       "integrity": "sha512-EpiF/4YYmHq1VSSKWKkvCfbzIZ3bbYETT+eUC4SB936gZQQE5FJVhL9UJOSJ2l7fvNR+z240+8BknwWQKUdvVA==",
       "dev": true,
       "requires": {
-        "@ethersproject/base64": "^5.0.3",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/strings": "^5.0.4"
+        "@ethersproject/base64": "5.0.3",
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/logger": "5.0.5",
+        "@ethersproject/properties": "5.0.3",
+        "@ethersproject/strings": "5.0.4"
       }
     },
     "@ethersproject/wordlists": {
@@ -867,11 +867,11 @@
       "integrity": "sha512-z/NsGqdYFvpeG6vPLxuD0pYNR5lLhQAy+oLVqg6G0o1c/OoL5J/a0iDOAFvnacQphc3lMP52d1LEX3YGoy2oBQ==",
       "dev": true,
       "requires": {
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/hash": "^5.0.4",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/strings": "^5.0.4"
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/hash": "5.0.4",
+        "@ethersproject/logger": "5.0.5",
+        "@ethersproject/properties": "5.0.3",
+        "@ethersproject/strings": "5.0.4"
       }
     },
     "@nomiclabs/buidler": {
@@ -880,49 +880,49 @@
       "integrity": "sha512-BF3JL5EDnGIkUwVUaPlgEYGWSeTWaF89VrglKvIYDLdnSQ5USAcf/fuMaJJaEufwyQQGTorSJCXfTQAcFaToCg==",
       "dev": true,
       "requires": {
-        "@nomiclabs/ethereumjs-vm": "^4.1.1",
-        "@sentry/node": "^5.18.1",
-        "@solidity-parser/parser": "^0.5.2",
-        "@types/bn.js": "^4.11.5",
-        "@types/lru-cache": "^5.1.0",
-        "abort-controller": "^3.0.0",
-        "ansi-escapes": "^4.3.0",
-        "chalk": "^2.4.2",
-        "chokidar": "^3.4.0",
-        "ci-info": "^2.0.0",
-        "debug": "^4.1.1",
-        "deepmerge": "^2.1.0",
-        "download": "^7.1.0",
-        "enquirer": "^2.3.0",
-        "env-paths": "^2.2.0",
-        "eth-sig-util": "^2.5.2",
-        "ethereum-cryptography": "^0.1.2",
-        "ethereumjs-abi": "^0.6.8",
-        "ethereumjs-account": "^3.0.0",
-        "ethereumjs-block": "^2.2.0",
-        "ethereumjs-common": "^1.3.2",
-        "ethereumjs-tx": "^2.1.1",
-        "ethereumjs-util": "^6.1.0",
-        "find-up": "^2.1.0",
+        "@nomiclabs/ethereumjs-vm": "4.2.0",
+        "@sentry/node": "5.23.0",
+        "@solidity-parser/parser": "0.5.2",
+        "@types/bn.js": "4.11.6",
+        "@types/lru-cache": "5.1.0",
+        "abort-controller": "3.0.0",
+        "ansi-escapes": "4.3.1",
+        "chalk": "2.4.2",
+        "chokidar": "3.4.2",
+        "ci-info": "2.0.0",
+        "debug": "4.1.1",
+        "deepmerge": "2.2.1",
+        "download": "7.1.0",
+        "enquirer": "2.3.6",
+        "env-paths": "2.2.0",
+        "eth-sig-util": "2.5.3",
+        "ethereum-cryptography": "0.1.3",
+        "ethereumjs-abi": "0.6.8",
+        "ethereumjs-account": "3.0.0",
+        "ethereumjs-block": "2.2.2",
+        "ethereumjs-common": "1.5.2",
+        "ethereumjs-tx": "2.1.2",
+        "ethereumjs-util": "6.2.1",
+        "find-up": "2.1.0",
         "fp-ts": "1.19.3",
-        "fs-extra": "^7.0.1",
-        "glob": "^7.1.3",
+        "fs-extra": "7.0.1",
+        "glob": "7.1.3",
         "io-ts": "1.10.4",
-        "is-installed-globally": "^0.2.0",
-        "lodash": "^4.17.11",
-        "merkle-patricia-tree": "^3.0.0",
-        "mocha": "^7.1.2",
-        "node-fetch": "^2.6.0",
-        "qs": "^6.7.0",
-        "raw-body": "^2.4.1",
-        "semver": "^6.3.0",
-        "slash": "^3.0.0",
+        "is-installed-globally": "0.2.0",
+        "lodash": "4.17.20",
+        "merkle-patricia-tree": "3.0.0",
+        "mocha": "7.2.0",
+        "node-fetch": "2.6.1",
+        "qs": "6.9.4",
+        "raw-body": "2.4.1",
+        "semver": "6.3.0",
+        "slash": "3.0.0",
         "solc": "0.6.8",
-        "source-map-support": "^0.5.13",
-        "ts-essentials": "^2.0.7",
+        "source-map-support": "0.5.19",
+        "ts-essentials": "2.0.12",
         "tsort": "0.0.1",
-        "uuid": "^3.3.2",
-        "ws": "^7.2.1"
+        "uuid": "3.4.0",
+        "ws": "7.3.1"
       },
       "dependencies": {
         "ansi-escapes": {
@@ -931,7 +931,7 @@
           "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
           "dev": true,
           "requires": {
-            "type-fest": "^0.11.0"
+            "type-fest": "0.11.0"
           }
         },
         "ci-info": {
@@ -946,8 +946,8 @@
           "integrity": "sha512-g3TzWCnR/eO4Q3abCwgFjOFw7uVOfxG4m8hMr/39Jcf2YvE5mHrFKqpyuraWV4zwx9XhjnVO4nY0ZI4llzl0Pg==",
           "dev": true,
           "requires": {
-            "global-dirs": "^0.1.1",
-            "is-path-inside": "^2.1.0"
+            "global-dirs": "0.1.1",
+            "is-path-inside": "2.1.0"
           }
         },
         "is-path-inside": {
@@ -956,7 +956,7 @@
           "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
           "dev": true,
           "requires": {
-            "path-is-inside": "^1.0.2"
+            "path-is-inside": "1.0.2"
           }
         },
         "semver": {
@@ -985,7 +985,7 @@
       "integrity": "sha512-Z1SJOGrRCcSu9E87mFaBHi4QimNxP9ZTYtJwLZCcyszS1fi0XLgp4syzTH3QXrQUBOP2P5oQMD6uCp0gNNS3hw==",
       "dev": true,
       "requires": {
-        "@types/sinon-chai": "^3.2.3",
+        "@types/sinon-chai": "3.2.4",
         "@types/web3": "1.0.19"
       }
     },
@@ -995,21 +995,21 @@
       "integrity": "sha512-+XwqoO941bILTO4KDLIUJ37U42ySxw6it7jyoi0tKv0/VUcOrWKF1TCQWMv6dBDRlxpPQd273n9o5SVlYYLRWQ==",
       "dev": true,
       "requires": {
-        "async": "^2.1.2",
-        "async-eventemitter": "^0.2.2",
-        "core-js-pure": "^3.0.1",
-        "ethereumjs-account": "^3.0.0",
-        "ethereumjs-block": "^2.2.2",
-        "ethereumjs-blockchain": "^4.0.3",
-        "ethereumjs-common": "^1.5.0",
-        "ethereumjs-tx": "^2.1.2",
-        "ethereumjs-util": "^6.2.0",
-        "fake-merkle-patricia-tree": "^1.0.1",
-        "functional-red-black-tree": "^1.0.1",
-        "merkle-patricia-tree": "^2.3.2",
-        "rustbn.js": "~0.2.0",
-        "safe-buffer": "^5.1.1",
-        "util.promisify": "^1.0.0"
+        "async": "2.6.3",
+        "async-eventemitter": "0.2.4",
+        "core-js-pure": "3.6.5",
+        "ethereumjs-account": "3.0.0",
+        "ethereumjs-block": "2.2.2",
+        "ethereumjs-blockchain": "4.0.4",
+        "ethereumjs-common": "1.5.2",
+        "ethereumjs-tx": "2.1.2",
+        "ethereumjs-util": "6.2.1",
+        "fake-merkle-patricia-tree": "1.0.1",
+        "functional-red-black-tree": "1.0.1",
+        "merkle-patricia-tree": "2.3.2",
+        "rustbn.js": "0.2.0",
+        "safe-buffer": "5.2.1",
+        "util.promisify": "1.0.1"
       },
       "dependencies": {
         "bn.js": {
@@ -1024,14 +1024,14 @@
           "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
           "dev": true,
           "requires": {
-            "async": "^1.4.2",
-            "ethereumjs-util": "^5.0.0",
+            "async": "1.5.2",
+            "ethereumjs-util": "5.2.1",
             "level-ws": "0.0.0",
-            "levelup": "^1.2.1",
-            "memdown": "^1.0.0",
-            "readable-stream": "^2.0.0",
-            "rlp": "^2.0.0",
-            "semaphore": ">=1.0.1"
+            "levelup": "1.3.9",
+            "memdown": "1.4.1",
+            "readable-stream": "2.3.7",
+            "rlp": "2.2.6",
+            "semaphore": "1.1.0"
           },
           "dependencies": {
             "async": {
@@ -1046,13 +1046,13 @@
               "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
-                "ethjs-util": "^0.1.3",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
+                "bn.js": "4.11.9",
+                "create-hash": "1.2.0",
+                "elliptic": "6.5.3",
+                "ethereum-cryptography": "0.1.3",
+                "ethjs-util": "0.1.6",
+                "rlp": "2.2.6",
+                "safe-buffer": "5.2.1"
               }
             }
           }
@@ -1063,13 +1063,13 @@
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.4",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.1",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           },
           "dependencies": {
             "safe-buffer": {
@@ -1086,7 +1086,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           },
           "dependencies": {
             "safe-buffer": {
@@ -1111,9 +1111,9 @@
       "integrity": "sha512-eB8nEbKDJJBi5p5SrvrvILn4a0h42bKtbCTri3ZxCGt6UvoQyp7HnGOfki944bUjBSHKK3RvgfViHn+kqdXtnQ==",
       "dev": true,
       "requires": {
-        "debug": "^3.1.0",
-        "is-url": "^1.2.4",
-        "request": "^2.85.0"
+        "debug": "3.2.6",
+        "is-url": "1.2.4",
+        "request": "2.88.2"
       },
       "dependencies": {
         "debug": {
@@ -1122,7 +1122,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         }
       }
@@ -1133,8 +1133,8 @@
       "integrity": "sha512-wQ9RhPUcny02Wm0IuJwYMyAG8fXVeKdmhm8xizNByD4ryZlx6PP6kRen+t/haF43cMfmaV7T3Cx6ChOdHEhFUQ==",
       "dev": true,
       "requires": {
-        "@resolver-engine/core": "^0.3.3",
-        "debug": "^3.1.0"
+        "@resolver-engine/core": "0.3.3",
+        "debug": "3.2.6"
       },
       "dependencies": {
         "debug": {
@@ -1143,7 +1143,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         }
       }
@@ -1154,11 +1154,11 @@
       "integrity": "sha512-anHpS4wN4sRMwsAbMXhMfOD/y4a4Oo0Cw/5+rue7hSwGWsDOQaAU1ClK1OxjUC35/peazxEl8JaSRRS+Xb8t3Q==",
       "dev": true,
       "requires": {
-        "@resolver-engine/core": "^0.3.3",
-        "debug": "^3.1.0",
-        "hosted-git-info": "^2.6.0",
-        "path-browserify": "^1.0.0",
-        "url": "^0.11.0"
+        "@resolver-engine/core": "0.3.3",
+        "debug": "3.2.6",
+        "hosted-git-info": "2.8.8",
+        "path-browserify": "1.0.1",
+        "url": "0.11.0"
       },
       "dependencies": {
         "debug": {
@@ -1167,7 +1167,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         }
       }
@@ -1178,9 +1178,9 @@
       "integrity": "sha512-7Pjg/ZAZtxpeyCFlZR5zqYkz+Wdo84ugB5LApwriT8XFeQoLwGUj4tZFFvvCuxaNCcqZzCYbonJgmGObYBzyCA==",
       "dev": true,
       "requires": {
-        "@resolver-engine/fs": "^0.3.3",
-        "@resolver-engine/imports": "^0.3.3",
-        "debug": "^3.1.0"
+        "@resolver-engine/fs": "0.3.3",
+        "@resolver-engine/imports": "0.3.3",
+        "debug": "3.2.6"
       },
       "dependencies": {
         "debug": {
@@ -1189,7 +1189,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         }
       }
@@ -1204,7 +1204,7 @@
         "@sentry/minimal": "5.23.0",
         "@sentry/types": "5.23.0",
         "@sentry/utils": "5.23.0",
-        "tslib": "^1.9.3"
+        "tslib": "1.13.0"
       }
     },
     "@sentry/hub": {
@@ -1215,7 +1215,7 @@
       "requires": {
         "@sentry/types": "5.23.0",
         "@sentry/utils": "5.23.0",
-        "tslib": "^1.9.3"
+        "tslib": "1.13.0"
       }
     },
     "@sentry/minimal": {
@@ -1226,7 +1226,7 @@
       "requires": {
         "@sentry/hub": "5.23.0",
         "@sentry/types": "5.23.0",
-        "tslib": "^1.9.3"
+        "tslib": "1.13.0"
       }
     },
     "@sentry/node": {
@@ -1240,10 +1240,10 @@
         "@sentry/tracing": "5.23.0",
         "@sentry/types": "5.23.0",
         "@sentry/utils": "5.23.0",
-        "cookie": "^0.4.1",
-        "https-proxy-agent": "^5.0.0",
-        "lru_map": "^0.3.3",
-        "tslib": "^1.9.3"
+        "cookie": "0.4.1",
+        "https-proxy-agent": "5.0.0",
+        "lru_map": "0.3.3",
+        "tslib": "1.13.0"
       },
       "dependencies": {
         "agent-base": {
@@ -1252,7 +1252,7 @@
           "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
           "dev": true,
           "requires": {
-            "debug": "4"
+            "debug": "4.1.1"
           }
         },
         "https-proxy-agent": {
@@ -1261,8 +1261,8 @@
           "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
           "dev": true,
           "requires": {
-            "agent-base": "6",
-            "debug": "4"
+            "agent-base": "6.0.1",
+            "debug": "4.1.1"
           }
         }
       }
@@ -1277,7 +1277,7 @@
         "@sentry/minimal": "5.23.0",
         "@sentry/types": "5.23.0",
         "@sentry/utils": "5.23.0",
-        "tslib": "^1.9.3"
+        "tslib": "1.13.0"
       }
     },
     "@sentry/types": {
@@ -1293,7 +1293,7 @@
       "dev": true,
       "requires": {
         "@sentry/types": "5.23.0",
-        "tslib": "^1.9.3"
+        "tslib": "1.13.0"
       }
     },
     "@sindresorhus/is": {
@@ -1314,7 +1314,7 @@
       "integrity": "sha512-CWxLmlmfM7NMT6OSq8UXZM7mSkHU1xrbNi40Hvj26S97jKnwERmNbiERgy4fXXOdVqb+zCshnZQ9X+P5WndLMA==",
       "dev": true,
       "requires": {
-        "ethers": "^5.0.2"
+        "ethers": "5.0.13"
       }
     },
     "@types/bn.js": {
@@ -1323,7 +1323,7 @@
       "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "14.0.27"
       }
     },
     "@types/chai": {
@@ -1344,7 +1344,7 @@
       "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "14.0.27"
       }
     },
     "@types/mocha": {
@@ -1365,8 +1365,8 @@
       "integrity": "sha512-o2WVNf5UhWRkxlf6eq+jMZDu7kjgpgJfl4xVNlvryc95O/6F2ld8ztKX+qu+Rjyet93WAWm5LjeX9H5FGkODvw==",
       "dev": true,
       "requires": {
-        "@types/node": "*",
-        "form-data": "^3.0.0"
+        "@types/node": "14.0.27",
+        "form-data": "3.0.0"
       },
       "dependencies": {
         "form-data": {
@@ -1375,9 +1375,9 @@
           "integrity": "sha512-CKMFDglpbMi6PyN+brwB9Q/GOw0eAnsrEZDgcsH5Krhz5Od/haKHAX0NmQfha2zPPz0JpWzA7GJHGSnvCRLWsg==",
           "dev": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.8",
+            "mime-types": "2.1.27"
           }
         }
       }
@@ -1388,7 +1388,7 @@
       "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "14.0.27"
       }
     },
     "@types/prettier": {
@@ -1403,7 +1403,7 @@
       "integrity": "sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "14.0.27"
       }
     },
     "@types/secp256k1": {
@@ -1412,7 +1412,7 @@
       "integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "14.0.27"
       }
     },
     "@types/sinon": {
@@ -1421,7 +1421,7 @@
       "integrity": "sha512-4CnkGdM/5/FXDGqL32JQ1ttVrGvhOoesLLF7VnTh4KdjK5N5VQOtxaylFqqTjnHx55MnD9O02Nbk5c1ELC8wlQ==",
       "dev": true,
       "requires": {
-        "@types/sinonjs__fake-timers": "*"
+        "@types/sinonjs__fake-timers": "6.0.1"
       }
     },
     "@types/sinon-chai": {
@@ -1430,8 +1430,8 @@
       "integrity": "sha512-xq5KOWNg70PRC7dnR2VOxgYQ6paumW+4pTZP+6uTSdhpYsAUEeeT5bw6rRHHQrZ4KyR+M5ojOR+lje6TGSpUxA==",
       "dev": true,
       "requires": {
-        "@types/chai": "*",
-        "@types/sinon": "*"
+        "@types/chai": "4.2.12",
+        "@types/sinon": "9.0.5"
       }
     },
     "@types/sinonjs__fake-timers": {
@@ -1452,8 +1452,8 @@
       "integrity": "sha512-fhZ9DyvDYDwHZUp5/STa9XW2re0E8GxoioYJ4pEUZ13YHpApSagixj7IAdoYH5uAK+UalGq6Ml8LYzmgRA/q+A==",
       "dev": true,
       "requires": {
-        "@types/bn.js": "*",
-        "@types/underscore": "*"
+        "@types/bn.js": "4.11.6",
+        "@types/underscore": "1.10.22"
       }
     },
     "@yarnpkg/lockfile": {
@@ -1474,7 +1474,7 @@
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "dev": true,
       "requires": {
-        "event-target-shim": "^5.0.0"
+        "event-target-shim": "5.0.1"
       }
     },
     "abstract-leveldown": {
@@ -1483,7 +1483,7 @@
       "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
       "dev": true,
       "requires": {
-        "xtend": "~4.0.0"
+        "xtend": "4.0.2"
       }
     },
     "aes-js": {
@@ -1498,8 +1498,8 @@
       "integrity": "sha1-1t4Q1a9hMtW9aSQn1G/FOFOQlMc=",
       "dev": true,
       "requires": {
-        "extend": "~3.0.0",
-        "semver": "~5.0.1"
+        "extend": "3.0.2",
+        "semver": "5.0.3"
       },
       "dependencies": {
         "semver": {
@@ -1516,10 +1516,10 @@
       "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
       "dev": true,
       "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "3.1.3",
+        "fast-json-stable-stringify": "2.1.0",
+        "json-schema-traverse": "0.4.1",
+        "uri-js": "4.4.0"
       }
     },
     "ansi-align": {
@@ -1528,7 +1528,7 @@
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
       "dev": true,
       "requires": {
-        "string-width": "^2.0.0"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1543,8 +1543,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -1553,7 +1553,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -1582,7 +1582,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "^1.9.0"
+        "color-convert": "1.9.3"
       }
     },
     "any-promise": {
@@ -1597,8 +1597,8 @@
       "integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
       "dev": true,
       "requires": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
+        "normalize-path": "3.0.0",
+        "picomatch": "2.2.2"
       }
     },
     "archive-type": {
@@ -1607,7 +1607,7 @@
       "integrity": "sha1-+S5yIzBW38aWlHJ0nCZ72wRrHXA=",
       "dev": true,
       "requires": {
-        "file-type": "^4.2.0"
+        "file-type": "4.4.0"
       },
       "dependencies": {
         "file-type": {
@@ -1636,7 +1636,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arr-diff": {
@@ -1663,7 +1663,7 @@
       "integrity": "sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==",
       "dev": true,
       "requires": {
-        "typical": "^2.6.1"
+        "typical": "2.6.1"
       }
     },
     "array-uniq": {
@@ -1684,7 +1684,7 @@
       "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
       "dev": true,
       "requires": {
-        "safer-buffer": "~2.1.0"
+        "safer-buffer": "2.1.2"
       }
     },
     "assert-plus": {
@@ -1711,7 +1711,7 @@
       "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.14"
+        "lodash": "4.17.20"
       }
     },
     "async-eventemitter": {
@@ -1720,7 +1720,7 @@
       "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
       "dev": true,
       "requires": {
-        "async": "^2.4.0"
+        "async": "2.6.3"
       }
     },
     "asynckit": {
@@ -1759,13 +1759,13 @@
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
       "requires": {
-        "cache-base": "^1.0.1",
-        "class-utils": "^0.3.5",
-        "component-emitter": "^1.2.1",
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.1",
-        "mixin-deep": "^1.2.0",
-        "pascalcase": "^0.1.1"
+        "cache-base": "1.0.1",
+        "class-utils": "0.3.6",
+        "component-emitter": "1.3.0",
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "mixin-deep": "1.3.2",
+        "pascalcase": "0.1.1"
       },
       "dependencies": {
         "define-property": {
@@ -1774,7 +1774,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -1783,7 +1783,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-data-descriptor": {
@@ -1792,7 +1792,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-descriptor": {
@@ -1801,9 +1801,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.3"
           }
         }
       }
@@ -1814,7 +1814,7 @@
       "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.2.1"
       }
     },
     "base64-js": {
@@ -1829,7 +1829,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       },
       "dependencies": {
         "tweetnacl": {
@@ -1858,8 +1858,8 @@
       "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
+        "readable-stream": "2.3.7",
+        "safe-buffer": "5.2.1"
       },
       "dependencies": {
         "readable-stream": {
@@ -1868,13 +1868,13 @@
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.4",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.1",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           },
           "dependencies": {
             "safe-buffer": {
@@ -1891,7 +1891,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           },
           "dependencies": {
             "safe-buffer": {
@@ -1928,13 +1928,13 @@
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
       "requires": {
-        "ansi-align": "^2.0.0",
-        "camelcase": "^4.0.0",
-        "chalk": "^2.0.1",
-        "cli-boxes": "^1.0.0",
-        "string-width": "^2.0.0",
-        "term-size": "^1.2.0",
-        "widest-line": "^2.0.0"
+        "ansi-align": "2.0.0",
+        "camelcase": "4.1.0",
+        "chalk": "2.4.2",
+        "cli-boxes": "1.0.0",
+        "string-width": "2.1.1",
+        "term-size": "1.2.0",
+        "widest-line": "2.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1955,8 +1955,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -1965,7 +1965,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -1976,7 +1976,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -1986,7 +1986,7 @@
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dev": true,
       "requires": {
-        "fill-range": "^7.0.1"
+        "fill-range": "7.0.1"
       }
     },
     "brorand": {
@@ -2007,12 +2007,12 @@
       "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
       "dev": true,
       "requires": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "buffer-xor": "1.0.3",
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "evp_bytestokey": "1.0.3",
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.1"
       }
     },
     "bs58": {
@@ -2021,7 +2021,7 @@
       "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
       "dev": true,
       "requires": {
-        "base-x": "^3.0.2"
+        "base-x": "3.0.8"
       }
     },
     "bs58check": {
@@ -2030,9 +2030,9 @@
       "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
       "dev": true,
       "requires": {
-        "bs58": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "safe-buffer": "^5.1.2"
+        "bs58": "4.0.1",
+        "create-hash": "1.2.0",
+        "safe-buffer": "5.2.1"
       }
     },
     "buffer": {
@@ -2041,8 +2041,8 @@
       "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
       "dev": true,
       "requires": {
-        "base64-js": "^1.0.2",
-        "ieee754": "^1.1.4"
+        "base64-js": "1.3.1",
+        "ieee754": "1.1.13"
       }
     },
     "buffer-alloc": {
@@ -2051,8 +2051,8 @@
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "dev": true,
       "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
+        "buffer-alloc-unsafe": "1.1.0",
+        "buffer-fill": "1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -2103,15 +2103,15 @@
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
       "requires": {
-        "collection-visit": "^1.0.0",
-        "component-emitter": "^1.2.1",
-        "get-value": "^2.0.6",
-        "has-value": "^1.0.0",
-        "isobject": "^3.0.1",
-        "set-value": "^2.0.0",
-        "to-object-path": "^0.3.0",
-        "union-value": "^1.0.0",
-        "unset-value": "^1.0.0"
+        "collection-visit": "1.0.0",
+        "component-emitter": "1.3.0",
+        "get-value": "2.0.6",
+        "has-value": "1.0.0",
+        "isobject": "3.0.1",
+        "set-value": "2.0.1",
+        "to-object-path": "0.3.0",
+        "union-value": "1.0.1",
+        "unset-value": "1.0.0"
       }
     },
     "cacheable-request": {
@@ -2161,10 +2161,10 @@
       "integrity": "sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==",
       "dev": true,
       "requires": {
-        "get-proxy": "^2.0.0",
-        "isurl": "^1.0.0-alpha5",
-        "tunnel-agent": "^0.6.0",
-        "url-to-options": "^1.0.1"
+        "get-proxy": "2.1.0",
+        "isurl": "1.0.0",
+        "tunnel-agent": "0.6.0",
+        "url-to-options": "1.0.1"
       }
     },
     "chai": {
@@ -2173,12 +2173,12 @@
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
-        "type-detect": "^4.0.5"
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
       }
     },
     "chalk": {
@@ -2187,9 +2187,9 @@
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
+        "ansi-styles": "3.2.1",
+        "escape-string-regexp": "1.0.5",
+        "supports-color": "5.5.0"
       },
       "dependencies": {
         "supports-color": {
@@ -2198,7 +2198,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -2215,7 +2215,7 @@
       "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
       "dev": true,
       "requires": {
-        "functional-red-black-tree": "^1.0.1"
+        "functional-red-black-tree": "1.0.1"
       }
     },
     "chokidar": {
@@ -2224,14 +2224,14 @@
       "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
       "dev": true,
       "requires": {
-        "anymatch": "~3.1.1",
-        "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
-        "glob-parent": "~5.1.0",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.4.0"
+        "anymatch": "3.1.1",
+        "braces": "3.0.2",
+        "fsevents": "2.1.3",
+        "glob-parent": "5.1.1",
+        "is-binary-path": "2.1.0",
+        "is-glob": "4.0.1",
+        "normalize-path": "3.0.0",
+        "readdirp": "3.4.0"
       }
     },
     "ci-info": {
@@ -2246,8 +2246,8 @@
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.1"
       }
     },
     "class-utils": {
@@ -2256,10 +2256,10 @@
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "define-property": "^0.2.5",
-        "isobject": "^3.0.0",
-        "static-extend": "^0.1.1"
+        "arr-union": "3.1.0",
+        "define-property": "0.2.5",
+        "isobject": "3.0.1",
+        "static-extend": "0.1.2"
       },
       "dependencies": {
         "define-property": {
@@ -2268,7 +2268,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -2285,7 +2285,7 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "dev": true,
       "requires": {
-        "restore-cursor": "^1.0.1"
+        "restore-cursor": "1.0.1"
       }
     },
     "cli-truncate": {
@@ -2294,8 +2294,8 @@
       "integrity": "sha512-bAtZo0u82gCfaAGfSNxUdTI9mNyza7D8w4CVCcaOsy7sgwDzvx6ekr6cuWJqY3UGzgnQ1+4wgENup5eIhgxEYA==",
       "dev": true,
       "requires": {
-        "slice-ansi": "^1.0.0",
-        "string-width": "^2.0.0"
+        "slice-ansi": "1.0.0",
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2310,8 +2310,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -2320,7 +2320,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -2331,9 +2331,9 @@
       "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "dev": true,
       "requires": {
-        "string-width": "^3.1.0",
-        "strip-ansi": "^5.2.0",
-        "wrap-ansi": "^5.1.0"
+        "string-width": "3.1.0",
+        "strip-ansi": "5.2.0",
+        "wrap-ansi": "5.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2348,9 +2348,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "7.0.3",
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "5.2.0"
           }
         },
         "strip-ansi": {
@@ -2359,7 +2359,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "4.1.0"
           }
         }
       }
@@ -2370,7 +2370,7 @@
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "dev": true,
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.1"
       }
     },
     "code-point-at": {
@@ -2385,8 +2385,8 @@
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
       "dev": true,
       "requires": {
-        "map-visit": "^1.0.0",
-        "object-visit": "^1.0.0"
+        "map-visit": "1.0.0",
+        "object-visit": "1.0.1"
       }
     },
     "color-convert": {
@@ -2410,8 +2410,8 @@
       "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
       "dev": true,
       "requires": {
-        "strip-ansi": "^3.0.0",
-        "wcwidth": "^1.0.0"
+        "strip-ansi": "3.0.1",
+        "wcwidth": "1.0.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -2426,7 +2426,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         }
       }
@@ -2437,7 +2437,7 @@
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "command-exists": {
@@ -2452,9 +2452,9 @@
       "integrity": "sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==",
       "dev": true,
       "requires": {
-        "array-back": "^2.0.0",
-        "find-replace": "^1.0.3",
-        "typical": "^2.6.1"
+        "array-back": "2.0.0",
+        "find-replace": "1.0.3",
+        "typical": "2.6.1"
       }
     },
     "commander": {
@@ -2481,10 +2481,10 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.1",
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.7",
+        "typedarray": "0.0.6"
       },
       "dependencies": {
         "readable-stream": {
@@ -2493,13 +2493,13 @@
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.4",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.1",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "safe-buffer": {
@@ -2514,7 +2514,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -2525,8 +2525,8 @@
       "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
       "dev": true,
       "requires": {
-        "ini": "^1.3.4",
-        "proto-list": "~1.2.1"
+        "ini": "1.3.5",
+        "proto-list": "1.2.4"
       }
     },
     "configstore": {
@@ -2535,12 +2535,12 @@
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
       "dev": true,
       "requires": {
-        "dot-prop": "^4.1.0",
-        "graceful-fs": "^4.1.2",
-        "make-dir": "^1.0.0",
-        "unique-string": "^1.0.0",
-        "write-file-atomic": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "dot-prop": "4.2.1",
+        "graceful-fs": "4.2.4",
+        "make-dir": "1.3.0",
+        "unique-string": "1.0.0",
+        "write-file-atomic": "2.4.3",
+        "xdg-basedir": "3.0.0"
       }
     },
     "content-disposition": {
@@ -2590,7 +2590,7 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "dev": true,
       "requires": {
-        "capture-stack-trace": "^1.0.0"
+        "capture-stack-trace": "1.0.1"
       }
     },
     "create-hash": {
@@ -2599,11 +2599,11 @@
       "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.1",
-        "inherits": "^2.0.1",
-        "md5.js": "^1.3.4",
-        "ripemd160": "^2.0.1",
-        "sha.js": "^2.4.0"
+        "cipher-base": "1.0.4",
+        "inherits": "2.0.4",
+        "md5.js": "1.3.5",
+        "ripemd160": "2.0.2",
+        "sha.js": "2.4.11"
       }
     },
     "create-hmac": {
@@ -2612,12 +2612,12 @@
       "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
       "dev": true,
       "requires": {
-        "cipher-base": "^1.0.3",
-        "create-hash": "^1.1.0",
-        "inherits": "^2.0.1",
-        "ripemd160": "^2.0.0",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "cipher-base": "1.0.4",
+        "create-hash": "1.2.0",
+        "inherits": "2.0.4",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.2.1",
+        "sha.js": "2.4.11"
       }
     },
     "cross-spawn": {
@@ -2626,9 +2626,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "lru-cache": "4.1.5",
+        "shebang-command": "1.2.0",
+        "which": "1.3.1"
       }
     },
     "crypto-random-string": {
@@ -2643,7 +2643,7 @@
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "debug": {
@@ -2652,7 +2652,7 @@
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "dev": true,
       "requires": {
-        "ms": "^2.1.1"
+        "ms": "2.1.1"
       }
     },
     "decamelize": {
@@ -2673,14 +2673,14 @@
       "integrity": "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==",
       "dev": true,
       "requires": {
-        "decompress-tar": "^4.0.0",
-        "decompress-tarbz2": "^4.0.0",
-        "decompress-targz": "^4.0.0",
-        "decompress-unzip": "^4.0.1",
-        "graceful-fs": "^4.1.10",
-        "make-dir": "^1.0.0",
-        "pify": "^2.3.0",
-        "strip-dirs": "^2.0.0"
+        "decompress-tar": "4.1.1",
+        "decompress-tarbz2": "4.1.1",
+        "decompress-targz": "4.1.1",
+        "decompress-unzip": "4.0.1",
+        "graceful-fs": "4.2.4",
+        "make-dir": "1.3.0",
+        "pify": "2.3.0",
+        "strip-dirs": "2.1.0"
       },
       "dependencies": {
         "pify": {
@@ -2697,7 +2697,7 @@
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "dev": true,
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.1"
       }
     },
     "decompress-tar": {
@@ -2706,9 +2706,9 @@
       "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
       "dev": true,
       "requires": {
-        "file-type": "^5.2.0",
-        "is-stream": "^1.1.0",
-        "tar-stream": "^1.5.2"
+        "file-type": "5.2.0",
+        "is-stream": "1.1.0",
+        "tar-stream": "1.6.2"
       },
       "dependencies": {
         "file-type": {
@@ -2725,11 +2725,11 @@
       "integrity": "sha512-s88xLzf1r81ICXLAVQVzaN6ZmX4A6U4z2nMbOwobxkLoIIfjVMBg7TeguTUXkKeXni795B6y5rnvDw7rxhAq9A==",
       "dev": true,
       "requires": {
-        "decompress-tar": "^4.1.0",
-        "file-type": "^6.1.0",
-        "is-stream": "^1.1.0",
-        "seek-bzip": "^1.0.5",
-        "unbzip2-stream": "^1.0.9"
+        "decompress-tar": "4.1.1",
+        "file-type": "6.2.0",
+        "is-stream": "1.1.0",
+        "seek-bzip": "1.0.6",
+        "unbzip2-stream": "1.4.3"
       },
       "dependencies": {
         "file-type": {
@@ -2746,9 +2746,9 @@
       "integrity": "sha512-4z81Znfr6chWnRDNfFNqLwPvm4db3WuZkqV+UgXQzSngG3CEKdBkw5jrv3axjjL96glyiiKjsxJG3X6WBZwX3w==",
       "dev": true,
       "requires": {
-        "decompress-tar": "^4.1.1",
-        "file-type": "^5.2.0",
-        "is-stream": "^1.1.0"
+        "decompress-tar": "4.1.1",
+        "file-type": "5.2.0",
+        "is-stream": "1.1.0"
       },
       "dependencies": {
         "file-type": {
@@ -2765,10 +2765,10 @@
       "integrity": "sha1-3qrM39FK6vhVePczroIQ+bSEj2k=",
       "dev": true,
       "requires": {
-        "file-type": "^3.8.0",
-        "get-stream": "^2.2.0",
-        "pify": "^2.3.0",
-        "yauzl": "^2.4.2"
+        "file-type": "3.9.0",
+        "get-stream": "2.3.1",
+        "pify": "2.3.0",
+        "yauzl": "2.10.0"
       },
       "dependencies": {
         "file-type": {
@@ -2783,8 +2783,8 @@
           "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4=",
           "dev": true,
           "requires": {
-            "object-assign": "^4.0.1",
-            "pinkie-promise": "^2.0.0"
+            "object-assign": "4.1.1",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -2801,7 +2801,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "^4.0.0"
+        "type-detect": "4.0.8"
       }
     },
     "deep-extend": {
@@ -2822,7 +2822,7 @@
       "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
       "dev": true,
       "requires": {
-        "clone": "^1.0.2"
+        "clone": "1.0.4"
       },
       "dependencies": {
         "clone": {
@@ -2839,7 +2839,7 @@
       "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
       "dev": true,
       "requires": {
-        "abstract-leveldown": "~2.6.0"
+        "abstract-leveldown": "2.6.3"
       }
     },
     "define-properties": {
@@ -2848,7 +2848,7 @@
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
       "dev": true,
       "requires": {
-        "object-keys": "^1.0.12"
+        "object-keys": "1.1.1"
       },
       "dependencies": {
         "object-keys": {
@@ -2865,8 +2865,8 @@
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "dev": true,
       "requires": {
-        "is-descriptor": "^1.0.2",
-        "isobject": "^3.0.1"
+        "is-descriptor": "1.0.2",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "is-accessor-descriptor": {
@@ -2875,7 +2875,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-data-descriptor": {
@@ -2884,7 +2884,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-descriptor": {
@@ -2893,9 +2893,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.3"
           }
         }
       }
@@ -2942,7 +2942,7 @@
       "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
       "dev": true,
       "requires": {
-        "is-obj": "^1.0.0"
+        "is-obj": "1.0.1"
       }
     },
     "download": {
@@ -2951,18 +2951,18 @@
       "integrity": "sha512-xqnBTVd/E+GxJVrX5/eUJiLYjCGPwMpdL+jGhGU57BvtcA7wwhtHVbXBeUk51kOpW3S7Jn3BQbN9Q1R1Km2qDQ==",
       "dev": true,
       "requires": {
-        "archive-type": "^4.0.0",
-        "caw": "^2.0.1",
-        "content-disposition": "^0.5.2",
-        "decompress": "^4.2.0",
-        "ext-name": "^5.0.0",
-        "file-type": "^8.1.0",
-        "filenamify": "^2.0.0",
-        "get-stream": "^3.0.0",
-        "got": "^8.3.1",
-        "make-dir": "^1.2.0",
-        "p-event": "^2.1.0",
-        "pify": "^3.0.0"
+        "archive-type": "4.0.0",
+        "caw": "2.0.1",
+        "content-disposition": "0.5.3",
+        "decompress": "4.2.1",
+        "ext-name": "5.0.0",
+        "file-type": "8.1.0",
+        "filenamify": "2.1.0",
+        "get-stream": "3.0.0",
+        "got": "8.3.2",
+        "make-dir": "1.3.0",
+        "p-event": "2.3.1",
+        "pify": "3.0.0"
       }
     },
     "duplexer3": {
@@ -2977,8 +2977,8 @@
       "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
       "dev": true,
       "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2"
       }
     },
     "elegant-spinner": {
@@ -2993,13 +2993,13 @@
       "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.4.0",
-        "brorand": "^1.0.1",
-        "hash.js": "^1.0.0",
-        "hmac-drbg": "^1.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.0"
+        "bn.js": "4.11.9",
+        "brorand": "1.1.0",
+        "hash.js": "1.1.7",
+        "hmac-drbg": "1.0.1",
+        "inherits": "2.0.4",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       },
       "dependencies": {
         "bn.js": {
@@ -3022,11 +3022,11 @@
       "integrity": "sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==",
       "dev": true,
       "requires": {
-        "abstract-leveldown": "^5.0.0",
-        "inherits": "^2.0.3",
-        "level-codec": "^9.0.0",
-        "level-errors": "^2.0.0",
-        "xtend": "^4.0.1"
+        "abstract-leveldown": "5.0.0",
+        "inherits": "2.0.4",
+        "level-codec": "9.0.2",
+        "level-errors": "2.0.1",
+        "xtend": "4.0.2"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -3035,7 +3035,7 @@
           "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
           "dev": true,
           "requires": {
-            "xtend": "~4.0.0"
+            "xtend": "4.0.2"
           }
         },
         "level-codec": {
@@ -3044,7 +3044,7 @@
           "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
           "dev": true,
           "requires": {
-            "buffer": "^5.6.0"
+            "buffer": "5.6.0"
           }
         },
         "level-errors": {
@@ -3053,7 +3053,7 @@
           "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
           "dev": true,
           "requires": {
-            "errno": "~0.1.1"
+            "errno": "0.1.7"
           }
         }
       }
@@ -3064,7 +3064,7 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dev": true,
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "enquirer": {
@@ -3073,7 +3073,7 @@
       "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
       "dev": true,
       "requires": {
-        "ansi-colors": "^4.1.1"
+        "ansi-colors": "4.1.1"
       }
     },
     "env-paths": {
@@ -3088,7 +3088,7 @@
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "dev": true,
       "requires": {
-        "prr": "~1.0.1"
+        "prr": "1.0.1"
       }
     },
     "error-ex": {
@@ -3097,7 +3097,7 @@
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
-        "is-arrayish": "^0.2.1"
+        "is-arrayish": "0.2.1"
       }
     },
     "es-abstract": {
@@ -3106,17 +3106,17 @@
       "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.2.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
-        "is-callable": "^1.2.0",
-        "is-regex": "^1.1.0",
-        "object-inspect": "^1.7.0",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.0",
-        "string.prototype.trimend": "^1.0.1",
-        "string.prototype.trimstart": "^1.0.1"
+        "es-to-primitive": "1.2.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "has-symbols": "1.0.1",
+        "is-callable": "1.2.1",
+        "is-regex": "1.1.1",
+        "object-inspect": "1.8.0",
+        "object-keys": "1.1.1",
+        "object.assign": "4.1.1",
+        "string.prototype.trimend": "1.0.1",
+        "string.prototype.trimstart": "1.0.1"
       },
       "dependencies": {
         "object-keys": {
@@ -3133,9 +3133,9 @@
       "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
       "dev": true,
       "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
+        "is-callable": "1.2.1",
+        "is-date-object": "1.0.2",
+        "is-symbol": "1.0.3"
       }
     },
     "escape-string-regexp": {
@@ -3156,7 +3156,7 @@
       "integrity": "sha512-sBQUnvJwpeE9QnPrxh7dpI/dp67erYG4WXEAreAMoelPRpMR7NWb4YtwRPn9b+H1uLQKl/qS8WYmyaljTpjIsw==",
       "dev": true,
       "requires": {
-        "esprima": "^4.0.0"
+        "esprima": "4.0.1"
       }
     },
     "eth-ens-namehash": {
@@ -3165,8 +3165,8 @@
       "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
       "dev": true,
       "requires": {
-        "idna-uts46-hx": "^2.3.1",
-        "js-sha3": "^0.5.7"
+        "idna-uts46-hx": "2.3.1",
+        "js-sha3": "0.5.7"
       },
       "dependencies": {
         "js-sha3": {
@@ -3183,9 +3183,9 @@
       "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
       "dev": true,
       "requires": {
-        "bn.js": "^4.11.6",
-        "elliptic": "^6.4.0",
-        "xhr-request-promise": "^0.1.2"
+        "bn.js": "4.11.9",
+        "elliptic": "6.5.3",
+        "xhr-request-promise": "0.1.3"
       },
       "dependencies": {
         "bn.js": {
@@ -3202,12 +3202,12 @@
       "integrity": "sha512-KpXbCKmmBUNUTGh9MRKmNkIPietfhzBqqYqysDavLseIiMUGl95k6UcPEkALAZlj41e9E6yioYXc1PC333RKqw==",
       "dev": true,
       "requires": {
-        "buffer": "^5.2.1",
-        "elliptic": "^6.4.0",
+        "buffer": "5.6.0",
+        "elliptic": "6.5.3",
         "ethereumjs-abi": "0.6.5",
-        "ethereumjs-util": "^5.1.1",
-        "tweetnacl": "^1.0.0",
-        "tweetnacl-util": "^0.15.0"
+        "ethereumjs-util": "5.2.1",
+        "tweetnacl": "1.0.3",
+        "tweetnacl-util": "0.15.1"
       },
       "dependencies": {
         "bn.js": {
@@ -3222,8 +3222,8 @@
           "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
           "dev": true,
           "requires": {
-            "bn.js": "^4.10.0",
-            "ethereumjs-util": "^4.3.0"
+            "bn.js": "4.11.9",
+            "ethereumjs-util": "4.5.1"
           },
           "dependencies": {
             "ethereumjs-util": {
@@ -3232,11 +3232,11 @@
               "integrity": "sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==",
               "dev": true,
               "requires": {
-                "bn.js": "^4.8.0",
-                "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
-                "rlp": "^2.0.0"
+                "bn.js": "4.11.9",
+                "create-hash": "1.2.0",
+                "elliptic": "6.5.3",
+                "ethereum-cryptography": "0.1.3",
+                "rlp": "2.2.6"
               }
             }
           }
@@ -3247,13 +3247,13 @@
           "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
           "dev": true,
           "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "^0.1.3",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1"
+            "bn.js": "4.11.9",
+            "create-hash": "1.2.0",
+            "elliptic": "6.5.3",
+            "ethereum-cryptography": "0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "2.2.6",
+            "safe-buffer": "5.2.1"
           }
         }
       }
@@ -3264,10 +3264,10 @@
       "integrity": "sha512-/MSbf/r2/Ld8o0l15AymjOTlPqpN8Cr4ByUEA9GtR4x0yAh3TdtDzEg29zMjXCNPI7u6E5fOQdj/Cf9Tc7oVNw==",
       "dev": true,
       "requires": {
-        "async": "^2.1.2",
-        "buffer-xor": "^2.0.1",
-        "ethereumjs-util": "^7.0.2",
-        "miller-rabin": "^4.0.0"
+        "async": "2.6.3",
+        "buffer-xor": "2.0.2",
+        "ethereumjs-util": "7.0.5",
+        "miller-rabin": "4.0.1"
       },
       "dependencies": {
         "buffer-xor": {
@@ -3276,7 +3276,7 @@
           "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.1.1"
+            "safe-buffer": "5.2.1"
           }
         },
         "ethereumjs-util": {
@@ -3285,12 +3285,12 @@
           "integrity": "sha512-gLLZVXYUHR6pamO3h/+M1jzKz7qE20PKFyFKtq1PrIHA6wcLI96mDz96EMkkhXfrpk30rhpkw0iRnzxKhqaIdQ==",
           "dev": true,
           "requires": {
-            "@types/bn.js": "^4.11.3",
-            "bn.js": "^5.1.2",
-            "create-hash": "^1.1.2",
-            "ethereum-cryptography": "^0.1.3",
+            "@types/bn.js": "4.11.6",
+            "bn.js": "5.1.3",
+            "create-hash": "1.2.0",
+            "ethereum-cryptography": "0.1.3",
             "ethjs-util": "0.1.6",
-            "rlp": "^2.2.4"
+            "rlp": "2.2.6"
           }
         }
       }
@@ -3301,7 +3301,7 @@
       "integrity": "sha512-cDcJJSJ9GMAcURiAWO3DxIEhTL/uWqlQnvgKpuYQzYPrt/izuGU+1ntQmHt0IRq6ADoSYHFnB+aCEFIldjhkMQ==",
       "dev": true,
       "requires": {
-        "js-sha3": "^0.8.0"
+        "js-sha3": "0.8.0"
       },
       "dependencies": {
         "js-sha3": {
@@ -3318,21 +3318,21 @@
       "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
       "dev": true,
       "requires": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
+        "@types/pbkdf2": "3.1.0",
+        "@types/secp256k1": "4.0.1",
+        "blakejs": "1.1.0",
+        "browserify-aes": "1.2.0",
+        "bs58check": "2.1.2",
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "hash.js": "1.1.7",
+        "keccak": "3.0.1",
+        "pbkdf2": "3.1.1",
+        "randombytes": "2.1.0",
+        "safe-buffer": "5.2.1",
+        "scrypt-js": "3.0.1",
+        "secp256k1": "4.0.2",
+        "setimmediate": "1.0.5"
       }
     },
     "ethereum-waffle": {
@@ -3341,11 +3341,11 @@
       "integrity": "sha512-QSEzYhxBAjJAgVXZcR1lMB4Px1lAtf8M3QQPIflasNwHpw/VZWaYqN4o2fl615iPtOc3FFtMu1JSEbiuYojk/w==",
       "dev": true,
       "requires": {
-        "@ethereum-waffle/chai": "^3.1.0",
-        "@ethereum-waffle/compiler": "^3.1.0",
-        "@ethereum-waffle/mock-contract": "^3.1.0",
-        "@ethereum-waffle/provider": "^3.1.0",
-        "ethers": "^5.0.1"
+        "@ethereum-waffle/chai": "3.1.0",
+        "@ethereum-waffle/compiler": "3.1.0",
+        "@ethereum-waffle/mock-contract": "3.1.0",
+        "@ethereum-waffle/provider": "3.1.0",
+        "ethers": "5.0.13"
       }
     },
     "ethereumjs-abi": {
@@ -3354,8 +3354,8 @@
       "integrity": "sha512-Tx0r/iXI6r+lRsdvkFDlut0N08jWMnKRZ6Gkq+Nmw75lZe4e6o3EkSnkaBP5NF6+m5PTGAr9JP43N3LyeoglsA==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.11.8",
-        "ethereumjs-util": "^6.0.0"
+        "bn.js": "4.11.9",
+        "ethereumjs-util": "6.2.1"
       },
       "dependencies": {
         "bn.js": {
@@ -3372,9 +3372,9 @@
       "integrity": "sha512-WP6BdscjiiPkQfF9PVfMcwx/rDvfZTjFKY0Uwc09zSQr9JfIVH87dYIJu0gNhBhpmovV4yq295fdllS925fnBA==",
       "dev": true,
       "requires": {
-        "ethereumjs-util": "^6.0.0",
-        "rlp": "^2.2.1",
-        "safe-buffer": "^5.1.1"
+        "ethereumjs-util": "6.2.1",
+        "rlp": "2.2.6",
+        "safe-buffer": "5.2.1"
       }
     },
     "ethereumjs-block": {
@@ -3383,11 +3383,11 @@
       "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
       "dev": true,
       "requires": {
-        "async": "^2.0.1",
-        "ethereumjs-common": "^1.5.0",
-        "ethereumjs-tx": "^2.1.1",
-        "ethereumjs-util": "^5.0.0",
-        "merkle-patricia-tree": "^2.1.2"
+        "async": "2.6.3",
+        "ethereumjs-common": "1.5.2",
+        "ethereumjs-tx": "2.1.2",
+        "ethereumjs-util": "5.2.1",
+        "merkle-patricia-tree": "2.3.2"
       },
       "dependencies": {
         "bn.js": {
@@ -3402,13 +3402,13 @@
           "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
           "dev": true,
           "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "^0.1.3",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1"
+            "bn.js": "4.11.9",
+            "create-hash": "1.2.0",
+            "elliptic": "6.5.3",
+            "ethereum-cryptography": "0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "2.2.6",
+            "safe-buffer": "5.2.1"
           }
         },
         "merkle-patricia-tree": {
@@ -3417,14 +3417,14 @@
           "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
           "dev": true,
           "requires": {
-            "async": "^1.4.2",
-            "ethereumjs-util": "^5.0.0",
+            "async": "1.5.2",
+            "ethereumjs-util": "5.2.1",
             "level-ws": "0.0.0",
-            "levelup": "^1.2.1",
-            "memdown": "^1.0.0",
-            "readable-stream": "^2.0.0",
-            "rlp": "^2.0.0",
-            "semaphore": ">=1.0.1"
+            "levelup": "1.3.9",
+            "memdown": "1.4.1",
+            "readable-stream": "2.3.7",
+            "rlp": "2.2.6",
+            "semaphore": "1.1.0"
           },
           "dependencies": {
             "async": {
@@ -3441,13 +3441,13 @@
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.4",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.1",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           },
           "dependencies": {
             "safe-buffer": {
@@ -3464,7 +3464,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           },
           "dependencies": {
             "safe-buffer": {
@@ -3483,16 +3483,16 @@
       "integrity": "sha512-zCxaRMUOzzjvX78DTGiKjA+4h2/sF0OYL1QuPux0DHpyq8XiNoF5GYHtb++GUxVlMsMfZV7AVyzbtgcRdIcEPQ==",
       "dev": true,
       "requires": {
-        "async": "^2.6.1",
-        "ethashjs": "~0.0.7",
-        "ethereumjs-block": "~2.2.2",
-        "ethereumjs-common": "^1.5.0",
-        "ethereumjs-util": "^6.1.0",
-        "flow-stoplight": "^1.0.0",
-        "level-mem": "^3.0.1",
-        "lru-cache": "^5.1.1",
-        "rlp": "^2.2.2",
-        "semaphore": "^1.1.0"
+        "async": "2.6.3",
+        "ethashjs": "0.0.8",
+        "ethereumjs-block": "2.2.2",
+        "ethereumjs-common": "1.5.2",
+        "ethereumjs-util": "6.2.1",
+        "flow-stoplight": "1.0.0",
+        "level-mem": "3.0.1",
+        "lru-cache": "5.1.1",
+        "rlp": "2.2.6",
+        "semaphore": "1.1.0"
       },
       "dependencies": {
         "lru-cache": {
@@ -3501,7 +3501,7 @@
           "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "dev": true,
           "requires": {
-            "yallist": "^3.0.2"
+            "yallist": "3.1.1"
           }
         }
       }
@@ -3518,8 +3518,8 @@
       "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
       "dev": true,
       "requires": {
-        "ethereumjs-common": "^1.5.0",
-        "ethereumjs-util": "^6.0.0"
+        "ethereumjs-common": "1.5.2",
+        "ethereumjs-util": "6.2.1"
       }
     },
     "ethereumjs-util": {
@@ -3528,13 +3528,13 @@
       "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
       "dev": true,
       "requires": {
-        "@types/bn.js": "^4.11.3",
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
-        "ethereum-cryptography": "^0.1.3",
+        "@types/bn.js": "4.11.6",
+        "bn.js": "4.11.9",
+        "create-hash": "1.2.0",
+        "elliptic": "6.5.3",
+        "ethereum-cryptography": "0.1.3",
         "ethjs-util": "0.1.6",
-        "rlp": "^2.2.3"
+        "rlp": "2.2.6"
       },
       "dependencies": {
         "bn.js": {
@@ -3551,36 +3551,36 @@
       "integrity": "sha512-xtSVE6r3ltLZ2EHtzA0rd1s2TQaLTC11qhSG+iYhOgno+lhyIXffBC8CzLkQEp51+GlRTn9/xCjly6JCn5qwMA==",
       "dev": true,
       "requires": {
-        "@ethersproject/abi": "^5.0.5",
-        "@ethersproject/abstract-provider": "^5.0.4",
-        "@ethersproject/abstract-signer": "^5.0.4",
-        "@ethersproject/address": "^5.0.4",
-        "@ethersproject/base64": "^5.0.3",
-        "@ethersproject/basex": "^5.0.3",
-        "@ethersproject/bignumber": "^5.0.7",
-        "@ethersproject/bytes": "^5.0.4",
-        "@ethersproject/constants": "^5.0.4",
-        "@ethersproject/contracts": "^5.0.4",
-        "@ethersproject/hash": "^5.0.4",
-        "@ethersproject/hdnode": "^5.0.4",
-        "@ethersproject/json-wallets": "^5.0.6",
-        "@ethersproject/keccak256": "^5.0.3",
-        "@ethersproject/logger": "^5.0.5",
-        "@ethersproject/networks": "^5.0.3",
-        "@ethersproject/pbkdf2": "^5.0.3",
-        "@ethersproject/properties": "^5.0.3",
-        "@ethersproject/providers": "^5.0.8",
-        "@ethersproject/random": "^5.0.3",
-        "@ethersproject/rlp": "^5.0.3",
-        "@ethersproject/sha2": "^5.0.3",
-        "@ethersproject/signing-key": "^5.0.4",
-        "@ethersproject/solidity": "^5.0.4",
-        "@ethersproject/strings": "^5.0.4",
-        "@ethersproject/transactions": "^5.0.5",
-        "@ethersproject/units": "^5.0.4",
-        "@ethersproject/wallet": "^5.0.4",
-        "@ethersproject/web": "^5.0.6",
-        "@ethersproject/wordlists": "^5.0.4"
+        "@ethersproject/abi": "5.0.5",
+        "@ethersproject/abstract-provider": "5.0.4",
+        "@ethersproject/abstract-signer": "5.0.4",
+        "@ethersproject/address": "5.0.4",
+        "@ethersproject/base64": "5.0.3",
+        "@ethersproject/basex": "5.0.3",
+        "@ethersproject/bignumber": "5.0.7",
+        "@ethersproject/bytes": "5.0.4",
+        "@ethersproject/constants": "5.0.4",
+        "@ethersproject/contracts": "5.0.4",
+        "@ethersproject/hash": "5.0.4",
+        "@ethersproject/hdnode": "5.0.4",
+        "@ethersproject/json-wallets": "5.0.6",
+        "@ethersproject/keccak256": "5.0.3",
+        "@ethersproject/logger": "5.0.5",
+        "@ethersproject/networks": "5.0.3",
+        "@ethersproject/pbkdf2": "5.0.3",
+        "@ethersproject/properties": "5.0.3",
+        "@ethersproject/providers": "5.0.8",
+        "@ethersproject/random": "5.0.3",
+        "@ethersproject/rlp": "5.0.3",
+        "@ethersproject/sha2": "5.0.3",
+        "@ethersproject/signing-key": "5.0.4",
+        "@ethersproject/solidity": "5.0.4",
+        "@ethersproject/strings": "5.0.4",
+        "@ethersproject/transactions": "5.0.5",
+        "@ethersproject/units": "5.0.4",
+        "@ethersproject/wallet": "5.0.4",
+        "@ethersproject/web": "5.0.6",
+        "@ethersproject/wordlists": "5.0.4"
       }
     },
     "ethjs-unit": {
@@ -3623,8 +3623,8 @@
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
       "dev": true,
       "requires": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
+        "md5.js": "1.3.5",
+        "safe-buffer": "5.2.1"
       }
     },
     "execa": {
@@ -3633,13 +3633,13 @@
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
-        "is-stream": "^1.1.0",
-        "npm-run-path": "^2.0.0",
-        "p-finally": "^1.0.0",
-        "signal-exit": "^3.0.0",
-        "strip-eof": "^1.0.0"
+        "cross-spawn": "5.1.0",
+        "get-stream": "3.0.0",
+        "is-stream": "1.1.0",
+        "npm-run-path": "2.0.2",
+        "p-finally": "1.0.0",
+        "signal-exit": "3.0.3",
+        "strip-eof": "1.0.0"
       },
       "dependencies": {
         "get-stream": {
@@ -3662,13 +3662,13 @@
       "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
       "dev": true,
       "requires": {
-        "debug": "^2.3.3",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "posix-character-classes": "^0.1.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "posix-character-classes": "0.1.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "debug": {
@@ -3686,7 +3686,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -3695,7 +3695,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "ms": {
@@ -3712,7 +3712,7 @@
       "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
       "dev": true,
       "requires": {
-        "mime-db": "^1.28.0"
+        "mime-db": "1.44.0"
       }
     },
     "ext-name": {
@@ -3721,8 +3721,8 @@
       "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
       "dev": true,
       "requires": {
-        "ext-list": "^2.0.0",
-        "sort-keys-length": "^1.0.0"
+        "ext-list": "2.2.2",
+        "sort-keys-length": "1.0.1"
       }
     },
     "extend": {
@@ -3737,8 +3737,8 @@
       "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
       "dev": true,
       "requires": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
+        "assign-symbols": "1.0.0",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -3747,7 +3747,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -3758,14 +3758,14 @@
       "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "dev": true,
       "requires": {
-        "array-unique": "^0.3.2",
-        "define-property": "^1.0.0",
-        "expand-brackets": "^2.1.4",
-        "extend-shallow": "^2.0.1",
-        "fragment-cache": "^0.2.1",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "array-unique": "0.3.2",
+        "define-property": "1.0.0",
+        "expand-brackets": "2.1.4",
+        "extend-shallow": "2.0.1",
+        "fragment-cache": "0.2.1",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "define-property": {
@@ -3774,7 +3774,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "extend-shallow": {
@@ -3783,7 +3783,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "is-accessor-descriptor": {
@@ -3792,7 +3792,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-data-descriptor": {
@@ -3801,7 +3801,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-descriptor": {
@@ -3810,9 +3810,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.3"
           }
         }
       }
@@ -3823,8 +3823,8 @@
       "integrity": "sha512-dzbZV2AdSSVW/4E7Ti5hZdHWbA+Z80RJsJhr5uiL10oyjl/gy7/o+HI1HwK4/WSZhlq4SNKU3oUzXlM13Qx02Q==",
       "dev": true,
       "requires": {
-        "esprima-extract-comments": "^1.1.0",
-        "parse-code-context": "^1.0.0"
+        "esprima-extract-comments": "1.1.0",
+        "parse-code-context": "1.0.0"
       }
     },
     "extsprintf": {
@@ -3839,7 +3839,7 @@
       "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
       "dev": true,
       "requires": {
-        "checkpoint-store": "^1.1.0"
+        "checkpoint-store": "1.1.0"
       }
     },
     "fast-deep-equal": {
@@ -3860,7 +3860,7 @@
       "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
-        "pend": "~1.2.0"
+        "pend": "1.2.0"
       }
     },
     "file-type": {
@@ -3881,9 +3881,9 @@
       "integrity": "sha512-ICw7NTT6RsDp2rnYKVd8Fu4cr6ITzGy3+u4vUujPkabyaz+03F24NWEX7fs5fp+kBonlaqPH8fAO2NM+SXt/JA==",
       "dev": true,
       "requires": {
-        "filename-reserved-regex": "^2.0.0",
-        "strip-outer": "^1.0.0",
-        "trim-repeated": "^1.0.0"
+        "filename-reserved-regex": "2.0.0",
+        "strip-outer": "1.0.1",
+        "trim-repeated": "1.0.0"
       }
     },
     "fill-range": {
@@ -3892,7 +3892,7 @@
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dev": true,
       "requires": {
-        "to-regex-range": "^5.0.1"
+        "to-regex-range": "5.0.1"
       }
     },
     "find-replace": {
@@ -3901,8 +3901,8 @@
       "integrity": "sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=",
       "dev": true,
       "requires": {
-        "array-back": "^1.0.4",
-        "test-value": "^2.1.0"
+        "array-back": "1.0.4",
+        "test-value": "2.1.0"
       },
       "dependencies": {
         "array-back": {
@@ -3911,7 +3911,7 @@
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "typical": "^2.6.0"
+            "typical": "2.6.1"
           }
         }
       }
@@ -3922,7 +3922,7 @@
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
       "dev": true,
       "requires": {
-        "locate-path": "^2.0.0"
+        "locate-path": "2.0.0"
       }
     },
     "find-yarn-workspace-root": {
@@ -3931,8 +3931,8 @@
       "integrity": "sha512-dVtfb0WuQG+8Ag2uWkbG79hOUzEsRrhBzgfn86g2sJPkzmcpGdghbNTfUKGTxymFrY/tLIodDzLoW9nOJ4FY8Q==",
       "dev": true,
       "requires": {
-        "fs-extra": "^4.0.3",
-        "micromatch": "^3.1.4"
+        "fs-extra": "4.0.3",
+        "micromatch": "3.1.10"
       },
       "dependencies": {
         "braces": {
@@ -3941,16 +3941,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -3959,7 +3959,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -3970,10 +3970,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -3982,7 +3982,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -3993,9 +3993,9 @@
           "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "graceful-fs": "4.2.4",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.2"
           }
         },
         "is-buffer": {
@@ -4010,7 +4010,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -4019,7 +4019,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -4030,19 +4030,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.3",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "to-regex-range": {
@@ -4051,8 +4051,8 @@
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
           "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1"
           }
         }
       }
@@ -4063,7 +4063,7 @@
       "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
       "dev": true,
       "requires": {
-        "is-buffer": "~2.0.3"
+        "is-buffer": "2.0.4"
       }
     },
     "flow-stoplight": {
@@ -4090,9 +4090,9 @@
       "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
       "dev": true,
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.8",
+        "mime-types": "2.1.27"
       }
     },
     "fp-ts": {
@@ -4107,7 +4107,7 @@
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
       "dev": true,
       "requires": {
-        "map-cache": "^0.2.2"
+        "map-cache": "0.2.2"
       }
     },
     "from2": {
@@ -4116,8 +4116,8 @@
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
+        "inherits": "2.0.4",
+        "readable-stream": "2.3.7"
       },
       "dependencies": {
         "readable-stream": {
@@ -4126,13 +4126,13 @@
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.4",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.1",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "safe-buffer": {
@@ -4147,7 +4147,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -4164,9 +4164,9 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
+        "graceful-fs": "4.2.4",
+        "jsonfile": "4.0.0",
+        "universalify": "0.1.2"
       }
     },
     "fs.realpath": {
@@ -4244,7 +4244,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "defer-to-connect": "^1.0.1"
+            "defer-to-connect": "1.1.3"
           }
         },
         "@types/bignumber.js": {
@@ -4252,9 +4252,8 @@
           "resolved": "https://registry.npmjs.org/@types/bignumber.js/-/bignumber.js-5.0.0.tgz",
           "integrity": "sha512-0DH7aPGCClywOFaxxjE6UwpN2kQYe9LwuDQMv+zYA97j5GkOMo8e66LYT+a8JYU7jfmUFRZLa9KycxHDsKXJCA==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "bignumber.js": "*"
+            "bignumber.js": "9.0.0"
           }
         },
         "@types/bn.js": {
@@ -4263,7 +4262,7 @@
           "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "14.0.27"
           }
         },
         "@types/node": {
@@ -4278,7 +4277,7 @@
           "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "14.0.27"
           }
         },
         "@types/secp256k1": {
@@ -4287,7 +4286,7 @@
           "integrity": "sha512-+ZjSA8ELlOp8SlKi0YLB2tz9d5iPNEmOBd+8Rz21wTMdaXQIa9b6TEnD6l5qKOCypE7FSyPyck12qZJxSDNoog==",
           "dev": true,
           "requires": {
-            "@types/node": "*"
+            "@types/node": "14.0.27"
           }
         },
         "@web3-js/scrypt-shim": {
@@ -4297,8 +4296,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "scryptsy": "^2.1.0",
-            "semver": "^6.3.0"
+            "scryptsy": "2.1.0",
+            "semver": "6.3.0"
           },
           "dependencies": {
             "scryptsy": {
@@ -4322,13 +4321,12 @@
           "resolved": "https://registry.npmjs.org/@web3-js/websocket/-/websocket-1.0.30.tgz",
           "integrity": "sha512-fDwrD47MiDrzcJdSeTLF75aCcxVVt8B1N74rA+vh2XCAvFy4tEWJjtnUtj2QG7/zlQ6g9cQ88bZFBxwd9/FmtA==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "debug": "^2.2.0",
-            "es5-ext": "^0.10.50",
-            "nan": "^2.14.0",
-            "typedarray-to-buffer": "^3.1.5",
-            "yaeti": "^0.0.6"
+            "debug": "2.6.9",
+            "es5-ext": "0.10.53",
+            "nan": "2.14.1",
+            "typedarray-to-buffer": "3.1.5",
+            "yaeti": "0.0.6"
           },
           "dependencies": {
             "debug": {
@@ -4336,7 +4334,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -4345,8 +4342,7 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -4356,7 +4352,7 @@
           "integrity": "sha512-KUWx9UWGQD12zsmLNj64/pndaz4iJh/Pj7nopgkfDG6RlCcbMZvT6+9l7dchK4idog2Is8VdC/PvNbFuFmalIQ==",
           "dev": true,
           "requires": {
-            "xtend": "~4.0.0"
+            "xtend": "4.0.2"
           }
         },
         "accepts": {
@@ -4366,7 +4362,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "mime-types": "~2.1.24",
+            "mime-types": "2.1.27",
             "negotiator": "0.6.2"
           }
         },
@@ -4383,10 +4379,10 @@
           "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
           "dev": true,
           "requires": {
-            "fast-deep-equal": "^3.1.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.2"
+            "fast-deep-equal": "3.1.3",
+            "fast-json-stable-stringify": "2.1.0",
+            "json-schema-traverse": "0.4.1",
+            "uri-js": "4.2.2"
           }
         },
         "ansi-colors": {
@@ -4395,7 +4391,7 @@
           "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
           "dev": true,
           "requires": {
-            "ansi-wrap": "^0.1.0"
+            "ansi-wrap": "0.1.0"
           }
         },
         "ansi-gray": {
@@ -4429,8 +4425,7 @@
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
           "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "anymatch": {
           "version": "2.0.0",
@@ -4438,8 +4433,8 @@
           "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
           "dev": true,
           "requires": {
-            "micromatch": "^3.1.4",
-            "normalize-path": "^2.1.1"
+            "micromatch": "3.1.10",
+            "normalize-path": "2.1.1"
           },
           "dependencies": {
             "normalize-path": {
@@ -4448,7 +4443,7 @@
               "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
               "dev": true,
               "requires": {
-                "remove-trailing-separator": "^1.0.1"
+                "remove-trailing-separator": "1.1.0"
               }
             }
           }
@@ -4459,7 +4454,7 @@
           "integrity": "sha1-2CIM9GYIFSXv6lBhTz3mUU36WPE=",
           "dev": true,
           "requires": {
-            "buffer-equal": "^1.0.0"
+            "buffer-equal": "1.0.0"
           }
         },
         "archy": {
@@ -4480,7 +4475,7 @@
           "integrity": "sha1-Q/3d0JHo7xGqTEXZzcGOLf8XEe4=",
           "dev": true,
           "requires": {
-            "make-iterator": "^1.0.0"
+            "make-iterator": "1.0.1"
           }
         },
         "arr-flatten": {
@@ -4495,7 +4490,7 @@
           "integrity": "sha1-Onc0X/wc814qkYJWAfnljy4kysQ=",
           "dev": true,
           "requires": {
-            "make-iterator": "^1.0.0"
+            "make-iterator": "1.0.1"
           }
         },
         "arr-union": {
@@ -4523,8 +4518,8 @@
           "integrity": "sha1-L6dLJnOTccOUe9enrcc74zSz15U=",
           "dev": true,
           "requires": {
-            "array-slice": "^1.0.0",
-            "is-number": "^4.0.0"
+            "array-slice": "1.1.0",
+            "is-number": "4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -4541,7 +4536,7 @@
           "integrity": "sha512-eOCut5rXlI6aCOS7Z7kCplKRKyiFQ6dHFBem4PwlwKeNFk2/XxTrhRh5T9PyaEWGy/NHTZWbY+nsZlNFJu9rYg==",
           "dev": true,
           "requires": {
-            "is-number": "^4.0.0"
+            "is-number": "4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -4564,9 +4559,9 @@
           "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
           "dev": true,
           "requires": {
-            "default-compare": "^1.0.0",
-            "get-value": "^2.0.6",
-            "kind-of": "^5.0.2"
+            "default-compare": "1.0.0",
+            "get-value": "2.0.6",
+            "kind-of": "5.1.0"
           },
           "dependencies": {
             "kind-of": {
@@ -4589,7 +4584,7 @@
           "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
           "dev": true,
           "requires": {
-            "safer-buffer": "~2.1.0"
+            "safer-buffer": "2.1.2"
           }
         },
         "asn1.js": {
@@ -4597,11 +4592,10 @@
           "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
           "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "bn.js": "^4.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0"
+            "bn.js": "4.11.9",
+            "inherits": "2.0.4",
+            "minimalistic-assert": "1.0.1"
           }
         },
         "assert-plus": {
@@ -4622,7 +4616,7 @@
           "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
           "dev": true,
           "requires": {
-            "lodash": "^4.17.11"
+            "lodash": "4.17.14"
           }
         },
         "async-done": {
@@ -4631,10 +4625,10 @@
           "integrity": "sha512-uYkTP8dw2og1tu1nmza1n1CMW0qb8gWWlwqMmLb7MhBVs4BXrFziT6HXUd+/RlRA/i4H9AkofYloUbs1fwMqlw==",
           "dev": true,
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.2",
-            "process-nextick-args": "^2.0.0",
-            "stream-exhaust": "^1.0.1"
+            "end-of-stream": "1.4.4",
+            "once": "1.4.0",
+            "process-nextick-args": "2.0.1",
+            "stream-exhaust": "1.0.2"
           }
         },
         "async-each": {
@@ -4649,7 +4643,7 @@
           "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
           "dev": true,
           "requires": {
-            "async": "^2.4.0"
+            "async": "2.6.2"
           }
         },
         "async-limiter": {
@@ -4664,7 +4658,7 @@
           "integrity": "sha1-HQqRS7Aldb7IqPOnTlCA9yssDGs=",
           "dev": true,
           "requires": {
-            "async-done": "^1.2.2"
+            "async-done": "1.3.2"
           }
         },
         "asynckit": {
@@ -4697,9 +4691,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.2"
+            "chalk": "1.1.3",
+            "esutils": "2.0.3",
+            "js-tokens": "3.0.2"
           }
         },
         "babel-core": {
@@ -4708,25 +4702,25 @@
           "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
           "dev": true,
           "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-generator": "^6.26.0",
-            "babel-helpers": "^6.24.1",
-            "babel-messages": "^6.23.0",
-            "babel-register": "^6.26.0",
-            "babel-runtime": "^6.26.0",
-            "babel-template": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "convert-source-map": "^1.5.1",
-            "debug": "^2.6.9",
-            "json5": "^0.5.1",
-            "lodash": "^4.17.4",
-            "minimatch": "^3.0.4",
-            "path-is-absolute": "^1.0.1",
-            "private": "^0.1.8",
-            "slash": "^1.0.0",
-            "source-map": "^0.5.7"
+            "babel-code-frame": "6.26.0",
+            "babel-generator": "6.26.1",
+            "babel-helpers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-register": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "convert-source-map": "1.7.0",
+            "debug": "2.6.9",
+            "json5": "0.5.1",
+            "lodash": "4.17.14",
+            "minimatch": "3.0.4",
+            "path-is-absolute": "1.0.1",
+            "private": "0.1.8",
+            "slash": "1.0.0",
+            "source-map": "0.5.7"
           },
           "dependencies": {
             "debug": {
@@ -4758,14 +4752,14 @@
           "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
           "dev": true,
           "requires": {
-            "babel-messages": "^6.23.0",
-            "babel-runtime": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "detect-indent": "^4.0.0",
-            "jsesc": "^1.3.0",
-            "lodash": "^4.17.4",
-            "source-map": "^0.5.7",
-            "trim-right": "^1.0.1"
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.14",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
           },
           "dependencies": {
             "jsesc": {
@@ -4788,9 +4782,9 @@
           "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
           "dev": true,
           "requires": {
-            "babel-helper-explode-assignable-expression": "^6.24.1",
-            "babel-runtime": "^6.22.0",
-            "babel-types": "^6.24.1"
+            "babel-helper-explode-assignable-expression": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
           }
         },
         "babel-helper-call-delegate": {
@@ -4799,10 +4793,10 @@
           "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
           "dev": true,
           "requires": {
-            "babel-helper-hoist-variables": "^6.24.1",
-            "babel-runtime": "^6.22.0",
-            "babel-traverse": "^6.24.1",
-            "babel-types": "^6.24.1"
+            "babel-helper-hoist-variables": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
           }
         },
         "babel-helper-define-map": {
@@ -4811,10 +4805,10 @@
           "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
           "dev": true,
           "requires": {
-            "babel-helper-function-name": "^6.24.1",
-            "babel-runtime": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "lodash": "^4.17.4"
+            "babel-helper-function-name": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "lodash": "4.17.14"
           }
         },
         "babel-helper-explode-assignable-expression": {
@@ -4823,9 +4817,9 @@
           "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0",
-            "babel-traverse": "^6.24.1",
-            "babel-types": "^6.24.1"
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
           }
         },
         "babel-helper-function-name": {
@@ -4834,11 +4828,11 @@
           "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
           "dev": true,
           "requires": {
-            "babel-helper-get-function-arity": "^6.24.1",
-            "babel-runtime": "^6.22.0",
-            "babel-template": "^6.24.1",
-            "babel-traverse": "^6.24.1",
-            "babel-types": "^6.24.1"
+            "babel-helper-get-function-arity": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
           }
         },
         "babel-helper-get-function-arity": {
@@ -4847,8 +4841,8 @@
           "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0",
-            "babel-types": "^6.24.1"
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
           }
         },
         "babel-helper-hoist-variables": {
@@ -4857,8 +4851,8 @@
           "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0",
-            "babel-types": "^6.24.1"
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
           }
         },
         "babel-helper-optimise-call-expression": {
@@ -4867,8 +4861,8 @@
           "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0",
-            "babel-types": "^6.24.1"
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
           }
         },
         "babel-helper-regex": {
@@ -4877,9 +4871,9 @@
           "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "lodash": "^4.17.4"
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "lodash": "4.17.14"
           }
         },
         "babel-helper-remap-async-to-generator": {
@@ -4888,11 +4882,11 @@
           "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
           "dev": true,
           "requires": {
-            "babel-helper-function-name": "^6.24.1",
-            "babel-runtime": "^6.22.0",
-            "babel-template": "^6.24.1",
-            "babel-traverse": "^6.24.1",
-            "babel-types": "^6.24.1"
+            "babel-helper-function-name": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
           }
         },
         "babel-helper-replace-supers": {
@@ -4901,12 +4895,12 @@
           "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
           "dev": true,
           "requires": {
-            "babel-helper-optimise-call-expression": "^6.24.1",
-            "babel-messages": "^6.23.0",
-            "babel-runtime": "^6.22.0",
-            "babel-template": "^6.24.1",
-            "babel-traverse": "^6.24.1",
-            "babel-types": "^6.24.1"
+            "babel-helper-optimise-call-expression": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
           }
         },
         "babel-helpers": {
@@ -4915,8 +4909,8 @@
           "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0",
-            "babel-template": "^6.24.1"
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0"
           }
         },
         "babel-messages": {
@@ -4925,7 +4919,7 @@
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0"
+            "babel-runtime": "6.26.0"
           }
         },
         "babel-plugin-check-es2015-constants": {
@@ -4934,7 +4928,7 @@
           "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0"
+            "babel-runtime": "6.26.0"
           }
         },
         "babel-plugin-syntax-async-functions": {
@@ -4961,9 +4955,9 @@
           "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
           "dev": true,
           "requires": {
-            "babel-helper-remap-async-to-generator": "^6.24.1",
-            "babel-plugin-syntax-async-functions": "^6.8.0",
-            "babel-runtime": "^6.22.0"
+            "babel-helper-remap-async-to-generator": "6.24.1",
+            "babel-plugin-syntax-async-functions": "6.13.0",
+            "babel-runtime": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-arrow-functions": {
@@ -4972,7 +4966,7 @@
           "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0"
+            "babel-runtime": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-block-scoped-functions": {
@@ -4981,7 +4975,7 @@
           "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0"
+            "babel-runtime": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-block-scoping": {
@@ -4990,11 +4984,11 @@
           "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.26.0",
-            "babel-template": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "lodash": "^4.17.4"
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "lodash": "4.17.14"
           }
         },
         "babel-plugin-transform-es2015-classes": {
@@ -5003,15 +4997,15 @@
           "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
           "dev": true,
           "requires": {
-            "babel-helper-define-map": "^6.24.1",
-            "babel-helper-function-name": "^6.24.1",
-            "babel-helper-optimise-call-expression": "^6.24.1",
-            "babel-helper-replace-supers": "^6.24.1",
-            "babel-messages": "^6.23.0",
-            "babel-runtime": "^6.22.0",
-            "babel-template": "^6.24.1",
-            "babel-traverse": "^6.24.1",
-            "babel-types": "^6.24.1"
+            "babel-helper-define-map": "6.26.0",
+            "babel-helper-function-name": "6.24.1",
+            "babel-helper-optimise-call-expression": "6.24.1",
+            "babel-helper-replace-supers": "6.24.1",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-computed-properties": {
@@ -5020,8 +5014,8 @@
           "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0",
-            "babel-template": "^6.24.1"
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-destructuring": {
@@ -5030,7 +5024,7 @@
           "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0"
+            "babel-runtime": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-duplicate-keys": {
@@ -5039,8 +5033,8 @@
           "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0",
-            "babel-types": "^6.24.1"
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-for-of": {
@@ -5049,7 +5043,7 @@
           "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0"
+            "babel-runtime": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-function-name": {
@@ -5058,9 +5052,9 @@
           "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
           "dev": true,
           "requires": {
-            "babel-helper-function-name": "^6.24.1",
-            "babel-runtime": "^6.22.0",
-            "babel-types": "^6.24.1"
+            "babel-helper-function-name": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-literals": {
@@ -5069,7 +5063,7 @@
           "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0"
+            "babel-runtime": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-modules-amd": {
@@ -5078,9 +5072,9 @@
           "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
           "dev": true,
           "requires": {
-            "babel-plugin-transform-es2015-modules-commonjs": "^6.24.1",
-            "babel-runtime": "^6.22.0",
-            "babel-template": "^6.24.1"
+            "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-modules-commonjs": {
@@ -5089,10 +5083,10 @@
           "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
           "dev": true,
           "requires": {
-            "babel-plugin-transform-strict-mode": "^6.24.1",
-            "babel-runtime": "^6.26.0",
-            "babel-template": "^6.26.0",
-            "babel-types": "^6.26.0"
+            "babel-plugin-transform-strict-mode": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-types": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-modules-systemjs": {
@@ -5101,9 +5095,9 @@
           "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
           "dev": true,
           "requires": {
-            "babel-helper-hoist-variables": "^6.24.1",
-            "babel-runtime": "^6.22.0",
-            "babel-template": "^6.24.1"
+            "babel-helper-hoist-variables": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-modules-umd": {
@@ -5112,9 +5106,9 @@
           "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
           "dev": true,
           "requires": {
-            "babel-plugin-transform-es2015-modules-amd": "^6.24.1",
-            "babel-runtime": "^6.22.0",
-            "babel-template": "^6.24.1"
+            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-object-super": {
@@ -5123,8 +5117,8 @@
           "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
           "dev": true,
           "requires": {
-            "babel-helper-replace-supers": "^6.24.1",
-            "babel-runtime": "^6.22.0"
+            "babel-helper-replace-supers": "6.24.1",
+            "babel-runtime": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-parameters": {
@@ -5133,12 +5127,12 @@
           "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
           "dev": true,
           "requires": {
-            "babel-helper-call-delegate": "^6.24.1",
-            "babel-helper-get-function-arity": "^6.24.1",
-            "babel-runtime": "^6.22.0",
-            "babel-template": "^6.24.1",
-            "babel-traverse": "^6.24.1",
-            "babel-types": "^6.24.1"
+            "babel-helper-call-delegate": "6.24.1",
+            "babel-helper-get-function-arity": "6.24.1",
+            "babel-runtime": "6.26.0",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-shorthand-properties": {
@@ -5147,8 +5141,8 @@
           "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0",
-            "babel-types": "^6.24.1"
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-spread": {
@@ -5157,7 +5151,7 @@
           "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0"
+            "babel-runtime": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-sticky-regex": {
@@ -5166,9 +5160,9 @@
           "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
           "dev": true,
           "requires": {
-            "babel-helper-regex": "^6.24.1",
-            "babel-runtime": "^6.22.0",
-            "babel-types": "^6.24.1"
+            "babel-helper-regex": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-template-literals": {
@@ -5177,7 +5171,7 @@
           "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0"
+            "babel-runtime": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-typeof-symbol": {
@@ -5186,7 +5180,7 @@
           "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0"
+            "babel-runtime": "6.26.0"
           }
         },
         "babel-plugin-transform-es2015-unicode-regex": {
@@ -5195,9 +5189,9 @@
           "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
           "dev": true,
           "requires": {
-            "babel-helper-regex": "^6.24.1",
-            "babel-runtime": "^6.22.0",
-            "regexpu-core": "^2.0.0"
+            "babel-helper-regex": "6.26.0",
+            "babel-runtime": "6.26.0",
+            "regexpu-core": "2.0.0"
           }
         },
         "babel-plugin-transform-exponentiation-operator": {
@@ -5206,9 +5200,9 @@
           "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
           "dev": true,
           "requires": {
-            "babel-helper-builder-binary-assignment-operator-visitor": "^6.24.1",
-            "babel-plugin-syntax-exponentiation-operator": "^6.8.0",
-            "babel-runtime": "^6.22.0"
+            "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
+            "babel-plugin-syntax-exponentiation-operator": "6.13.0",
+            "babel-runtime": "6.26.0"
           }
         },
         "babel-plugin-transform-regenerator": {
@@ -5217,7 +5211,7 @@
           "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
           "dev": true,
           "requires": {
-            "regenerator-transform": "^0.10.0"
+            "regenerator-transform": "0.10.1"
           }
         },
         "babel-plugin-transform-strict-mode": {
@@ -5226,8 +5220,8 @@
           "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0",
-            "babel-types": "^6.24.1"
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0"
           }
         },
         "babel-preset-env": {
@@ -5236,36 +5230,36 @@
           "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
           "dev": true,
           "requires": {
-            "babel-plugin-check-es2015-constants": "^6.22.0",
-            "babel-plugin-syntax-trailing-function-commas": "^6.22.0",
-            "babel-plugin-transform-async-to-generator": "^6.22.0",
-            "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
-            "babel-plugin-transform-es2015-block-scoped-functions": "^6.22.0",
-            "babel-plugin-transform-es2015-block-scoping": "^6.23.0",
-            "babel-plugin-transform-es2015-classes": "^6.23.0",
-            "babel-plugin-transform-es2015-computed-properties": "^6.22.0",
-            "babel-plugin-transform-es2015-destructuring": "^6.23.0",
-            "babel-plugin-transform-es2015-duplicate-keys": "^6.22.0",
-            "babel-plugin-transform-es2015-for-of": "^6.23.0",
-            "babel-plugin-transform-es2015-function-name": "^6.22.0",
-            "babel-plugin-transform-es2015-literals": "^6.22.0",
-            "babel-plugin-transform-es2015-modules-amd": "^6.22.0",
-            "babel-plugin-transform-es2015-modules-commonjs": "^6.23.0",
-            "babel-plugin-transform-es2015-modules-systemjs": "^6.23.0",
-            "babel-plugin-transform-es2015-modules-umd": "^6.23.0",
-            "babel-plugin-transform-es2015-object-super": "^6.22.0",
-            "babel-plugin-transform-es2015-parameters": "^6.23.0",
-            "babel-plugin-transform-es2015-shorthand-properties": "^6.22.0",
-            "babel-plugin-transform-es2015-spread": "^6.22.0",
-            "babel-plugin-transform-es2015-sticky-regex": "^6.22.0",
-            "babel-plugin-transform-es2015-template-literals": "^6.22.0",
-            "babel-plugin-transform-es2015-typeof-symbol": "^6.23.0",
-            "babel-plugin-transform-es2015-unicode-regex": "^6.22.0",
-            "babel-plugin-transform-exponentiation-operator": "^6.22.0",
-            "babel-plugin-transform-regenerator": "^6.22.0",
-            "browserslist": "^3.2.6",
-            "invariant": "^2.2.2",
-            "semver": "^5.3.0"
+            "babel-plugin-check-es2015-constants": "6.22.0",
+            "babel-plugin-syntax-trailing-function-commas": "6.22.0",
+            "babel-plugin-transform-async-to-generator": "6.24.1",
+            "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
+            "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
+            "babel-plugin-transform-es2015-block-scoping": "6.26.0",
+            "babel-plugin-transform-es2015-classes": "6.24.1",
+            "babel-plugin-transform-es2015-computed-properties": "6.24.1",
+            "babel-plugin-transform-es2015-destructuring": "6.23.0",
+            "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
+            "babel-plugin-transform-es2015-for-of": "6.23.0",
+            "babel-plugin-transform-es2015-function-name": "6.24.1",
+            "babel-plugin-transform-es2015-literals": "6.22.0",
+            "babel-plugin-transform-es2015-modules-amd": "6.24.1",
+            "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
+            "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
+            "babel-plugin-transform-es2015-modules-umd": "6.24.1",
+            "babel-plugin-transform-es2015-object-super": "6.24.1",
+            "babel-plugin-transform-es2015-parameters": "6.24.1",
+            "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
+            "babel-plugin-transform-es2015-spread": "6.22.0",
+            "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
+            "babel-plugin-transform-es2015-template-literals": "6.22.0",
+            "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
+            "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
+            "babel-plugin-transform-exponentiation-operator": "6.24.1",
+            "babel-plugin-transform-regenerator": "6.26.0",
+            "browserslist": "3.2.8",
+            "invariant": "2.2.4",
+            "semver": "5.7.1"
           },
           "dependencies": {
             "semver": {
@@ -5282,13 +5276,13 @@
           "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
           "dev": true,
           "requires": {
-            "babel-core": "^6.26.0",
-            "babel-runtime": "^6.26.0",
-            "core-js": "^2.5.0",
-            "home-or-tmp": "^2.0.0",
-            "lodash": "^4.17.4",
-            "mkdirp": "^0.5.1",
-            "source-map-support": "^0.4.15"
+            "babel-core": "6.26.3",
+            "babel-runtime": "6.26.0",
+            "core-js": "2.6.11",
+            "home-or-tmp": "2.0.0",
+            "lodash": "4.17.14",
+            "mkdirp": "0.5.5",
+            "source-map-support": "0.4.18"
           },
           "dependencies": {
             "mkdirp": {
@@ -5297,7 +5291,7 @@
               "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
               "dev": true,
               "requires": {
-                "minimist": "^1.2.5"
+                "minimist": "1.2.5"
               }
             },
             "source-map": {
@@ -5312,7 +5306,7 @@
               "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
               "dev": true,
               "requires": {
-                "source-map": "^0.5.6"
+                "source-map": "0.5.7"
               }
             }
           }
@@ -5323,8 +5317,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "core-js": "2.6.11",
+            "regenerator-runtime": "0.11.1"
           }
         },
         "babel-template": {
@@ -5333,11 +5327,11 @@
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "lodash": "^4.17.4"
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "lodash": "4.17.14"
           }
         },
         "babel-traverse": {
@@ -5346,15 +5340,15 @@
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-messages": "^6.23.0",
-            "babel-runtime": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "debug": "^2.6.8",
-            "globals": "^9.18.0",
-            "invariant": "^2.2.2",
-            "lodash": "^4.17.4"
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.9",
+            "globals": "9.18.0",
+            "invariant": "2.2.4",
+            "lodash": "4.17.14"
           },
           "dependencies": {
             "debug": {
@@ -5380,10 +5374,10 @@
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.26.0",
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.4",
-            "to-fast-properties": "^1.0.3"
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.3",
+            "lodash": "4.17.14",
+            "to-fast-properties": "1.0.3"
           }
         },
         "babelify": {
@@ -5392,8 +5386,8 @@
           "integrity": "sha1-qlau3nBn/XvVSWZu4W3ChQh+iOU=",
           "dev": true,
           "requires": {
-            "babel-core": "^6.0.14",
-            "object-assign": "^4.0.0"
+            "babel-core": "6.26.3",
+            "object-assign": "4.1.1"
           }
         },
         "babylon": {
@@ -5408,15 +5402,15 @@
           "integrity": "sha1-Szzpa/JxNPeaG0FKUcFONMO9mIA=",
           "dev": true,
           "requires": {
-            "arr-filter": "^1.1.1",
-            "arr-flatten": "^1.0.1",
-            "arr-map": "^2.0.0",
-            "array-each": "^1.0.0",
-            "array-initial": "^1.0.0",
-            "array-last": "^1.1.1",
-            "async-done": "^1.2.2",
-            "async-settle": "^1.0.0",
-            "now-and-later": "^2.0.0"
+            "arr-filter": "1.1.2",
+            "arr-flatten": "1.1.0",
+            "arr-map": "2.0.2",
+            "array-each": "1.0.1",
+            "array-initial": "1.1.0",
+            "array-last": "1.3.0",
+            "async-done": "1.3.2",
+            "async-settle": "1.0.0",
+            "now-and-later": "2.0.1"
           }
         },
         "backoff": {
@@ -5425,7 +5419,7 @@
           "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
           "dev": true,
           "requires": {
-            "precond": "0.2"
+            "precond": "0.2.3"
           }
         },
         "balanced-match": {
@@ -5440,13 +5434,13 @@
           "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
           "dev": true,
           "requires": {
-            "cache-base": "^1.0.1",
-            "class-utils": "^0.3.5",
-            "component-emitter": "^1.2.1",
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.1",
-            "mixin-deep": "^1.2.0",
-            "pascalcase": "^0.1.1"
+            "cache-base": "1.0.1",
+            "class-utils": "0.3.6",
+            "component-emitter": "1.3.0",
+            "define-property": "1.0.0",
+            "isobject": "3.0.1",
+            "mixin-deep": "1.3.2",
+            "pascalcase": "0.1.1"
           },
           "dependencies": {
             "define-property": {
@@ -5455,7 +5449,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "is-accessor-descriptor": {
@@ -5464,7 +5458,7 @@
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.3"
               }
             },
             "is-data-descriptor": {
@@ -5473,7 +5467,7 @@
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.3"
               }
             },
             "is-descriptor": {
@@ -5482,9 +5476,9 @@
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.3"
               }
             }
           }
@@ -5495,7 +5489,7 @@
           "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.2.1"
           }
         },
         "base64-js": {
@@ -5510,7 +5504,7 @@
           "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
           "dev": true,
           "requires": {
-            "tweetnacl": "^0.14.3"
+            "tweetnacl": "0.14.5"
           },
           "dependencies": {
             "tweetnacl": {
@@ -5525,8 +5519,7 @@
           "version": "9.0.0",
           "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
           "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "binary-extensions": {
           "version": "1.13.1",
@@ -5549,11 +5542,11 @@
           "integrity": "sha512-xwIx/8JKoT2+IPJpFEfXoWdYwP7UVAoUxxLNfGCfVowaJE7yg1Y5B1BVPqlUNsBq5/nGwmFkwRJ8xDW4sX8OdA==",
           "dev": true,
           "requires": {
-            "create-hash": "^1.1.0",
-            "pbkdf2": "^3.0.9",
-            "randombytes": "^2.0.1",
-            "safe-buffer": "^5.0.1",
-            "unorm": "^1.3.3"
+            "create-hash": "1.2.0",
+            "pbkdf2": "3.1.1",
+            "randombytes": "2.1.0",
+            "safe-buffer": "5.2.1",
+            "unorm": "1.6.0"
           }
         },
         "bip66": {
@@ -5562,7 +5555,7 @@
           "integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.2.1"
           }
         },
         "bl": {
@@ -5570,41 +5563,37 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
           "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "readable-stream": "^2.3.5",
-            "safe-buffer": "^5.1.1"
+            "readable-stream": "2.3.7",
+            "safe-buffer": "5.2.1"
           },
           "dependencies": {
             "isarray": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "readable-stream": {
               "version": "2.3.7",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
               "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
-              "optional": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.1",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               },
               "dependencies": {
                 "safe-buffer": {
                   "version": "5.1.2",
                   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
                   "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 }
               }
             },
@@ -5613,17 +5602,15 @@
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
-              "optional": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
               },
               "dependencies": {
                 "safe-buffer": {
                   "version": "5.1.2",
                   "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
                   "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 }
               }
             }
@@ -5653,18 +5640,17 @@
           "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
           "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bytes": "3.1.0",
-            "content-type": "~1.0.4",
+            "content-type": "1.0.4",
             "debug": "2.6.9",
-            "depd": "~1.1.2",
+            "depd": "1.1.2",
             "http-errors": "1.7.2",
             "iconv-lite": "0.4.24",
-            "on-finished": "~2.3.0",
+            "on-finished": "2.3.0",
             "qs": "6.7.0",
             "raw-body": "2.4.0",
-            "type-is": "~1.6.17"
+            "type-is": "1.6.18"
           },
           "dependencies": {
             "debug": {
@@ -5672,7 +5658,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -5681,8 +5666,7 @@
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -5692,7 +5676,7 @@
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -5702,16 +5686,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.3",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -5720,7 +5704,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -5737,12 +5721,12 @@
           "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
           "dev": true,
           "requires": {
-            "buffer-xor": "^1.0.3",
-            "cipher-base": "^1.0.0",
-            "create-hash": "^1.1.0",
-            "evp_bytestokey": "^1.0.3",
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
+            "buffer-xor": "1.0.3",
+            "cipher-base": "1.0.4",
+            "create-hash": "1.2.0",
+            "evp_bytestokey": "1.0.3",
+            "inherits": "2.0.4",
+            "safe-buffer": "5.2.1"
           }
         },
         "browserify-cipher": {
@@ -5752,9 +5736,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "browserify-aes": "^1.0.4",
-            "browserify-des": "^1.0.0",
-            "evp_bytestokey": "^1.0.0"
+            "browserify-aes": "1.2.0",
+            "browserify-des": "1.0.2",
+            "evp_bytestokey": "1.0.3"
           }
         },
         "browserify-des": {
@@ -5764,10 +5748,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "cipher-base": "^1.0.1",
-            "des.js": "^1.0.0",
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.1.2"
+            "cipher-base": "1.0.4",
+            "des.js": "1.0.1",
+            "inherits": "2.0.4",
+            "safe-buffer": "5.2.1"
           }
         },
         "browserify-rsa": {
@@ -5775,10 +5759,9 @@
           "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
           "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
           "dev": true,
-          "optional": true,
           "requires": {
-            "bn.js": "^4.1.0",
-            "randombytes": "^2.0.1"
+            "bn.js": "4.11.9",
+            "randombytes": "2.1.0"
           }
         },
         "browserify-sign": {
@@ -5788,15 +5771,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bn.js": "^5.1.1",
-            "browserify-rsa": "^4.0.1",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "elliptic": "^6.5.3",
-            "inherits": "^2.0.4",
-            "parse-asn1": "^5.1.5",
-            "readable-stream": "^3.6.0",
-            "safe-buffer": "^5.2.0"
+            "bn.js": "5.1.2",
+            "browserify-rsa": "4.0.1",
+            "create-hash": "1.2.0",
+            "create-hmac": "1.1.7",
+            "elliptic": "6.5.3",
+            "inherits": "2.0.4",
+            "parse-asn1": "5.1.5",
+            "readable-stream": "3.6.0",
+            "safe-buffer": "5.2.1"
           },
           "dependencies": {
             "bn.js": {
@@ -5814,8 +5797,8 @@
           "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "^1.0.30000844",
-            "electron-to-chromium": "^1.3.47"
+            "caniuse-lite": "1.0.30001111",
+            "electron-to-chromium": "1.3.521"
           }
         },
         "bs58": {
@@ -5824,7 +5807,7 @@
           "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
           "dev": true,
           "requires": {
-            "base-x": "^3.0.2"
+            "base-x": "3.0.8"
           }
         },
         "bs58check": {
@@ -5833,9 +5816,9 @@
           "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
           "dev": true,
           "requires": {
-            "bs58": "^4.0.0",
-            "create-hash": "^1.1.0",
-            "safe-buffer": "^5.1.2"
+            "bs58": "4.0.1",
+            "create-hash": "1.2.0",
+            "safe-buffer": "5.2.1"
           }
         },
         "buffer": {
@@ -5844,8 +5827,8 @@
           "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
           "dev": true,
           "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
+            "base64-js": "1.3.1",
+            "ieee754": "1.1.13"
           }
         },
         "buffer-alloc": {
@@ -5853,18 +5836,16 @@
           "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
           "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "buffer-alloc-unsafe": "^1.1.0",
-            "buffer-fill": "^1.0.0"
+            "buffer-alloc-unsafe": "1.1.0",
+            "buffer-fill": "1.0.0"
           }
         },
         "buffer-alloc-unsafe": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
           "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "buffer-crc32": {
           "version": "0.2.13",
@@ -5883,8 +5864,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
           "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "buffer-from": {
           "version": "1.1.1",
@@ -5896,8 +5876,7 @@
           "version": "0.0.5",
           "resolved": "https://registry.npmjs.org/buffer-to-arraybuffer/-/buffer-to-arraybuffer-0.0.5.tgz",
           "integrity": "sha1-YGSkD6dutDxyOrqe+PbhIW0QURo=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "buffer-xor": {
           "version": "1.0.3",
@@ -5909,8 +5888,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
           "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "bytewise": {
           "version": "1.1.0",
@@ -5918,8 +5896,8 @@
           "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
           "dev": true,
           "requires": {
-            "bytewise-core": "^1.2.2",
-            "typewise": "^1.0.3"
+            "bytewise-core": "1.2.3",
+            "typewise": "1.0.3"
           }
         },
         "bytewise-core": {
@@ -5928,7 +5906,7 @@
           "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
           "dev": true,
           "requires": {
-            "typewise-core": "^1.2"
+            "typewise-core": "1.2.0"
           }
         },
         "cache-base": {
@@ -5937,15 +5915,15 @@
           "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
           "dev": true,
           "requires": {
-            "collection-visit": "^1.0.0",
-            "component-emitter": "^1.2.1",
-            "get-value": "^2.0.6",
-            "has-value": "^1.0.0",
-            "isobject": "^3.0.1",
-            "set-value": "^2.0.0",
-            "to-object-path": "^0.3.0",
-            "union-value": "^1.0.0",
-            "unset-value": "^1.0.0"
+            "collection-visit": "1.0.0",
+            "component-emitter": "1.3.0",
+            "get-value": "2.0.6",
+            "has-value": "1.0.0",
+            "isobject": "3.0.1",
+            "set-value": "2.0.1",
+            "to-object-path": "0.3.0",
+            "union-value": "1.0.1",
+            "unset-value": "1.0.0"
           }
         },
         "cacheable-request": {
@@ -5955,13 +5933,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "clone-response": "^1.0.2",
-            "get-stream": "^5.1.0",
-            "http-cache-semantics": "^4.0.0",
-            "keyv": "^3.0.0",
-            "lowercase-keys": "^2.0.0",
-            "normalize-url": "^4.1.0",
-            "responselike": "^1.0.2"
+            "clone-response": "1.0.2",
+            "get-stream": "5.1.0",
+            "http-cache-semantics": "4.1.0",
+            "keyv": "3.1.0",
+            "lowercase-keys": "2.0.0",
+            "normalize-url": "4.5.0",
+            "responselike": "1.0.2"
           },
           "dependencies": {
             "get-stream": {
@@ -5971,7 +5949,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "pump": "^3.0.0"
+                "pump": "3.0.0"
               }
             },
             "lowercase-keys": {
@@ -5989,8 +5967,8 @@
           "integrity": "sha1-1D8DbkUQaWsxJG19sx6/D3rDLRU=",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "^2.4.1",
-            "lru-cache": "^3.2.0"
+            "abstract-leveldown": "2.7.2",
+            "lru-cache": "3.2.0"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -5999,7 +5977,7 @@
               "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
               "dev": true,
               "requires": {
-                "xtend": "~4.0.0"
+                "xtend": "4.0.2"
               }
             },
             "lru-cache": {
@@ -6008,7 +5986,7 @@
               "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
               "dev": true,
               "requires": {
-                "pseudomap": "^1.0.1"
+                "pseudomap": "1.0.2"
               }
             }
           }
@@ -6037,11 +6015,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "checkpoint-store": {
@@ -6050,7 +6028,7 @@
           "integrity": "sha1-BOTLUWuRQziTWB5tRgGnjpVS6gY=",
           "dev": true,
           "requires": {
-            "functional-red-black-tree": "^1.0.1"
+            "functional-red-black-tree": "1.0.1"
           }
         },
         "chokidar": {
@@ -6059,18 +6037,18 @@
           "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
           "dev": true,
           "requires": {
-            "anymatch": "^2.0.0",
-            "async-each": "^1.0.1",
-            "braces": "^2.3.2",
-            "fsevents": "^1.2.7",
-            "glob-parent": "^3.1.0",
-            "inherits": "^2.0.3",
-            "is-binary-path": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "normalize-path": "^3.0.0",
-            "path-is-absolute": "^1.0.0",
-            "readdirp": "^2.2.1",
-            "upath": "^1.1.1"
+            "anymatch": "2.0.0",
+            "async-each": "1.0.3",
+            "braces": "2.3.2",
+            "fsevents": "1.2.13",
+            "glob-parent": "3.1.0",
+            "inherits": "2.0.4",
+            "is-binary-path": "1.0.1",
+            "is-glob": "4.0.1",
+            "normalize-path": "3.0.0",
+            "path-is-absolute": "1.0.1",
+            "readdirp": "2.2.1",
+            "upath": "1.2.0"
           }
         },
         "chownr": {
@@ -6086,8 +6064,8 @@
           "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
+            "inherits": "2.0.4",
+            "safe-buffer": "5.2.1"
           }
         },
         "class-utils": {
@@ -6096,10 +6074,10 @@
           "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
           "dev": true,
           "requires": {
-            "arr-union": "^3.1.0",
-            "define-property": "^0.2.5",
-            "isobject": "^3.0.0",
-            "static-extend": "^0.1.1"
+            "arr-union": "3.1.0",
+            "define-property": "0.2.5",
+            "isobject": "3.0.1",
+            "static-extend": "0.1.2"
           },
           "dependencies": {
             "define-property": {
@@ -6108,7 +6086,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             }
           }
@@ -6119,9 +6097,9 @@
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
           }
         },
         "clone": {
@@ -6143,7 +6121,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "mimic-response": "^1.0.0"
+            "mimic-response": "1.0.1"
           }
         },
         "clone-stats": {
@@ -6158,9 +6136,9 @@
           "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "process-nextick-args": "^2.0.0",
-            "readable-stream": "^2.3.5"
+            "inherits": "2.0.4",
+            "process-nextick-args": "2.0.1",
+            "readable-stream": "2.3.7"
           },
           "dependencies": {
             "isarray": {
@@ -6175,13 +6153,13 @@
               "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.1",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               }
             },
             "safe-buffer": {
@@ -6196,7 +6174,7 @@
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -6213,9 +6191,9 @@
           "integrity": "sha1-rqDwb40mx4DCt1SUOFVEsiVa8Yw=",
           "dev": true,
           "requires": {
-            "arr-map": "^2.0.2",
-            "for-own": "^1.0.0",
-            "make-iterator": "^1.0.0"
+            "arr-map": "2.0.2",
+            "for-own": "1.0.0",
+            "make-iterator": "1.0.1"
           }
         },
         "collection-visit": {
@@ -6224,8 +6202,8 @@
           "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
           "dev": true,
           "requires": {
-            "map-visit": "^1.0.0",
-            "object-visit": "^1.0.0"
+            "map-visit": "1.0.0",
+            "object-visit": "1.0.1"
           }
         },
         "color-support": {
@@ -6240,7 +6218,7 @@
           "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
           "dev": true,
           "requires": {
-            "delayed-stream": "~1.0.0"
+            "delayed-stream": "1.0.0"
           }
         },
         "commander": {
@@ -6268,10 +6246,10 @@
           "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "dev": true,
           "requires": {
-            "buffer-from": "^1.0.0",
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.2",
-            "typedarray": "^0.0.6"
+            "buffer-from": "1.1.1",
+            "inherits": "2.0.4",
+            "readable-stream": "2.3.7",
+            "typedarray": "0.0.6"
           },
           "dependencies": {
             "isarray": {
@@ -6286,13 +6264,13 @@
               "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.1",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               }
             },
             "safe-buffer": {
@@ -6307,7 +6285,7 @@
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -6335,8 +6313,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
           "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "convert-source-map": {
           "version": "1.7.0",
@@ -6344,7 +6321,7 @@
           "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.1"
+            "safe-buffer": "5.1.2"
           },
           "dependencies": {
             "safe-buffer": {
@@ -6373,8 +6350,7 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.2.tgz",
           "integrity": "sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "copy-descriptor": {
           "version": "0.1.1",
@@ -6388,8 +6364,8 @@
           "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
           "dev": true,
           "requires": {
-            "each-props": "^1.3.0",
-            "is-plain-object": "^2.0.1"
+            "each-props": "1.3.2",
+            "is-plain-object": "2.0.4"
           }
         },
         "core-js": {
@@ -6417,8 +6393,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "object-assign": "^4",
-            "vary": "^1"
+            "object-assign": "4.1.1",
+            "vary": "1.1.2"
           }
         },
         "create-ecdh": {
@@ -6428,8 +6404,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bn.js": "^4.1.0",
-            "elliptic": "^6.5.3"
+            "bn.js": "4.11.9",
+            "elliptic": "6.5.3"
           }
         },
         "create-hash": {
@@ -6438,11 +6414,11 @@
           "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
           "dev": true,
           "requires": {
-            "cipher-base": "^1.0.1",
-            "inherits": "^2.0.1",
-            "md5.js": "^1.3.4",
-            "ripemd160": "^2.0.1",
-            "sha.js": "^2.4.0"
+            "cipher-base": "1.0.4",
+            "inherits": "2.0.4",
+            "md5.js": "1.3.5",
+            "ripemd160": "2.0.2",
+            "sha.js": "2.4.11"
           }
         },
         "create-hmac": {
@@ -6451,12 +6427,12 @@
           "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
           "dev": true,
           "requires": {
-            "cipher-base": "^1.0.3",
-            "create-hash": "^1.1.0",
-            "inherits": "^2.0.1",
-            "ripemd160": "^2.0.0",
-            "safe-buffer": "^5.0.1",
-            "sha.js": "^2.4.8"
+            "cipher-base": "1.0.4",
+            "create-hash": "1.2.0",
+            "inherits": "2.0.4",
+            "ripemd160": "2.0.2",
+            "safe-buffer": "5.2.1",
+            "sha.js": "2.4.11"
           }
         },
         "cross-fetch": {
@@ -6476,17 +6452,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "browserify-cipher": "^1.0.0",
-            "browserify-sign": "^4.0.0",
-            "create-ecdh": "^4.0.0",
-            "create-hash": "^1.1.0",
-            "create-hmac": "^1.1.0",
-            "diffie-hellman": "^5.0.0",
-            "inherits": "^2.0.1",
-            "pbkdf2": "^3.0.3",
-            "public-encrypt": "^4.0.0",
-            "randombytes": "^2.0.0",
-            "randomfill": "^1.0.3"
+            "browserify-cipher": "1.0.1",
+            "browserify-sign": "4.2.1",
+            "create-ecdh": "4.0.4",
+            "create-hash": "1.2.0",
+            "create-hmac": "1.1.7",
+            "diffie-hellman": "5.0.3",
+            "inherits": "2.0.4",
+            "pbkdf2": "3.1.1",
+            "public-encrypt": "4.0.3",
+            "randombytes": "2.1.0",
+            "randomfill": "1.0.4"
           }
         },
         "d": {
@@ -6495,8 +6471,8 @@
           "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
           "dev": true,
           "requires": {
-            "es5-ext": "^0.10.50",
-            "type": "^1.0.1"
+            "es5-ext": "0.10.53",
+            "type": "1.2.0"
           }
         },
         "dashdash": {
@@ -6505,7 +6481,7 @@
           "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           }
         },
         "debug": {
@@ -6514,7 +6490,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "decamelize": {
@@ -6536,14 +6512,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "decompress-tar": "^4.0.0",
-            "decompress-tarbz2": "^4.0.0",
-            "decompress-targz": "^4.0.0",
-            "decompress-unzip": "^4.0.1",
-            "graceful-fs": "^4.1.10",
-            "make-dir": "^1.0.0",
-            "pify": "^2.3.0",
-            "strip-dirs": "^2.0.0"
+            "decompress-tar": "4.1.1",
+            "decompress-tarbz2": "4.1.1",
+            "decompress-targz": "4.1.1",
+            "decompress-unzip": "4.0.1",
+            "graceful-fs": "4.2.4",
+            "make-dir": "1.3.0",
+            "pify": "2.3.0",
+            "strip-dirs": "2.1.0"
           },
           "dependencies": {
             "pify": {
@@ -6560,9 +6536,8 @@
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
           "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
           "dev": true,
-          "optional": true,
           "requires": {
-            "mimic-response": "^1.0.0"
+            "mimic-response": "1.0.1"
           }
         },
         "decompress-tar": {
@@ -6570,11 +6545,10 @@
           "resolved": "https://registry.npmjs.org/decompress-tar/-/decompress-tar-4.1.1.tgz",
           "integrity": "sha512-JdJMaCrGpB5fESVyxwpCx4Jdj2AagLmv3y58Qy4GE6HMVjWz1FeVQk1Ct4Kye7PftcdOo/7U7UKzYBJgqnGeUQ==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "file-type": "^5.2.0",
-            "is-stream": "^1.1.0",
-            "tar-stream": "^1.5.2"
+            "file-type": "5.2.0",
+            "is-stream": "1.1.0",
+            "tar-stream": "1.6.2"
           }
         },
         "decompress-tarbz2": {
@@ -6584,11 +6558,11 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "decompress-tar": "^4.1.0",
-            "file-type": "^6.1.0",
-            "is-stream": "^1.1.0",
-            "seek-bzip": "^1.0.5",
-            "unbzip2-stream": "^1.0.9"
+            "decompress-tar": "4.1.1",
+            "file-type": "6.2.0",
+            "is-stream": "1.1.0",
+            "seek-bzip": "1.0.6",
+            "unbzip2-stream": "1.4.3"
           },
           "dependencies": {
             "file-type": {
@@ -6607,9 +6581,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "decompress-tar": "^4.1.1",
-            "file-type": "^5.2.0",
-            "is-stream": "^1.1.0"
+            "decompress-tar": "4.1.1",
+            "file-type": "5.2.0",
+            "is-stream": "1.1.0"
           }
         },
         "decompress-unzip": {
@@ -6619,10 +6593,10 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "file-type": "^3.8.0",
-            "get-stream": "^2.2.0",
-            "pify": "^2.3.0",
-            "yauzl": "^2.4.2"
+            "file-type": "3.9.0",
+            "get-stream": "2.3.1",
+            "pify": "2.3.0",
+            "yauzl": "2.10.0"
           },
           "dependencies": {
             "file-type": {
@@ -6639,8 +6613,8 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "object-assign": "^4.0.1",
-                "pinkie-promise": "^2.0.0"
+                "object-assign": "4.1.1",
+                "pinkie-promise": "2.0.1"
               }
             },
             "pify": {
@@ -6658,12 +6632,12 @@
           "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
           "dev": true,
           "requires": {
-            "is-arguments": "^1.0.4",
-            "is-date-object": "^1.0.1",
-            "is-regex": "^1.0.4",
-            "object-is": "^1.0.1",
-            "object-keys": "^1.1.1",
-            "regexp.prototype.flags": "^1.2.0"
+            "is-arguments": "1.0.4",
+            "is-date-object": "1.0.2",
+            "is-regex": "1.1.1",
+            "object-is": "1.1.2",
+            "object-keys": "1.1.1",
+            "regexp.prototype.flags": "1.3.0"
           },
           "dependencies": {
             "object-keys": {
@@ -6680,7 +6654,7 @@
           "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^5.0.2"
+            "kind-of": "5.1.0"
           },
           "dependencies": {
             "kind-of": {
@@ -6710,7 +6684,7 @@
           "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "~2.6.0"
+            "abstract-leveldown": "2.6.3"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -6719,7 +6693,7 @@
               "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
               "dev": true,
               "requires": {
-                "xtend": "~4.0.0"
+                "xtend": "4.0.2"
               }
             }
           }
@@ -6730,7 +6704,7 @@
           "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
           "dev": true,
           "requires": {
-            "object-keys": "^1.0.12"
+            "object-keys": "1.1.1"
           },
           "dependencies": {
             "object-keys": {
@@ -6747,8 +6721,8 @@
           "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.2",
-            "isobject": "^3.0.1"
+            "is-descriptor": "1.0.2",
+            "isobject": "3.0.1"
           },
           "dependencies": {
             "is-accessor-descriptor": {
@@ -6757,7 +6731,7 @@
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.3"
               }
             },
             "is-data-descriptor": {
@@ -6766,7 +6740,7 @@
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.3"
               }
             },
             "is-descriptor": {
@@ -6775,9 +6749,9 @@
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.3"
               }
             }
           }
@@ -6798,8 +6772,7 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
           "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "des.js": {
           "version": "1.0.1",
@@ -6808,16 +6781,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0"
+            "inherits": "2.0.4",
+            "minimalistic-assert": "1.0.1"
           }
         },
         "destroy": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
           "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "detect-file": {
           "version": "1.0.0",
@@ -6831,7 +6803,7 @@
           "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "dev": true,
           "requires": {
-            "repeating": "^2.0.0"
+            "repeating": "2.0.1"
           }
         },
         "diffie-hellman": {
@@ -6841,9 +6813,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bn.js": "^4.1.0",
-            "miller-rabin": "^4.0.0",
-            "randombytes": "^2.0.0"
+            "bn.js": "4.11.9",
+            "miller-rabin": "4.0.1",
+            "randombytes": "2.1.0"
           }
         },
         "dom-walk": {
@@ -6858,7 +6830,7 @@
           "integrity": "sha512-UGGGWfSauusaVJC+8fgV+NVvBXkCTmVv7sk6nojDZZvuOUNGUy0Zk4UpHQD6EDjS0jpBwcACvH4eofvyzBcRDw==",
           "dev": true,
           "requires": {
-            "minimatch": "^3.0.4"
+            "minimatch": "3.0.4"
           }
         },
         "drbg.js": {
@@ -6867,17 +6839,16 @@
           "integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
           "dev": true,
           "requires": {
-            "browserify-aes": "^1.0.6",
-            "create-hash": "^1.1.2",
-            "create-hmac": "^1.1.4"
+            "browserify-aes": "1.2.0",
+            "create-hash": "1.2.0",
+            "create-hmac": "1.1.7"
           }
         },
         "duplexer3": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
           "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "duplexify": {
           "version": "3.7.1",
@@ -6885,10 +6856,10 @@
           "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
           "dev": true,
           "requires": {
-            "end-of-stream": "^1.0.0",
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.0.0",
-            "stream-shift": "^1.0.0"
+            "end-of-stream": "1.4.4",
+            "inherits": "2.0.4",
+            "readable-stream": "2.3.7",
+            "stream-shift": "1.0.1"
           },
           "dependencies": {
             "isarray": {
@@ -6903,13 +6874,13 @@
               "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.1",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               }
             },
             "safe-buffer": {
@@ -6924,7 +6895,7 @@
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -6935,8 +6906,8 @@
           "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.1",
-            "object.defaults": "^1.1.0"
+            "is-plain-object": "2.0.4",
+            "object.defaults": "1.1.0"
           }
         },
         "ecc-jsbn": {
@@ -6945,16 +6916,15 @@
           "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
           "dev": true,
           "requires": {
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.1.0"
+            "jsbn": "0.1.1",
+            "safer-buffer": "2.1.2"
           }
         },
         "ee-first": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
           "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "electron-to-chromium": {
           "version": "1.3.521",
@@ -6968,21 +6938,20 @@
           "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
           "dev": true,
           "requires": {
-            "bn.js": "^4.4.0",
-            "brorand": "^1.0.1",
-            "hash.js": "^1.0.0",
-            "hmac-drbg": "^1.0.0",
-            "inherits": "^2.0.1",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.0"
+            "bn.js": "4.11.9",
+            "brorand": "1.1.0",
+            "hash.js": "1.1.7",
+            "hmac-drbg": "1.0.1",
+            "inherits": "2.0.4",
+            "minimalistic-assert": "1.0.1",
+            "minimalistic-crypto-utils": "1.0.1"
           }
         },
         "encodeurl": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
           "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "encoding": {
           "version": "0.1.13",
@@ -6990,7 +6959,7 @@
           "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
           "dev": true,
           "requires": {
-            "iconv-lite": "^0.6.2"
+            "iconv-lite": "0.6.2"
           },
           "dependencies": {
             "iconv-lite": {
@@ -6999,7 +6968,7 @@
               "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
               "dev": true,
               "requires": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
+                "safer-buffer": "2.1.2"
               }
             }
           }
@@ -7010,11 +6979,11 @@
           "integrity": "sha512-8CIZLDcSKxgzT+zX8ZVfgNbu8Md2wq/iqa1Y7zyVR18QBEAc0Nmzuvj/N5ykSKpfGzjM8qxbaFntLPwnVoUhZw==",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "^5.0.0",
-            "inherits": "^2.0.3",
-            "level-codec": "^9.0.0",
-            "level-errors": "^2.0.0",
-            "xtend": "^4.0.1"
+            "abstract-leveldown": "5.0.0",
+            "inherits": "2.0.4",
+            "level-codec": "9.0.2",
+            "level-errors": "2.0.1",
+            "xtend": "4.0.2"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -7023,7 +6992,7 @@
               "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
               "dev": true,
               "requires": {
-                "xtend": "~4.0.0"
+                "xtend": "4.0.2"
               }
             }
           }
@@ -7034,7 +7003,7 @@
           "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
           "dev": true,
           "requires": {
-            "once": "^1.4.0"
+            "once": "1.4.0"
           }
         },
         "errno": {
@@ -7043,7 +7012,7 @@
           "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
           "dev": true,
           "requires": {
-            "prr": "~1.0.1"
+            "prr": "1.0.1"
           }
         },
         "error-ex": {
@@ -7052,7 +7021,7 @@
           "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
           "dev": true,
           "requires": {
-            "is-arrayish": "^0.2.1"
+            "is-arrayish": "0.2.1"
           }
         },
         "es-abstract": {
@@ -7061,17 +7030,17 @@
           "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
           "dev": true,
           "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-regex": "^1.1.0",
-            "object-inspect": "^1.7.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
+            "es-to-primitive": "1.2.1",
+            "function-bind": "1.1.1",
+            "has": "1.0.3",
+            "has-symbols": "1.0.1",
+            "is-callable": "1.2.0",
+            "is-regex": "1.1.1",
+            "object-inspect": "1.8.0",
+            "object-keys": "1.1.1",
+            "object.assign": "4.1.0",
+            "string.prototype.trimend": "1.0.1",
+            "string.prototype.trimstart": "1.0.1"
           },
           "dependencies": {
             "object-keys": {
@@ -7088,9 +7057,9 @@
           "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
           "dev": true,
           "requires": {
-            "is-callable": "^1.1.4",
-            "is-date-object": "^1.0.1",
-            "is-symbol": "^1.0.2"
+            "is-callable": "1.2.0",
+            "is-date-object": "1.0.2",
+            "is-symbol": "1.0.3"
           }
         },
         "es5-ext": {
@@ -7099,9 +7068,9 @@
           "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
           "dev": true,
           "requires": {
-            "es6-iterator": "~2.0.3",
-            "es6-symbol": "~3.1.3",
-            "next-tick": "~1.0.0"
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.3",
+            "next-tick": "1.0.0"
           }
         },
         "es6-iterator": {
@@ -7110,9 +7079,9 @@
           "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
           "dev": true,
           "requires": {
-            "d": "1",
-            "es5-ext": "^0.10.35",
-            "es6-symbol": "^3.1.1"
+            "d": "1.0.1",
+            "es5-ext": "0.10.53",
+            "es6-symbol": "3.1.3"
           }
         },
         "es6-symbol": {
@@ -7121,8 +7090,8 @@
           "integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
           "dev": true,
           "requires": {
-            "d": "^1.0.1",
-            "ext": "^1.1.2"
+            "d": "1.0.1",
+            "ext": "1.4.0"
           }
         },
         "es6-weak-map": {
@@ -7131,18 +7100,17 @@
           "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
           "dev": true,
           "requires": {
-            "d": "1",
-            "es5-ext": "^0.10.46",
-            "es6-iterator": "^2.0.3",
-            "es6-symbol": "^3.1.1"
+            "d": "1.0.1",
+            "es5-ext": "0.10.53",
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.3"
           }
         },
         "escape-html": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
           "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "escape-string-regexp": {
           "version": "1.0.5",
@@ -7160,8 +7128,7 @@
           "version": "1.8.1",
           "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
           "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "eth-block-tracker": {
           "version": "3.0.1",
@@ -7169,13 +7136,13 @@
           "integrity": "sha512-WUVxWLuhMmsfenfZvFO5sbl1qFY2IqUlw/FPVmjjdElpqLsZtSG+wPe9Dz7W/sB6e80HgFKknOmKk2eNlznHug==",
           "dev": true,
           "requires": {
-            "eth-query": "^2.1.0",
-            "ethereumjs-tx": "^1.3.3",
-            "ethereumjs-util": "^5.1.3",
-            "ethjs-util": "^0.1.3",
-            "json-rpc-engine": "^3.6.0",
-            "pify": "^2.3.0",
-            "tape": "^4.6.3"
+            "eth-query": "2.1.2",
+            "ethereumjs-tx": "1.3.7",
+            "ethereumjs-util": "5.2.1",
+            "ethjs-util": "0.1.6",
+            "json-rpc-engine": "3.8.0",
+            "pify": "2.3.0",
+            "tape": "4.13.3"
           },
           "dependencies": {
             "ethereumjs-tx": {
@@ -7184,8 +7151,8 @@
               "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
               "dev": true,
               "requires": {
-                "ethereum-common": "^0.0.18",
-                "ethereumjs-util": "^5.0.0"
+                "ethereum-common": "0.0.18",
+                "ethereumjs-util": "5.2.1"
               }
             },
             "ethereumjs-util": {
@@ -7194,13 +7161,13 @@
               "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
-                "ethjs-util": "^0.1.3",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
+                "bn.js": "4.11.9",
+                "create-hash": "1.2.0",
+                "elliptic": "6.5.3",
+                "ethereum-cryptography": "0.1.3",
+                "ethjs-util": "0.1.6",
+                "rlp": "2.2.6",
+                "safe-buffer": "5.2.1"
               }
             },
             "pify": {
@@ -7218,8 +7185,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "idna-uts46-hx": "^2.3.1",
-            "js-sha3": "^0.5.7"
+            "idna-uts46-hx": "2.3.1",
+            "js-sha3": "0.5.7"
           },
           "dependencies": {
             "js-sha3": {
@@ -7237,10 +7204,10 @@
           "integrity": "sha512-W7zR4DZvyTn23Bxc0EWsq4XGDdD63+XPUCEhV2zQvQGavDVC4ZpFDK4k99qN7bd7/fjj37+rxmuBOBeIqCA5Mw==",
           "dev": true,
           "requires": {
-            "cross-fetch": "^2.1.1",
-            "eth-json-rpc-middleware": "^1.5.0",
-            "json-rpc-engine": "^3.4.0",
-            "json-rpc-error": "^2.0.0"
+            "cross-fetch": "2.2.3",
+            "eth-json-rpc-middleware": "1.6.0",
+            "json-rpc-engine": "3.8.0",
+            "json-rpc-error": "2.0.0"
           }
         },
         "eth-json-rpc-middleware": {
@@ -7249,19 +7216,19 @@
           "integrity": "sha512-tDVCTlrUvdqHKqivYMjtFZsdD7TtpNLBCfKAcOpaVs7orBMS/A8HWro6dIzNtTZIR05FAbJ3bioFOnZpuCew9Q==",
           "dev": true,
           "requires": {
-            "async": "^2.5.0",
-            "eth-query": "^2.1.2",
-            "eth-tx-summary": "^3.1.2",
-            "ethereumjs-block": "^1.6.0",
-            "ethereumjs-tx": "^1.3.3",
-            "ethereumjs-util": "^5.1.2",
-            "ethereumjs-vm": "^2.1.0",
-            "fetch-ponyfill": "^4.0.0",
-            "json-rpc-engine": "^3.6.0",
-            "json-rpc-error": "^2.0.0",
-            "json-stable-stringify": "^1.0.1",
-            "promise-to-callback": "^1.0.0",
-            "tape": "^4.6.3"
+            "async": "2.6.2",
+            "eth-query": "2.1.2",
+            "eth-tx-summary": "3.2.4",
+            "ethereumjs-block": "1.7.1",
+            "ethereumjs-tx": "1.3.7",
+            "ethereumjs-util": "5.2.1",
+            "ethereumjs-vm": "2.6.0",
+            "fetch-ponyfill": "4.1.0",
+            "json-rpc-engine": "3.8.0",
+            "json-rpc-error": "2.0.0",
+            "json-stable-stringify": "1.0.1",
+            "promise-to-callback": "1.0.0",
+            "tape": "4.13.3"
           },
           "dependencies": {
             "ethereum-common": {
@@ -7276,9 +7243,9 @@
               "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
               "dev": true,
               "requires": {
-                "ethereumjs-util": "^5.0.0",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
+                "ethereumjs-util": "5.2.1",
+                "rlp": "2.2.6",
+                "safe-buffer": "5.2.1"
               }
             },
             "ethereumjs-block": {
@@ -7287,11 +7254,11 @@
               "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
               "dev": true,
               "requires": {
-                "async": "^2.0.1",
+                "async": "2.6.2",
                 "ethereum-common": "0.2.0",
-                "ethereumjs-tx": "^1.2.2",
-                "ethereumjs-util": "^5.0.0",
-                "merkle-patricia-tree": "^2.1.2"
+                "ethereumjs-tx": "1.3.7",
+                "ethereumjs-util": "5.2.1",
+                "merkle-patricia-tree": "2.3.2"
               }
             },
             "ethereumjs-tx": {
@@ -7300,8 +7267,8 @@
               "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
               "dev": true,
               "requires": {
-                "ethereum-common": "^0.0.18",
-                "ethereumjs-util": "^5.0.0"
+                "ethereum-common": "0.0.18",
+                "ethereumjs-util": "5.2.1"
               },
               "dependencies": {
                 "ethereum-common": {
@@ -7318,13 +7285,13 @@
               "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
-                "ethjs-util": "^0.1.3",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
+                "bn.js": "4.11.9",
+                "create-hash": "1.2.0",
+                "elliptic": "6.5.3",
+                "ethereum-cryptography": "0.1.3",
+                "ethjs-util": "0.1.6",
+                "rlp": "2.2.6",
+                "safe-buffer": "5.2.1"
               }
             },
             "ethereumjs-vm": {
@@ -7333,17 +7300,17 @@
               "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
               "dev": true,
               "requires": {
-                "async": "^2.1.2",
-                "async-eventemitter": "^0.2.2",
-                "ethereumjs-account": "^2.0.3",
-                "ethereumjs-block": "~2.2.0",
-                "ethereumjs-common": "^1.1.0",
-                "ethereumjs-util": "^6.0.0",
-                "fake-merkle-patricia-tree": "^1.0.1",
-                "functional-red-black-tree": "^1.0.1",
-                "merkle-patricia-tree": "^2.3.2",
-                "rustbn.js": "~0.2.0",
-                "safe-buffer": "^5.1.1"
+                "async": "2.6.2",
+                "async-eventemitter": "0.2.4",
+                "ethereumjs-account": "2.0.5",
+                "ethereumjs-block": "2.2.2",
+                "ethereumjs-common": "1.5.0",
+                "ethereumjs-util": "6.2.1",
+                "fake-merkle-patricia-tree": "1.0.1",
+                "functional-red-black-tree": "1.0.1",
+                "merkle-patricia-tree": "2.3.2",
+                "rustbn.js": "0.2.0",
+                "safe-buffer": "5.2.1"
               },
               "dependencies": {
                 "ethereumjs-block": {
@@ -7352,11 +7319,11 @@
                   "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
                   "dev": true,
                   "requires": {
-                    "async": "^2.0.1",
-                    "ethereumjs-common": "^1.5.0",
-                    "ethereumjs-tx": "^2.1.1",
-                    "ethereumjs-util": "^5.0.0",
-                    "merkle-patricia-tree": "^2.1.2"
+                    "async": "2.6.2",
+                    "ethereumjs-common": "1.5.0",
+                    "ethereumjs-tx": "2.1.2",
+                    "ethereumjs-util": "5.2.1",
+                    "merkle-patricia-tree": "2.3.2"
                   },
                   "dependencies": {
                     "ethereumjs-util": {
@@ -7365,13 +7332,13 @@
                       "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
                       "dev": true,
                       "requires": {
-                        "bn.js": "^4.11.0",
-                        "create-hash": "^1.1.2",
-                        "elliptic": "^6.5.2",
-                        "ethereum-cryptography": "^0.1.3",
-                        "ethjs-util": "^0.1.3",
-                        "rlp": "^2.0.0",
-                        "safe-buffer": "^5.1.1"
+                        "bn.js": "4.11.9",
+                        "create-hash": "1.2.0",
+                        "elliptic": "6.5.3",
+                        "ethereum-cryptography": "0.1.3",
+                        "ethjs-util": "0.1.6",
+                        "rlp": "2.2.6",
+                        "safe-buffer": "5.2.1"
                       }
                     }
                   }
@@ -7382,8 +7349,8 @@
                   "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
                   "dev": true,
                   "requires": {
-                    "ethereumjs-common": "^1.5.0",
-                    "ethereumjs-util": "^6.0.0"
+                    "ethereumjs-common": "1.5.0",
+                    "ethereumjs-util": "6.2.1"
                   }
                 },
                 "ethereumjs-util": {
@@ -7392,13 +7359,13 @@
                   "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
                   "dev": true,
                   "requires": {
-                    "@types/bn.js": "^4.11.3",
-                    "bn.js": "^4.11.0",
-                    "create-hash": "^1.1.2",
-                    "elliptic": "^6.5.2",
-                    "ethereum-cryptography": "^0.1.3",
+                    "@types/bn.js": "4.11.6",
+                    "bn.js": "4.11.9",
+                    "create-hash": "1.2.0",
+                    "elliptic": "6.5.3",
+                    "ethereum-cryptography": "0.1.3",
                     "ethjs-util": "0.1.6",
-                    "rlp": "^2.2.3"
+                    "rlp": "2.2.6"
                   }
                 }
               }
@@ -7412,12 +7379,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bn.js": "^4.11.6",
-            "elliptic": "^6.4.0",
-            "nano-json-stream-parser": "^0.1.2",
-            "servify": "^0.1.12",
-            "ws": "^3.0.0",
-            "xhr-request-promise": "^0.1.2"
+            "bn.js": "4.11.9",
+            "elliptic": "6.5.3",
+            "nano-json-stream-parser": "0.1.2",
+            "servify": "0.1.12",
+            "ws": "3.3.3",
+            "xhr-request-promise": "0.1.3"
           }
         },
         "eth-query": {
@@ -7426,8 +7393,8 @@
           "integrity": "sha1-1nQdkAAQa1FRDHLbktY2VFam2l4=",
           "dev": true,
           "requires": {
-            "json-rpc-random-id": "^1.0.0",
-            "xtend": "^4.0.1"
+            "json-rpc-random-id": "1.0.1",
+            "xtend": "4.0.2"
           }
         },
         "eth-sig-util": {
@@ -7436,12 +7403,12 @@
           "integrity": "sha512-ugD1AvaggvKaZDgnS19W5qOfepjGc7qHrt7TrAaL54gJw9SHvgIXJ3r2xOMW30RWJZNP+1GlTOy5oye7yXA4xA==",
           "dev": true,
           "requires": {
-            "buffer": "^5.2.1",
-            "elliptic": "^6.4.0",
+            "buffer": "5.6.0",
+            "elliptic": "6.5.3",
             "ethereumjs-abi": "0.6.5",
-            "ethereumjs-util": "^5.1.1",
-            "tweetnacl": "^1.0.0",
-            "tweetnacl-util": "^0.15.0"
+            "ethereumjs-util": "5.2.1",
+            "tweetnacl": "1.0.3",
+            "tweetnacl-util": "0.15.1"
           },
           "dependencies": {
             "ethereumjs-abi": {
@@ -7450,8 +7417,8 @@
               "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
               "dev": true,
               "requires": {
-                "bn.js": "^4.10.0",
-                "ethereumjs-util": "^4.3.0"
+                "bn.js": "4.11.9",
+                "ethereumjs-util": "4.5.1"
               },
               "dependencies": {
                 "ethereumjs-util": {
@@ -7460,11 +7427,11 @@
                   "integrity": "sha512-WrckOZ7uBnei4+AKimpuF1B3Fv25OmoRgmYCpGsP7u8PFxXAmAgiJSYT2kRWnt6fVIlKaQlZvuwXp7PIrmn3/w==",
                   "dev": true,
                   "requires": {
-                    "bn.js": "^4.8.0",
-                    "create-hash": "^1.1.2",
-                    "elliptic": "^6.5.2",
-                    "ethereum-cryptography": "^0.1.3",
-                    "rlp": "^2.0.0"
+                    "bn.js": "4.11.9",
+                    "create-hash": "1.2.0",
+                    "elliptic": "6.5.3",
+                    "ethereum-cryptography": "0.1.3",
+                    "rlp": "2.2.6"
                   }
                 }
               }
@@ -7475,13 +7442,13 @@
               "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
-                "ethjs-util": "^0.1.3",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
+                "bn.js": "4.11.9",
+                "create-hash": "1.2.0",
+                "elliptic": "6.5.3",
+                "ethereum-cryptography": "0.1.3",
+                "ethjs-util": "0.1.6",
+                "rlp": "2.2.6",
+                "safe-buffer": "5.2.1"
               }
             }
           }
@@ -7492,16 +7459,16 @@
           "integrity": "sha512-NtlDnaVZah146Rm8HMRUNMgIwG/ED4jiqk0TME9zFheMl1jOp6jL1m0NKGjJwehXQ6ZKCPr16MTr+qspKpEXNg==",
           "dev": true,
           "requires": {
-            "async": "^2.1.2",
-            "clone": "^2.0.0",
-            "concat-stream": "^1.5.1",
-            "end-of-stream": "^1.1.0",
-            "eth-query": "^2.0.2",
-            "ethereumjs-block": "^1.4.1",
-            "ethereumjs-tx": "^1.1.1",
-            "ethereumjs-util": "^5.0.1",
-            "ethereumjs-vm": "^2.6.0",
-            "through2": "^2.0.3"
+            "async": "2.6.2",
+            "clone": "2.1.2",
+            "concat-stream": "1.6.2",
+            "end-of-stream": "1.4.4",
+            "eth-query": "2.1.2",
+            "ethereumjs-block": "1.7.1",
+            "ethereumjs-tx": "1.3.7",
+            "ethereumjs-util": "5.2.1",
+            "ethereumjs-vm": "2.6.0",
+            "through2": "2.0.5"
           },
           "dependencies": {
             "ethereum-common": {
@@ -7516,9 +7483,9 @@
               "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
               "dev": true,
               "requires": {
-                "ethereumjs-util": "^5.0.0",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
+                "ethereumjs-util": "5.2.1",
+                "rlp": "2.2.6",
+                "safe-buffer": "5.2.1"
               }
             },
             "ethereumjs-block": {
@@ -7527,11 +7494,11 @@
               "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
               "dev": true,
               "requires": {
-                "async": "^2.0.1",
+                "async": "2.6.2",
                 "ethereum-common": "0.2.0",
-                "ethereumjs-tx": "^1.2.2",
-                "ethereumjs-util": "^5.0.0",
-                "merkle-patricia-tree": "^2.1.2"
+                "ethereumjs-tx": "1.3.7",
+                "ethereumjs-util": "5.2.1",
+                "merkle-patricia-tree": "2.3.2"
               }
             },
             "ethereumjs-tx": {
@@ -7540,8 +7507,8 @@
               "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
               "dev": true,
               "requires": {
-                "ethereum-common": "^0.0.18",
-                "ethereumjs-util": "^5.0.0"
+                "ethereum-common": "0.0.18",
+                "ethereumjs-util": "5.2.1"
               },
               "dependencies": {
                 "ethereum-common": {
@@ -7558,13 +7525,13 @@
               "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
-                "ethjs-util": "^0.1.3",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
+                "bn.js": "4.11.9",
+                "create-hash": "1.2.0",
+                "elliptic": "6.5.3",
+                "ethereum-cryptography": "0.1.3",
+                "ethjs-util": "0.1.6",
+                "rlp": "2.2.6",
+                "safe-buffer": "5.2.1"
               }
             },
             "ethereumjs-vm": {
@@ -7573,17 +7540,17 @@
               "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
               "dev": true,
               "requires": {
-                "async": "^2.1.2",
-                "async-eventemitter": "^0.2.2",
-                "ethereumjs-account": "^2.0.3",
-                "ethereumjs-block": "~2.2.0",
-                "ethereumjs-common": "^1.1.0",
-                "ethereumjs-util": "^6.0.0",
-                "fake-merkle-patricia-tree": "^1.0.1",
-                "functional-red-black-tree": "^1.0.1",
-                "merkle-patricia-tree": "^2.3.2",
-                "rustbn.js": "~0.2.0",
-                "safe-buffer": "^5.1.1"
+                "async": "2.6.2",
+                "async-eventemitter": "0.2.4",
+                "ethereumjs-account": "2.0.5",
+                "ethereumjs-block": "2.2.2",
+                "ethereumjs-common": "1.5.0",
+                "ethereumjs-util": "6.2.1",
+                "fake-merkle-patricia-tree": "1.0.1",
+                "functional-red-black-tree": "1.0.1",
+                "merkle-patricia-tree": "2.3.2",
+                "rustbn.js": "0.2.0",
+                "safe-buffer": "5.2.1"
               },
               "dependencies": {
                 "ethereumjs-block": {
@@ -7592,11 +7559,11 @@
                   "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
                   "dev": true,
                   "requires": {
-                    "async": "^2.0.1",
-                    "ethereumjs-common": "^1.5.0",
-                    "ethereumjs-tx": "^2.1.1",
-                    "ethereumjs-util": "^5.0.0",
-                    "merkle-patricia-tree": "^2.1.2"
+                    "async": "2.6.2",
+                    "ethereumjs-common": "1.5.0",
+                    "ethereumjs-tx": "2.1.2",
+                    "ethereumjs-util": "5.2.1",
+                    "merkle-patricia-tree": "2.3.2"
                   },
                   "dependencies": {
                     "ethereumjs-util": {
@@ -7605,13 +7572,13 @@
                       "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
                       "dev": true,
                       "requires": {
-                        "bn.js": "^4.11.0",
-                        "create-hash": "^1.1.2",
-                        "elliptic": "^6.5.2",
-                        "ethereum-cryptography": "^0.1.3",
-                        "ethjs-util": "^0.1.3",
-                        "rlp": "^2.0.0",
-                        "safe-buffer": "^5.1.1"
+                        "bn.js": "4.11.9",
+                        "create-hash": "1.2.0",
+                        "elliptic": "6.5.3",
+                        "ethereum-cryptography": "0.1.3",
+                        "ethjs-util": "0.1.6",
+                        "rlp": "2.2.6",
+                        "safe-buffer": "5.2.1"
                       }
                     }
                   }
@@ -7622,8 +7589,8 @@
                   "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
                   "dev": true,
                   "requires": {
-                    "ethereumjs-common": "^1.5.0",
-                    "ethereumjs-util": "^6.0.0"
+                    "ethereumjs-common": "1.5.0",
+                    "ethereumjs-util": "6.2.1"
                   }
                 },
                 "ethereumjs-util": {
@@ -7632,13 +7599,13 @@
                   "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
                   "dev": true,
                   "requires": {
-                    "@types/bn.js": "^4.11.3",
-                    "bn.js": "^4.11.0",
-                    "create-hash": "^1.1.2",
-                    "elliptic": "^6.5.2",
-                    "ethereum-cryptography": "^0.1.3",
+                    "@types/bn.js": "4.11.6",
+                    "bn.js": "4.11.9",
+                    "create-hash": "1.2.0",
+                    "elliptic": "6.5.3",
+                    "ethereum-cryptography": "0.1.3",
                     "ethjs-util": "0.1.6",
-                    "rlp": "^2.2.3"
+                    "rlp": "2.2.6"
                   }
                 }
               }
@@ -7651,10 +7618,10 @@
           "integrity": "sha512-/MSbf/r2/Ld8o0l15AymjOTlPqpN8Cr4ByUEA9GtR4x0yAh3TdtDzEg29zMjXCNPI7u6E5fOQdj/Cf9Tc7oVNw==",
           "dev": true,
           "requires": {
-            "async": "^2.1.2",
-            "buffer-xor": "^2.0.1",
-            "ethereumjs-util": "^7.0.2",
-            "miller-rabin": "^4.0.0"
+            "async": "2.6.2",
+            "buffer-xor": "2.0.2",
+            "ethereumjs-util": "7.0.4",
+            "miller-rabin": "4.0.1"
           },
           "dependencies": {
             "bn.js": {
@@ -7669,7 +7636,7 @@
               "integrity": "sha512-eHslX0bin3GB+Lx2p7lEYRShRewuNZL3fUl4qlVJGGiwoPGftmt8JQgk2Y9Ji5/01TnVDo33E5b5O3vUB1HdqQ==",
               "dev": true,
               "requires": {
-                "safe-buffer": "^5.1.1"
+                "safe-buffer": "5.2.1"
               }
             },
             "ethereumjs-util": {
@@ -7678,12 +7645,12 @@
               "integrity": "sha512-isldtbCn9fdnhBPxedMNbFkNWVZ8ZdQvKRDSrdflame/AycAPKMer+vEpndpBxYIB3qxN6bd3Gh1YCQW9LDkCQ==",
               "dev": true,
               "requires": {
-                "@types/bn.js": "^4.11.3",
-                "bn.js": "^5.1.2",
-                "create-hash": "^1.1.2",
-                "ethereum-cryptography": "^0.1.3",
+                "@types/bn.js": "4.11.6",
+                "bn.js": "5.1.2",
+                "create-hash": "1.2.0",
+                "ethereum-cryptography": "0.1.3",
                 "ethjs-util": "0.1.6",
-                "rlp": "^2.2.4"
+                "rlp": "2.2.6"
               }
             }
           }
@@ -7693,9 +7660,8 @@
           "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.7.tgz",
           "integrity": "sha512-cDcJJSJ9GMAcURiAWO3DxIEhTL/uWqlQnvgKpuYQzYPrt/izuGU+1ntQmHt0IRq6ADoSYHFnB+aCEFIldjhkMQ==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "js-sha3": "^0.8.0"
+            "js-sha3": "0.8.0"
           }
         },
         "ethereum-common": {
@@ -7710,21 +7676,21 @@
           "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
           "dev": true,
           "requires": {
-            "@types/pbkdf2": "^3.0.0",
-            "@types/secp256k1": "^4.0.1",
-            "blakejs": "^1.1.0",
-            "browserify-aes": "^1.2.0",
-            "bs58check": "^2.1.2",
-            "create-hash": "^1.2.0",
-            "create-hmac": "^1.1.7",
-            "hash.js": "^1.1.7",
-            "keccak": "^3.0.0",
-            "pbkdf2": "^3.0.17",
-            "randombytes": "^2.1.0",
-            "safe-buffer": "^5.1.2",
-            "scrypt-js": "^3.0.0",
-            "secp256k1": "^4.0.1",
-            "setimmediate": "^1.0.5"
+            "@types/pbkdf2": "3.1.0",
+            "@types/secp256k1": "4.0.1",
+            "blakejs": "1.1.0",
+            "browserify-aes": "1.2.0",
+            "bs58check": "2.1.2",
+            "create-hash": "1.2.0",
+            "create-hmac": "1.1.7",
+            "hash.js": "1.1.7",
+            "keccak": "3.0.1",
+            "pbkdf2": "3.1.1",
+            "randombytes": "2.1.0",
+            "safe-buffer": "5.2.1",
+            "scrypt-js": "3.0.1",
+            "secp256k1": "4.0.2",
+            "setimmediate": "1.0.5"
           }
         },
         "ethereumjs-abi": {
@@ -7733,8 +7699,8 @@
           "integrity": "sha512-EMLOA8ICO5yAaXDhjVEfYjsJIXYutY8ufTE93eEKwsVtp2usQreKwsDTJ9zvam3omYqNuffr8IONIqb2uUslGQ==",
           "dev": true,
           "requires": {
-            "bn.js": "^4.11.8",
-            "ethereumjs-util": "^6.0.0"
+            "bn.js": "4.11.9",
+            "ethereumjs-util": "6.2.0"
           }
         },
         "ethereumjs-account": {
@@ -7743,9 +7709,9 @@
           "integrity": "sha512-WP6BdscjiiPkQfF9PVfMcwx/rDvfZTjFKY0Uwc09zSQr9JfIVH87dYIJu0gNhBhpmovV4yq295fdllS925fnBA==",
           "dev": true,
           "requires": {
-            "ethereumjs-util": "^6.0.0",
-            "rlp": "^2.2.1",
-            "safe-buffer": "^5.1.1"
+            "ethereumjs-util": "6.2.0",
+            "rlp": "2.2.6",
+            "safe-buffer": "5.2.1"
           }
         },
         "ethereumjs-block": {
@@ -7754,11 +7720,11 @@
           "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
           "dev": true,
           "requires": {
-            "async": "^2.0.1",
-            "ethereumjs-common": "^1.5.0",
-            "ethereumjs-tx": "^2.1.1",
-            "ethereumjs-util": "^5.0.0",
-            "merkle-patricia-tree": "^2.1.2"
+            "async": "2.6.2",
+            "ethereumjs-common": "1.5.0",
+            "ethereumjs-tx": "2.1.2",
+            "ethereumjs-util": "5.2.1",
+            "merkle-patricia-tree": "2.3.2"
           },
           "dependencies": {
             "ethereumjs-util": {
@@ -7767,13 +7733,13 @@
               "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
-                "ethjs-util": "^0.1.3",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
+                "bn.js": "4.11.9",
+                "create-hash": "1.2.0",
+                "elliptic": "6.5.3",
+                "ethereum-cryptography": "0.1.3",
+                "ethjs-util": "0.1.6",
+                "rlp": "2.2.6",
+                "safe-buffer": "5.2.1"
               }
             }
           }
@@ -7784,16 +7750,16 @@
           "integrity": "sha512-zCxaRMUOzzjvX78DTGiKjA+4h2/sF0OYL1QuPux0DHpyq8XiNoF5GYHtb++GUxVlMsMfZV7AVyzbtgcRdIcEPQ==",
           "dev": true,
           "requires": {
-            "async": "^2.6.1",
-            "ethashjs": "~0.0.7",
-            "ethereumjs-block": "~2.2.2",
-            "ethereumjs-common": "^1.5.0",
-            "ethereumjs-util": "^6.1.0",
-            "flow-stoplight": "^1.0.0",
-            "level-mem": "^3.0.1",
-            "lru-cache": "^5.1.1",
-            "rlp": "^2.2.2",
-            "semaphore": "^1.1.0"
+            "async": "2.6.2",
+            "ethashjs": "0.0.8",
+            "ethereumjs-block": "2.2.2",
+            "ethereumjs-common": "1.5.0",
+            "ethereumjs-util": "6.2.0",
+            "flow-stoplight": "1.0.0",
+            "level-mem": "3.0.1",
+            "lru-cache": "5.1.1",
+            "rlp": "2.2.6",
+            "semaphore": "1.1.0"
           }
         },
         "ethereumjs-common": {
@@ -7808,8 +7774,8 @@
           "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
           "dev": true,
           "requires": {
-            "ethereumjs-common": "^1.5.0",
-            "ethereumjs-util": "^6.0.0"
+            "ethereumjs-common": "1.5.0",
+            "ethereumjs-util": "6.2.0"
           }
         },
         "ethereumjs-util": {
@@ -7818,13 +7784,13 @@
           "integrity": "sha512-vb0XN9J2QGdZGIEKG2vXM+kUdEivUfU6Wmi5y0cg+LRhDYKnXIZ/Lz7XjFbHRR9VIKq2lVGLzGBkA++y2nOdOQ==",
           "dev": true,
           "requires": {
-            "@types/bn.js": "^4.11.3",
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
+            "@types/bn.js": "4.11.6",
+            "bn.js": "4.11.9",
+            "create-hash": "1.2.0",
             "ethjs-util": "0.1.6",
-            "keccak": "^2.0.0",
-            "rlp": "^2.2.3",
-            "secp256k1": "^3.0.1"
+            "keccak": "2.1.0",
+            "rlp": "2.2.6",
+            "secp256k1": "3.8.0"
           },
           "dependencies": {
             "keccak": {
@@ -7833,10 +7799,10 @@
               "integrity": "sha512-m1wbJRTo+gWbctZWay9i26v5fFnYkOn7D5PCxJ3fZUGUEb49dE1Pm4BREUYCt/aoO6di7jeoGmhvqN9Nzylm3Q==",
               "dev": true,
               "requires": {
-                "bindings": "^1.5.0",
-                "inherits": "^2.0.4",
-                "nan": "^2.14.0",
-                "safe-buffer": "^5.2.0"
+                "bindings": "1.5.0",
+                "inherits": "2.0.4",
+                "nan": "2.14.1",
+                "safe-buffer": "5.2.1"
               }
             },
             "secp256k1": {
@@ -7845,14 +7811,14 @@
               "integrity": "sha512-k5ke5avRZbtl9Tqx/SA7CbY3NF6Ro+Sj9cZxezFzuBlLDmyqPiL8hJJ+EmzD8Ig4LUDByHJ3/iPOVoRixs/hmw==",
               "dev": true,
               "requires": {
-                "bindings": "^1.5.0",
-                "bip66": "^1.1.5",
-                "bn.js": "^4.11.8",
-                "create-hash": "^1.2.0",
-                "drbg.js": "^1.0.1",
-                "elliptic": "^6.5.2",
-                "nan": "^2.14.0",
-                "safe-buffer": "^5.1.2"
+                "bindings": "1.5.0",
+                "bip66": "1.1.5",
+                "bn.js": "4.11.9",
+                "create-hash": "1.2.0",
+                "drbg.js": "1.0.1",
+                "elliptic": "6.5.3",
+                "nan": "2.14.1",
+                "safe-buffer": "5.2.1"
               }
             }
           }
@@ -7863,21 +7829,21 @@
           "integrity": "sha512-X6qqZbsY33p5FTuZqCnQ4+lo957iUJMM6Mpa6bL4UW0dxM6WmDSHuI4j/zOp1E2TDKImBGCJA9QPfc08PaNubA==",
           "dev": true,
           "requires": {
-            "async": "^2.1.2",
-            "async-eventemitter": "^0.2.2",
-            "core-js-pure": "^3.0.1",
-            "ethereumjs-account": "^3.0.0",
-            "ethereumjs-block": "^2.2.2",
-            "ethereumjs-blockchain": "^4.0.3",
-            "ethereumjs-common": "^1.5.0",
-            "ethereumjs-tx": "^2.1.2",
-            "ethereumjs-util": "^6.2.0",
-            "fake-merkle-patricia-tree": "^1.0.1",
-            "functional-red-black-tree": "^1.0.1",
-            "merkle-patricia-tree": "^2.3.2",
-            "rustbn.js": "~0.2.0",
-            "safe-buffer": "^5.1.1",
-            "util.promisify": "^1.0.0"
+            "async": "2.6.2",
+            "async-eventemitter": "0.2.4",
+            "core-js-pure": "3.6.5",
+            "ethereumjs-account": "3.0.0",
+            "ethereumjs-block": "2.2.2",
+            "ethereumjs-blockchain": "4.0.4",
+            "ethereumjs-common": "1.5.0",
+            "ethereumjs-tx": "2.1.2",
+            "ethereumjs-util": "6.2.0",
+            "fake-merkle-patricia-tree": "1.0.1",
+            "functional-red-black-tree": "1.0.1",
+            "merkle-patricia-tree": "2.3.2",
+            "rustbn.js": "0.2.0",
+            "safe-buffer": "5.2.1",
+            "util.promisify": "1.0.1"
           }
         },
         "ethereumjs-wallet": {
@@ -7887,15 +7853,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "aes-js": "^3.1.1",
-            "bs58check": "^2.1.2",
-            "ethereumjs-util": "^6.0.0",
-            "hdkey": "^1.1.0",
-            "randombytes": "^2.0.6",
-            "safe-buffer": "^5.1.2",
-            "scrypt.js": "^0.3.0",
-            "utf8": "^3.0.0",
-            "uuid": "^3.3.2"
+            "aes-js": "3.1.2",
+            "bs58check": "2.1.2",
+            "ethereumjs-util": "6.2.0",
+            "hdkey": "1.1.2",
+            "randombytes": "2.1.0",
+            "safe-buffer": "5.2.1",
+            "scrypt.js": "0.3.0",
+            "utf8": "3.0.0",
+            "uuid": "3.4.0"
           }
         },
         "ethjs-unit": {
@@ -7903,7 +7869,6 @@
           "resolved": "https://registry.npmjs.org/ethjs-unit/-/ethjs-unit-0.1.6.tgz",
           "integrity": "sha1-xmWSHkduh7ziqdWIpv4EBbLEFpk=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "number-to-bn": "1.7.0"
@@ -7913,8 +7878,7 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -7932,8 +7896,7 @@
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
           "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "events": {
           "version": "3.2.0",
@@ -7947,8 +7910,8 @@
           "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
           "dev": true,
           "requires": {
-            "md5.js": "^1.3.4",
-            "safe-buffer": "^5.1.1"
+            "md5.js": "1.3.5",
+            "safe-buffer": "5.2.1"
           }
         },
         "expand-brackets": {
@@ -7957,13 +7920,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "debug": {
@@ -7981,7 +7944,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -7990,7 +7953,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "ms": {
@@ -8007,7 +7970,7 @@
           "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
           "dev": true,
           "requires": {
-            "homedir-polyfill": "^1.0.1"
+            "homedir-polyfill": "1.0.3"
           }
         },
         "express": {
@@ -8017,36 +7980,36 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "accepts": "~1.3.7",
+            "accepts": "1.3.7",
             "array-flatten": "1.1.1",
             "body-parser": "1.19.0",
             "content-disposition": "0.5.3",
-            "content-type": "~1.0.4",
+            "content-type": "1.0.4",
             "cookie": "0.4.0",
             "cookie-signature": "1.0.6",
             "debug": "2.6.9",
-            "depd": "~1.1.2",
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "etag": "~1.8.1",
-            "finalhandler": "~1.1.2",
+            "depd": "1.1.2",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
+            "finalhandler": "1.1.2",
             "fresh": "0.5.2",
             "merge-descriptors": "1.0.1",
-            "methods": "~1.1.2",
-            "on-finished": "~2.3.0",
-            "parseurl": "~1.3.3",
+            "methods": "1.1.2",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.3",
             "path-to-regexp": "0.1.7",
-            "proxy-addr": "~2.0.5",
+            "proxy-addr": "2.0.6",
             "qs": "6.7.0",
-            "range-parser": "~1.2.1",
+            "range-parser": "1.2.1",
             "safe-buffer": "5.1.2",
             "send": "0.17.1",
             "serve-static": "1.14.1",
             "setprototypeof": "1.1.1",
-            "statuses": "~1.5.0",
-            "type-is": "~1.6.18",
+            "statuses": "1.5.0",
+            "type-is": "1.6.18",
             "utils-merge": "1.0.1",
-            "vary": "~1.1.2"
+            "vary": "1.1.2"
           },
           "dependencies": {
             "debug": {
@@ -8081,7 +8044,7 @@
           "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
           "dev": true,
           "requires": {
-            "type": "^2.0.0"
+            "type": "2.0.0"
           },
           "dependencies": {
             "type": {
@@ -8104,8 +8067,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -8114,7 +8077,7 @@
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "dev": true,
               "requires": {
-                "is-plain-object": "^2.0.4"
+                "is-plain-object": "2.0.4"
               }
             }
           }
@@ -8125,14 +8088,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -8141,7 +8104,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -8150,7 +8113,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -8159,7 +8122,7 @@
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.3"
               }
             },
             "is-data-descriptor": {
@@ -8168,7 +8131,7 @@
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.3"
               }
             },
             "is-descriptor": {
@@ -8177,9 +8140,9 @@
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.3"
               }
             }
           }
@@ -8196,7 +8159,7 @@
           "integrity": "sha1-S4w6z7Ugr635hgsfFM2M40As3dM=",
           "dev": true,
           "requires": {
-            "checkpoint-store": "^1.1.0"
+            "checkpoint-store": "1.1.0"
           }
         },
         "fancy-log": {
@@ -8205,10 +8168,10 @@
           "integrity": "sha512-k9oEhlyc0FrVh25qYuSELjr8oxsCoc4/LEZfg2iJJrfEk/tZL9bCoJE47gqAvI2m/AUjluCS4+3I0eTx8n3AEw==",
           "dev": true,
           "requires": {
-            "ansi-gray": "^0.1.1",
-            "color-support": "^1.1.3",
-            "parse-node-version": "^1.0.0",
-            "time-stamp": "^1.0.0"
+            "ansi-gray": "0.1.1",
+            "color-support": "1.1.3",
+            "parse-node-version": "1.0.1",
+            "time-stamp": "1.1.0"
           }
         },
         "fast-deep-equal": {
@@ -8230,7 +8193,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "pend": "~1.2.0"
+            "pend": "1.2.0"
           }
         },
         "fetch-ponyfill": {
@@ -8239,7 +8202,7 @@
           "integrity": "sha1-rjzl9zLGReq4fkroeTQUcJsjmJM=",
           "dev": true,
           "requires": {
-            "node-fetch": "~1.7.1"
+            "node-fetch": "1.7.3"
           },
           "dependencies": {
             "node-fetch": {
@@ -8248,8 +8211,8 @@
               "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
               "dev": true,
               "requires": {
-                "encoding": "^0.1.11",
-                "is-stream": "^1.0.1"
+                "encoding": "0.1.13",
+                "is-stream": "1.1.0"
               }
             }
           }
@@ -8258,8 +8221,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
           "integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "file-uri-to-path": {
           "version": "1.0.0",
@@ -8273,10 +8235,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -8285,7 +8247,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -8298,12 +8260,12 @@
           "optional": true,
           "requires": {
             "debug": "2.6.9",
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "on-finished": "~2.3.0",
-            "parseurl": "~1.3.3",
-            "statuses": "~1.5.0",
-            "unpipe": "~1.0.0"
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "on-finished": "2.3.0",
+            "parseurl": "1.3.3",
+            "statuses": "1.5.0",
+            "unpipe": "1.0.0"
           },
           "dependencies": {
             "debug": {
@@ -8331,8 +8293,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "findup-sync": {
@@ -8341,10 +8303,10 @@
           "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
           "dev": true,
           "requires": {
-            "detect-file": "^1.0.0",
-            "is-glob": "^4.0.0",
-            "micromatch": "^3.0.4",
-            "resolve-dir": "^1.0.1"
+            "detect-file": "1.0.0",
+            "is-glob": "4.0.1",
+            "micromatch": "3.1.10",
+            "resolve-dir": "1.0.1"
           }
         },
         "fined": {
@@ -8353,11 +8315,11 @@
           "integrity": "sha512-ZYDqPLGxDkDhDZBjZBb+oD1+j0rA4E0pXY50eplAAOPg2N/gUBSSk5IM1/QhPfyVo19lJ+CvXpqfvk+b2p/8Ng==",
           "dev": true,
           "requires": {
-            "expand-tilde": "^2.0.2",
-            "is-plain-object": "^2.0.3",
-            "object.defaults": "^1.1.0",
-            "object.pick": "^1.2.0",
-            "parse-filepath": "^1.0.1"
+            "expand-tilde": "2.0.2",
+            "is-plain-object": "2.0.4",
+            "object.defaults": "1.1.0",
+            "object.pick": "1.3.0",
+            "parse-filepath": "1.0.2"
           }
         },
         "flagged-respawn": {
@@ -8378,8 +8340,8 @@
           "integrity": "sha512-3Z4XhFZ3992uIq0XOqb9AreonueSYphE6oYbpt5+3u06JWklbsPkNv3ZKkP9Bz/r+1MWCaMoSQ28P85+1Yc77w==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.3.6"
+            "inherits": "2.0.4",
+            "readable-stream": "2.3.7"
           },
           "dependencies": {
             "isarray": {
@@ -8394,13 +8356,13 @@
               "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.1",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               }
             },
             "safe-buffer": {
@@ -8415,7 +8377,7 @@
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -8426,7 +8388,7 @@
           "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
           "dev": true,
           "requires": {
-            "is-callable": "^1.1.3"
+            "is-callable": "1.2.0"
           }
         },
         "for-in": {
@@ -8441,7 +8403,7 @@
           "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.1"
+            "for-in": "1.0.2"
           }
         },
         "forever-agent": {
@@ -8456,9 +8418,9 @@
           "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
           "dev": true,
           "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.8",
+            "mime-types": "2.1.27"
           }
         },
         "forwarded": {
@@ -8474,22 +8436,20 @@
           "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
           "dev": true,
           "requires": {
-            "map-cache": "^0.2.2"
+            "map-cache": "0.2.2"
           }
         },
         "fresh": {
           "version": "0.5.2",
           "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
           "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "fs-constants": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
           "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "fs-extra": {
           "version": "4.0.3",
@@ -8498,9 +8458,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "graceful-fs": "4.2.4",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.2"
           }
         },
         "fs-minipass": {
@@ -8510,7 +8470,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.6.0"
+            "minipass": "2.9.0"
           }
         },
         "fs-mkdirp-stream": {
@@ -8519,8 +8479,8 @@
           "integrity": "sha1-C3gV/DIBxqaeFNuYzgmMFpNSWes=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "through2": "^2.0.3"
+            "graceful-fs": "4.2.4",
+            "through2": "2.0.5"
           }
         },
         "fs.realpath": {
@@ -8536,8 +8496,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bindings": "^1.5.0",
-            "nan": "^2.12.1"
+            "bindings": "1.5.0",
+            "nan": "2.14.1"
           }
         },
         "function-bind": {
@@ -8565,7 +8525,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "pump": "^3.0.0"
+            "pump": "3.0.0"
           }
         },
         "get-value": {
@@ -8580,7 +8540,7 @@
           "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "requires": {
-            "assert-plus": "^1.0.0"
+            "assert-plus": "1.0.0"
           }
         },
         "glob": {
@@ -8589,12 +8549,12 @@
           "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.4",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "glob-parent": {
@@ -8603,8 +8563,8 @@
           "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
           "dev": true,
           "requires": {
-            "is-glob": "^3.1.0",
-            "path-dirname": "^1.0.0"
+            "is-glob": "3.1.0",
+            "path-dirname": "1.0.2"
           },
           "dependencies": {
             "is-glob": {
@@ -8613,7 +8573,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             }
           }
@@ -8624,16 +8584,16 @@
           "integrity": "sha1-cEXJlBOz65SIjYOrRtC0BMx73eQ=",
           "dev": true,
           "requires": {
-            "extend": "^3.0.0",
-            "glob": "^7.1.1",
-            "glob-parent": "^3.1.0",
-            "is-negated-glob": "^1.0.0",
-            "ordered-read-streams": "^1.0.0",
-            "pumpify": "^1.3.5",
-            "readable-stream": "^2.1.5",
-            "remove-trailing-separator": "^1.0.1",
-            "to-absolute-glob": "^2.0.0",
-            "unique-stream": "^2.0.2"
+            "extend": "3.0.2",
+            "glob": "7.1.6",
+            "glob-parent": "3.1.0",
+            "is-negated-glob": "1.0.0",
+            "ordered-read-streams": "1.0.1",
+            "pumpify": "1.5.1",
+            "readable-stream": "2.3.7",
+            "remove-trailing-separator": "1.1.0",
+            "to-absolute-glob": "2.0.2",
+            "unique-stream": "2.3.1"
           },
           "dependencies": {
             "isarray": {
@@ -8648,13 +8608,13 @@
               "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.1",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               }
             },
             "safe-buffer": {
@@ -8669,7 +8629,7 @@
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -8680,13 +8640,13 @@
           "integrity": "sha512-zOZgGGEHPklZNjZQaZ9f41i7F2YwE+tS5ZHrDhbBCk3stwahn5vQxnFmBJZHoYdusR6R1bLSXeGUy/BhctwKzw==",
           "dev": true,
           "requires": {
-            "anymatch": "^2.0.0",
-            "async-done": "^1.2.0",
-            "chokidar": "^2.0.0",
-            "is-negated-glob": "^1.0.0",
-            "just-debounce": "^1.0.0",
-            "normalize-path": "^3.0.0",
-            "object.defaults": "^1.1.0"
+            "anymatch": "2.0.0",
+            "async-done": "1.3.2",
+            "chokidar": "2.1.8",
+            "is-negated-glob": "1.0.0",
+            "just-debounce": "1.0.0",
+            "normalize-path": "3.0.0",
+            "object.defaults": "1.1.0"
           }
         },
         "global": {
@@ -8695,8 +8655,8 @@
           "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
           "dev": true,
           "requires": {
-            "min-document": "^2.19.0",
-            "process": "~0.5.1"
+            "min-document": "2.19.0",
+            "process": "0.5.2"
           }
         },
         "global-modules": {
@@ -8705,9 +8665,9 @@
           "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
           "dev": true,
           "requires": {
-            "global-prefix": "^1.0.1",
-            "is-windows": "^1.0.1",
-            "resolve-dir": "^1.0.0"
+            "global-prefix": "1.0.2",
+            "is-windows": "1.0.2",
+            "resolve-dir": "1.0.1"
           }
         },
         "global-prefix": {
@@ -8716,11 +8676,11 @@
           "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
           "dev": true,
           "requires": {
-            "expand-tilde": "^2.0.2",
-            "homedir-polyfill": "^1.0.1",
-            "ini": "^1.3.4",
-            "is-windows": "^1.0.1",
-            "which": "^1.2.14"
+            "expand-tilde": "2.0.2",
+            "homedir-polyfill": "1.0.3",
+            "ini": "1.3.5",
+            "is-windows": "1.0.2",
+            "which": "1.3.1"
           }
         },
         "globals": {
@@ -8735,7 +8695,7 @@
           "integrity": "sha512-5mwUoSuBk44Y4EshyiqcH95ZntbDdTQqA3QYSrxmzj28Ai0vXBGMH1ApSANH14j2sIRtqCEyg6PfsuP7ElOEDA==",
           "dev": true,
           "requires": {
-            "sparkles": "^1.0.0"
+            "sparkles": "1.0.1"
           }
         },
         "got": {
@@ -8745,17 +8705,17 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "@sindresorhus/is": "^0.14.0",
-            "@szmarczak/http-timer": "^1.1.2",
-            "cacheable-request": "^6.0.0",
-            "decompress-response": "^3.3.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^4.1.0",
-            "lowercase-keys": "^1.0.1",
-            "mimic-response": "^1.0.1",
-            "p-cancelable": "^1.0.0",
-            "to-readable-stream": "^1.0.0",
-            "url-parse-lax": "^3.0.0"
+            "@sindresorhus/is": "0.14.0",
+            "@szmarczak/http-timer": "1.1.2",
+            "cacheable-request": "6.1.0",
+            "decompress-response": "3.3.0",
+            "duplexer3": "0.1.4",
+            "get-stream": "4.1.0",
+            "lowercase-keys": "1.0.1",
+            "mimic-response": "1.0.1",
+            "p-cancelable": "1.1.0",
+            "to-readable-stream": "1.0.0",
+            "url-parse-lax": "3.0.0"
           }
         },
         "graceful-fs": {
@@ -8770,10 +8730,10 @@
           "integrity": "sha512-dvEs27SCZt2ibF29xYgmnwwCYZxdxhQ/+LFWlbAW8y7jt68L/65402Lz3+CKy0Ov4rOs+NERmDq7YlZaDqUIfA==",
           "dev": true,
           "requires": {
-            "glob-watcher": "^5.0.3",
-            "gulp-cli": "^2.2.0",
-            "undertaker": "^1.2.1",
-            "vinyl-fs": "^3.0.0"
+            "glob-watcher": "5.0.5",
+            "gulp-cli": "2.3.0",
+            "undertaker": "1.2.1",
+            "vinyl-fs": "3.0.3"
           },
           "dependencies": {
             "gulp-cli": {
@@ -8782,24 +8742,24 @@
               "integrity": "sha512-zzGBl5fHo0EKSXsHzjspp3y5CONegCm8ErO5Qh0UzFzk2y4tMvzLWhoDokADbarfZRL2pGpRp7yt6gfJX4ph7A==",
               "dev": true,
               "requires": {
-                "ansi-colors": "^1.0.1",
-                "archy": "^1.0.0",
-                "array-sort": "^1.0.0",
-                "color-support": "^1.1.3",
-                "concat-stream": "^1.6.0",
-                "copy-props": "^2.0.1",
-                "fancy-log": "^1.3.2",
-                "gulplog": "^1.0.0",
-                "interpret": "^1.4.0",
-                "isobject": "^3.0.1",
-                "liftoff": "^3.1.0",
-                "matchdep": "^2.0.0",
-                "mute-stdout": "^1.0.0",
-                "pretty-hrtime": "^1.0.0",
-                "replace-homedir": "^1.0.0",
-                "semver-greatest-satisfied-range": "^1.1.0",
-                "v8flags": "^3.2.0",
-                "yargs": "^7.1.0"
+                "ansi-colors": "1.1.0",
+                "archy": "1.0.0",
+                "array-sort": "1.0.0",
+                "color-support": "1.1.3",
+                "concat-stream": "1.6.2",
+                "copy-props": "2.0.4",
+                "fancy-log": "1.3.3",
+                "gulplog": "1.0.0",
+                "interpret": "1.4.0",
+                "isobject": "3.0.1",
+                "liftoff": "3.1.0",
+                "matchdep": "2.0.0",
+                "mute-stdout": "1.0.1",
+                "pretty-hrtime": "1.0.3",
+                "replace-homedir": "1.0.0",
+                "semver-greatest-satisfied-range": "1.1.0",
+                "v8flags": "3.2.0",
+                "yargs": "7.1.1"
               }
             }
           }
@@ -8810,7 +8770,7 @@
           "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
           "dev": true,
           "requires": {
-            "glogg": "^1.0.0"
+            "glogg": "1.0.2"
           }
         },
         "har-schema": {
@@ -8825,8 +8785,8 @@
           "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
           "dev": true,
           "requires": {
-            "ajv": "^6.12.3",
-            "har-schema": "^2.0.0"
+            "ajv": "6.12.3",
+            "har-schema": "2.0.0"
           }
         },
         "has": {
@@ -8835,7 +8795,7 @@
           "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
           "dev": true,
           "requires": {
-            "function-bind": "^1.1.1"
+            "function-bind": "1.1.1"
           }
         },
         "has-ansi": {
@@ -8844,7 +8804,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "has-symbol-support-x": {
@@ -8867,7 +8827,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "has-symbol-support-x": "^1.4.1"
+            "has-symbol-support-x": "1.4.2"
           }
         },
         "has-value": {
@@ -8876,9 +8836,9 @@
           "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.6",
-            "has-values": "^1.0.0",
-            "isobject": "^3.0.0"
+            "get-value": "2.0.6",
+            "has-values": "1.0.0",
+            "isobject": "3.0.1"
           }
         },
         "has-values": {
@@ -8887,8 +8847,8 @@
           "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
           "dev": true,
           "requires": {
-            "is-number": "^3.0.0",
-            "kind-of": "^4.0.0"
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
           },
           "dependencies": {
             "kind-of": {
@@ -8897,7 +8857,7 @@
               "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -8908,9 +8868,9 @@
           "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.4",
-            "readable-stream": "^3.6.0",
-            "safe-buffer": "^5.2.0"
+            "inherits": "2.0.4",
+            "readable-stream": "3.6.0",
+            "safe-buffer": "5.2.1"
           }
         },
         "hash.js": {
@@ -8919,8 +8879,8 @@
           "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.3",
-            "minimalistic-assert": "^1.0.1"
+            "inherits": "2.0.4",
+            "minimalistic-assert": "1.0.1"
           }
         },
         "hdkey": {
@@ -8930,9 +8890,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bs58check": "^2.1.2",
-            "safe-buffer": "^5.1.1",
-            "secp256k1": "^3.0.1"
+            "bs58check": "2.1.2",
+            "safe-buffer": "5.2.1",
+            "secp256k1": "3.8.0"
           },
           "dependencies": {
             "secp256k1": {
@@ -8942,14 +8902,14 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "bindings": "^1.5.0",
-                "bip66": "^1.1.5",
-                "bn.js": "^4.11.8",
-                "create-hash": "^1.2.0",
-                "drbg.js": "^1.0.1",
-                "elliptic": "^6.5.2",
-                "nan": "^2.14.0",
-                "safe-buffer": "^5.1.2"
+                "bindings": "1.5.0",
+                "bip66": "1.1.5",
+                "bn.js": "4.11.9",
+                "create-hash": "1.2.0",
+                "drbg.js": "1.0.1",
+                "elliptic": "6.5.3",
+                "nan": "2.14.1",
+                "safe-buffer": "5.2.1"
               }
             }
           }
@@ -8966,9 +8926,9 @@
           "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
           "dev": true,
           "requires": {
-            "hash.js": "^1.0.3",
-            "minimalistic-assert": "^1.0.0",
-            "minimalistic-crypto-utils": "^1.0.1"
+            "hash.js": "1.1.7",
+            "minimalistic-assert": "1.0.1",
+            "minimalistic-crypto-utils": "1.0.1"
           }
         },
         "home-or-tmp": {
@@ -8977,8 +8937,8 @@
           "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
           "dev": true,
           "requires": {
-            "os-homedir": "^1.0.0",
-            "os-tmpdir": "^1.0.1"
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
           }
         },
         "homedir-polyfill": {
@@ -8987,7 +8947,7 @@
           "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
           "dev": true,
           "requires": {
-            "parse-passwd": "^1.0.0"
+            "parse-passwd": "1.0.0"
           }
         },
         "hosted-git-info": {
@@ -9008,12 +8968,11 @@
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
           "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "depd": "~1.1.2",
+            "depd": "1.1.2",
             "inherits": "2.0.3",
             "setprototypeof": "1.1.1",
-            "statuses": ">= 1.5.0 < 2",
+            "statuses": "1.5.0",
             "toidentifier": "1.0.0"
           },
           "dependencies": {
@@ -9021,8 +8980,7 @@
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -9030,8 +8988,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/http-https/-/http-https-1.0.0.tgz",
           "integrity": "sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "http-signature": {
           "version": "1.2.0",
@@ -9039,9 +8996,9 @@
           "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "dev": true,
           "requires": {
-            "assert-plus": "^1.0.0",
-            "jsprim": "^1.2.2",
-            "sshpk": "^1.7.0"
+            "assert-plus": "1.0.0",
+            "jsprim": "1.4.1",
+            "sshpk": "1.16.1"
           }
         },
         "iconv-lite": {
@@ -9049,9 +9006,8 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
+            "safer-buffer": "2.1.2"
           }
         },
         "idna-uts46-hx": {
@@ -9091,8 +9047,8 @@
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -9119,7 +9075,7 @@
           "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
           "dev": true,
           "requires": {
-            "loose-envify": "^1.0.0"
+            "loose-envify": "1.4.0"
           }
         },
         "invert-kv": {
@@ -9141,8 +9097,8 @@
           "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
           "dev": true,
           "requires": {
-            "is-relative": "^1.0.0",
-            "is-windows": "^1.0.1"
+            "is-relative": "1.0.0",
+            "is-windows": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -9151,7 +9107,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -9160,7 +9116,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -9183,7 +9139,7 @@
           "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
           "dev": true,
           "requires": {
-            "binary-extensions": "^1.0.0"
+            "binary-extensions": "1.13.1"
           }
         },
         "is-buffer": {
@@ -9204,7 +9160,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -9213,7 +9169,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -9230,9 +9186,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           },
           "dependencies": {
             "kind-of": {
@@ -9273,7 +9229,7 @@
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-function": {
@@ -9288,7 +9244,7 @@
           "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
           "dev": true,
           "requires": {
-            "is-extglob": "^2.1.1"
+            "is-extglob": "2.1.1"
           }
         },
         "is-hex-prefixed": {
@@ -9316,7 +9272,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -9325,7 +9281,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -9350,7 +9306,7 @@
           "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
           "dev": true,
           "requires": {
-            "isobject": "^3.0.1"
+            "isobject": "3.0.1"
           }
         },
         "is-regex": {
@@ -9359,7 +9315,7 @@
           "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
           "dev": true,
           "requires": {
-            "has-symbols": "^1.0.1"
+            "has-symbols": "1.0.1"
           }
         },
         "is-relative": {
@@ -9368,7 +9324,7 @@
           "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
           "dev": true,
           "requires": {
-            "is-unc-path": "^1.0.0"
+            "is-unc-path": "1.0.0"
           }
         },
         "is-retry-allowed": {
@@ -9390,7 +9346,7 @@
           "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
           "dev": true,
           "requires": {
-            "has-symbols": "^1.0.1"
+            "has-symbols": "1.0.1"
           }
         },
         "is-typedarray": {
@@ -9405,7 +9361,7 @@
           "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
           "dev": true,
           "requires": {
-            "unc-path-regex": "^0.1.2"
+            "unc-path-regex": "0.1.2"
           }
         },
         "is-utf8": {
@@ -9457,16 +9413,15 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "has-to-string-tag-x": "^1.2.0",
-            "is-object": "^1.0.1"
+            "has-to-string-tag-x": "1.4.1",
+            "is-object": "1.0.1"
           }
         },
         "js-sha3": {
           "version": "0.8.0",
           "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
           "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "js-tokens": {
           "version": "3.0.2",
@@ -9499,12 +9454,12 @@
           "integrity": "sha512-6QNcvm2gFuuK4TKU1uwfH0Qd/cOSb9c1lls0gbnIhciktIUQJwz6NQNAW4B1KiGPenv7IKu97V222Yo1bNhGuA==",
           "dev": true,
           "requires": {
-            "async": "^2.0.1",
-            "babel-preset-env": "^1.7.0",
-            "babelify": "^7.3.0",
-            "json-rpc-error": "^2.0.0",
-            "promise-to-callback": "^1.0.0",
-            "safe-event-emitter": "^1.0.1"
+            "async": "2.6.2",
+            "babel-preset-env": "1.7.0",
+            "babelify": "7.3.0",
+            "json-rpc-error": "2.0.0",
+            "promise-to-callback": "1.0.0",
+            "safe-event-emitter": "1.0.1"
           }
         },
         "json-rpc-error": {
@@ -9513,7 +9468,7 @@
           "integrity": "sha1-p6+cICg4tekFxyUOVH8a/3cligI=",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.1"
+            "inherits": "2.0.4"
           }
         },
         "json-rpc-random-id": {
@@ -9540,7 +9495,7 @@
           "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "requires": {
-            "jsonify": "~0.0.0"
+            "jsonify": "0.0.0"
           }
         },
         "json-stable-stringify-without-jsonify": {
@@ -9568,7 +9523,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.2.4"
           }
         },
         "jsonify": {
@@ -9601,8 +9556,8 @@
           "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
           "dev": true,
           "requires": {
-            "node-addon-api": "^2.0.0",
-            "node-gyp-build": "^4.2.0"
+            "node-addon-api": "2.0.2",
+            "node-gyp-build": "4.2.3"
           }
         },
         "keyv": {
@@ -9627,8 +9582,8 @@
           "integrity": "sha1-RblpQsF7HHnHchmCWbqUO+v4yls=",
           "dev": true,
           "requires": {
-            "default-resolution": "^2.0.0",
-            "es6-weak-map": "^2.0.1"
+            "default-resolution": "2.0.0",
+            "es6-weak-map": "2.0.3"
           }
         },
         "lazystream": {
@@ -9637,7 +9592,7 @@
           "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.0.5"
+            "readable-stream": "2.3.7"
           },
           "dependencies": {
             "isarray": {
@@ -9652,13 +9607,13 @@
               "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.1",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               }
             },
             "safe-buffer": {
@@ -9673,7 +9628,7 @@
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -9684,7 +9639,7 @@
           "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "dev": true,
           "requires": {
-            "invert-kv": "^1.0.0"
+            "invert-kv": "1.0.0"
           }
         },
         "lead": {
@@ -9693,7 +9648,7 @@
           "integrity": "sha1-bxT5mje+Op3XhPVJVpDlkDRm7kI=",
           "dev": true,
           "requires": {
-            "flush-write-stream": "^1.0.2"
+            "flush-write-stream": "1.1.1"
           }
         },
         "level-codec": {
@@ -9702,7 +9657,7 @@
           "integrity": "sha512-UyIwNb1lJBChJnGfjmO0OR+ezh2iVu1Kas3nvBS/BzGnx79dv6g7unpKIDNPMhfdTEGoc7mC8uAu51XEtX+FHQ==",
           "dev": true,
           "requires": {
-            "buffer": "^5.6.0"
+            "buffer": "5.6.0"
           }
         },
         "level-errors": {
@@ -9711,7 +9666,7 @@
           "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
           "dev": true,
           "requires": {
-            "errno": "~0.1.1"
+            "errno": "0.1.7"
           }
         },
         "level-iterator-stream": {
@@ -9720,10 +9675,10 @@
           "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "level-errors": "^1.0.3",
-            "readable-stream": "^1.0.33",
-            "xtend": "^4.0.0"
+            "inherits": "2.0.4",
+            "level-errors": "1.1.2",
+            "readable-stream": "1.1.14",
+            "xtend": "4.0.2"
           },
           "dependencies": {
             "level-errors": {
@@ -9732,7 +9687,7 @@
               "integrity": "sha512-Sw/IJwWbPKF5Ai4Wz60B52yj0zYeqzObLh8k1Tk88jVmD51cJSKWSYpRyhVIvFzZdvsPqlH5wfhp/yxdsaQH4w==",
               "dev": true,
               "requires": {
-                "errno": "~0.1.1"
+                "errno": "0.1.7"
               }
             },
             "readable-stream": {
@@ -9741,10 +9696,10 @@
               "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             },
             "string_decoder": {
@@ -9761,8 +9716,8 @@
           "integrity": "sha512-LbtfK9+3Ug1UmvvhR2DqLqXiPW1OJ5jEh0a3m9ZgAipiwpSxGj/qaVVy54RG5vAQN1nCuXqjvprCuKSCxcJHBg==",
           "dev": true,
           "requires": {
-            "level-packager": "~4.0.0",
-            "memdown": "~3.0.0"
+            "level-packager": "4.0.1",
+            "memdown": "3.0.0"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -9771,7 +9726,7 @@
               "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
               "dev": true,
               "requires": {
-                "xtend": "~4.0.0"
+                "xtend": "4.0.2"
               }
             },
             "immediate": {
@@ -9786,12 +9741,12 @@
               "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
               "dev": true,
               "requires": {
-                "abstract-leveldown": "~5.0.0",
-                "functional-red-black-tree": "~1.0.1",
-                "immediate": "~3.2.3",
-                "inherits": "~2.0.1",
-                "ltgt": "~2.2.0",
-                "safe-buffer": "~5.1.1"
+                "abstract-leveldown": "5.0.0",
+                "functional-red-black-tree": "1.0.1",
+                "immediate": "3.2.3",
+                "inherits": "2.0.4",
+                "ltgt": "2.2.1",
+                "safe-buffer": "5.1.2"
               }
             },
             "safe-buffer": {
@@ -9808,8 +9763,8 @@
           "integrity": "sha512-svCRKfYLn9/4CoFfi+d8krOtrp6RoX8+xm0Na5cgXMqSyRru0AnDYdLl+YI8u1FyS6gGZ94ILLZDE5dh2but3Q==",
           "dev": true,
           "requires": {
-            "encoding-down": "~5.0.0",
-            "levelup": "^3.0.0"
+            "encoding-down": "5.0.4",
+            "levelup": "3.1.1"
           }
         },
         "level-post": {
@@ -9818,7 +9773,7 @@
           "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
           "dev": true,
           "requires": {
-            "ltgt": "^2.1.2"
+            "ltgt": "2.2.1"
           }
         },
         "level-sublevel": {
@@ -9827,16 +9782,16 @@
           "integrity": "sha512-pcCrTUOiO48+Kp6F1+UAzF/OtWqLcQVTVF39HLdZ3RO8XBoXt+XVPKZO1vVr1aUoxHZA9OtD2e1v7G+3S5KFDA==",
           "dev": true,
           "requires": {
-            "bytewise": "~1.1.0",
-            "level-codec": "^9.0.0",
-            "level-errors": "^2.0.0",
-            "level-iterator-stream": "^2.0.3",
-            "ltgt": "~2.1.1",
-            "pull-defer": "^0.2.2",
-            "pull-level": "^2.0.3",
-            "pull-stream": "^3.6.8",
-            "typewiselite": "~1.0.0",
-            "xtend": "~4.0.0"
+            "bytewise": "1.1.0",
+            "level-codec": "9.0.2",
+            "level-errors": "2.0.1",
+            "level-iterator-stream": "2.0.3",
+            "ltgt": "2.1.3",
+            "pull-defer": "0.2.3",
+            "pull-level": "2.0.4",
+            "pull-stream": "3.6.14",
+            "typewiselite": "1.0.0",
+            "xtend": "4.0.2"
           },
           "dependencies": {
             "isarray": {
@@ -9851,9 +9806,9 @@
               "integrity": "sha512-I6Heg70nfF+e5Y3/qfthJFexhRw/Gi3bIymCoXAlijZdAcLaPuWSJs3KXyTYf23ID6g0o2QF62Yh+grOXY3Rig==",
               "dev": true,
               "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.0.5",
-                "xtend": "^4.0.0"
+                "inherits": "2.0.4",
+                "readable-stream": "2.3.7",
+                "xtend": "4.0.2"
               }
             },
             "ltgt": {
@@ -9868,13 +9823,13 @@
               "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.1",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               }
             },
             "safe-buffer": {
@@ -9889,7 +9844,7 @@
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -9900,8 +9855,8 @@
           "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
           "dev": true,
           "requires": {
-            "readable-stream": "~1.0.15",
-            "xtend": "~2.1.1"
+            "readable-stream": "1.0.34",
+            "xtend": "2.1.2"
           },
           "dependencies": {
             "readable-stream": {
@@ -9910,10 +9865,10 @@
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             },
             "string_decoder": {
@@ -9928,7 +9883,7 @@
               "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
               "dev": true,
               "requires": {
-                "object-keys": "~0.4.0"
+                "object-keys": "0.4.0"
               }
             }
           }
@@ -9939,10 +9894,10 @@
           "integrity": "sha512-9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==",
           "dev": true,
           "requires": {
-            "deferred-leveldown": "~4.0.0",
-            "level-errors": "~2.0.0",
-            "level-iterator-stream": "~3.0.0",
-            "xtend": "~4.0.0"
+            "deferred-leveldown": "4.0.2",
+            "level-errors": "2.0.1",
+            "level-iterator-stream": "3.0.1",
+            "xtend": "4.0.2"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -9951,7 +9906,7 @@
               "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
               "dev": true,
               "requires": {
-                "xtend": "~4.0.0"
+                "xtend": "4.0.2"
               }
             },
             "deferred-leveldown": {
@@ -9960,8 +9915,8 @@
               "integrity": "sha512-5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==",
               "dev": true,
               "requires": {
-                "abstract-leveldown": "~5.0.0",
-                "inherits": "^2.0.3"
+                "abstract-leveldown": "5.0.0",
+                "inherits": "2.0.4"
               }
             },
             "isarray": {
@@ -9976,9 +9931,9 @@
               "integrity": "sha512-nEIQvxEED9yRThxvOrq8Aqziy4EGzrxSZK+QzEFAVuJvQ8glfyZ96GB6BoI4sBbLfjMXm2w4vu3Tkcm9obcY0g==",
               "dev": true,
               "requires": {
-                "inherits": "^2.0.1",
-                "readable-stream": "^2.3.6",
-                "xtend": "^4.0.0"
+                "inherits": "2.0.4",
+                "readable-stream": "2.3.7",
+                "xtend": "4.0.2"
               }
             },
             "readable-stream": {
@@ -9987,13 +9942,13 @@
               "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.1",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               }
             },
             "safe-buffer": {
@@ -10008,7 +9963,7 @@
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -10019,14 +9974,14 @@
           "integrity": "sha512-DlIPlJUkCV0Ips2zf2pJP0unEoT1kwYhiiPUGF3s/jtxTCjziNLoiVVh+jqWOWeFi6mmwQ5fNxvAUyPad4Dfog==",
           "dev": true,
           "requires": {
-            "extend": "^3.0.0",
-            "findup-sync": "^3.0.0",
-            "fined": "^1.0.1",
-            "flagged-respawn": "^1.0.0",
-            "is-plain-object": "^2.0.4",
-            "object.map": "^1.0.0",
-            "rechoir": "^0.6.2",
-            "resolve": "^1.1.7"
+            "extend": "3.0.2",
+            "findup-sync": "3.0.0",
+            "fined": "1.2.0",
+            "flagged-respawn": "1.0.1",
+            "is-plain-object": "2.0.4",
+            "object.map": "1.0.1",
+            "rechoir": "0.6.2",
+            "resolve": "1.17.0"
           }
         },
         "load-json-file": {
@@ -10035,11 +9990,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.2.4",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           },
           "dependencies": {
             "pify": {
@@ -10068,15 +10023,14 @@
           "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
           "dev": true,
           "requires": {
-            "js-tokens": "^3.0.0 || ^4.0.0"
+            "js-tokens": "3.0.2"
           }
         },
         "lowercase-keys": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
           "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "5.1.1",
@@ -10084,7 +10038,7 @@
           "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "dev": true,
           "requires": {
-            "yallist": "^3.0.2"
+            "yallist": "3.1.1"
           }
         },
         "ltgt": {
@@ -10100,7 +10054,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "pify": "^3.0.0"
+            "pify": "3.0.0"
           },
           "dependencies": {
             "pify": {
@@ -10118,7 +10072,7 @@
           "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.2"
+            "kind-of": "6.0.3"
           }
         },
         "map-cache": {
@@ -10133,7 +10087,7 @@
           "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
           "dev": true,
           "requires": {
-            "object-visit": "^1.0.0"
+            "object-visit": "1.0.1"
           }
         },
         "matchdep": {
@@ -10142,9 +10096,9 @@
           "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
           "dev": true,
           "requires": {
-            "findup-sync": "^2.0.0",
-            "micromatch": "^3.0.4",
-            "resolve": "^1.4.0",
+            "findup-sync": "2.0.0",
+            "micromatch": "3.1.10",
+            "resolve": "1.17.0",
             "stack-trace": "0.0.10"
           },
           "dependencies": {
@@ -10154,10 +10108,10 @@
               "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
               "dev": true,
               "requires": {
-                "detect-file": "^1.0.0",
-                "is-glob": "^3.1.0",
-                "micromatch": "^3.0.4",
-                "resolve-dir": "^1.0.1"
+                "detect-file": "1.0.0",
+                "is-glob": "3.1.0",
+                "micromatch": "3.1.10",
+                "resolve-dir": "1.0.1"
               }
             },
             "is-glob": {
@@ -10166,7 +10120,7 @@
               "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
               "dev": true,
               "requires": {
-                "is-extglob": "^2.1.0"
+                "is-extglob": "2.1.1"
               }
             }
           }
@@ -10177,17 +10131,16 @@
           "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
           "dev": true,
           "requires": {
-            "hash-base": "^3.0.0",
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.1.2"
+            "hash-base": "3.1.0",
+            "inherits": "2.0.4",
+            "safe-buffer": "5.2.1"
           }
         },
         "media-typer": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
           "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "merge-descriptors": {
           "version": "1.0.1",
@@ -10202,14 +10155,14 @@
           "integrity": "sha512-81PW5m8oz/pz3GvsAwbauj7Y00rqm81Tzad77tHBwU7pIAtN+TJnMSOJhxBKflSVYhptMMb9RskhqHqrSm1V+g==",
           "dev": true,
           "requires": {
-            "async": "^1.4.2",
-            "ethereumjs-util": "^5.0.0",
+            "async": "1.5.2",
+            "ethereumjs-util": "5.2.1",
             "level-ws": "0.0.0",
-            "levelup": "^1.2.1",
-            "memdown": "^1.0.0",
-            "readable-stream": "^2.0.0",
-            "rlp": "^2.0.0",
-            "semaphore": ">=1.0.1"
+            "levelup": "1.3.9",
+            "memdown": "1.4.1",
+            "readable-stream": "2.3.7",
+            "rlp": "2.2.6",
+            "semaphore": "1.1.0"
           },
           "dependencies": {
             "abstract-leveldown": {
@@ -10218,7 +10171,7 @@
               "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
               "dev": true,
               "requires": {
-                "xtend": "~4.0.0"
+                "xtend": "4.0.2"
               }
             },
             "async": {
@@ -10233,13 +10186,13 @@
               "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
-                "ethjs-util": "^0.1.3",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
+                "bn.js": "4.11.9",
+                "create-hash": "1.2.0",
+                "elliptic": "6.5.3",
+                "ethereum-cryptography": "0.1.3",
+                "ethjs-util": "0.1.6",
+                "rlp": "2.2.6",
+                "safe-buffer": "5.2.1"
               }
             },
             "isarray": {
@@ -10260,7 +10213,7 @@
               "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
               "dev": true,
               "requires": {
-                "errno": "~0.1.1"
+                "errno": "0.1.7"
               }
             },
             "levelup": {
@@ -10269,13 +10222,13 @@
               "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
               "dev": true,
               "requires": {
-                "deferred-leveldown": "~1.2.1",
-                "level-codec": "~7.0.0",
-                "level-errors": "~1.0.3",
-                "level-iterator-stream": "~1.3.0",
-                "prr": "~1.0.1",
-                "semver": "~5.4.1",
-                "xtend": "~4.0.0"
+                "deferred-leveldown": "1.2.2",
+                "level-codec": "7.0.1",
+                "level-errors": "1.0.5",
+                "level-iterator-stream": "1.3.1",
+                "prr": "1.0.1",
+                "semver": "5.4.1",
+                "xtend": "4.0.2"
               }
             },
             "memdown": {
@@ -10284,12 +10237,12 @@
               "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
               "dev": true,
               "requires": {
-                "abstract-leveldown": "~2.7.1",
-                "functional-red-black-tree": "^1.0.1",
-                "immediate": "^3.2.3",
-                "inherits": "~2.0.1",
-                "ltgt": "~2.2.0",
-                "safe-buffer": "~5.1.1"
+                "abstract-leveldown": "2.7.2",
+                "functional-red-black-tree": "1.0.1",
+                "immediate": "3.3.0",
+                "inherits": "2.0.4",
+                "ltgt": "2.2.1",
+                "safe-buffer": "5.1.2"
               },
               "dependencies": {
                 "safe-buffer": {
@@ -10306,13 +10259,13 @@
               "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.1",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               },
               "dependencies": {
                 "safe-buffer": {
@@ -10335,7 +10288,7 @@
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
               },
               "dependencies": {
                 "safe-buffer": {
@@ -10361,19 +10314,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.3",
+            "nanomatch": "1.2.13",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "miller-rabin": {
@@ -10382,16 +10335,15 @@
           "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
           "dev": true,
           "requires": {
-            "bn.js": "^4.0.0",
-            "brorand": "^1.0.1"
+            "bn.js": "4.11.9",
+            "brorand": "1.1.0"
           }
         },
         "mime": {
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
           "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "mime-db": {
           "version": "1.44.0",
@@ -10412,8 +10364,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
           "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "min-document": {
           "version": "2.19.0",
@@ -10421,7 +10372,7 @@
           "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
           "dev": true,
           "requires": {
-            "dom-walk": "^0.1.0"
+            "dom-walk": "0.1.2"
           }
         },
         "minimalistic-assert": {
@@ -10442,7 +10393,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -10456,10 +10407,9 @@
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.0"
+            "safe-buffer": "5.2.1",
+            "yallist": "3.1.1"
           }
         },
         "minizlib": {
@@ -10469,7 +10419,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "minipass": "^2.9.0"
+            "minipass": "2.9.0"
           }
         },
         "mixin-deep": {
@@ -10478,8 +10428,8 @@
           "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.2",
-            "is-extendable": "^1.0.1"
+            "for-in": "1.0.2",
+            "is-extendable": "1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -10488,7 +10438,7 @@
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "dev": true,
               "requires": {
-                "is-plain-object": "^2.0.4"
+                "is-plain-object": "2.0.4"
               }
             }
           }
@@ -10507,7 +10457,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "mkdirp": "*"
+            "mkdirp": "1.0.4"
           }
         },
         "mock-fs": {
@@ -10548,17 +10498,17 @@
           "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "fragment-cache": "^0.2.1",
-            "is-windows": "^1.0.2",
-            "kind-of": "^6.0.2",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "fragment-cache": "0.2.1",
+            "is-windows": "1.0.2",
+            "kind-of": "6.0.3",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           }
         },
         "negotiator": {
@@ -10598,10 +10548,10 @@
           "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
           "dev": true,
           "requires": {
-            "hosted-git-info": "^2.1.4",
-            "resolve": "^1.10.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
+            "hosted-git-info": "2.8.8",
+            "resolve": "1.17.0",
+            "semver": "5.7.1",
+            "validate-npm-package-license": "3.0.4"
           },
           "dependencies": {
             "semver": {
@@ -10631,7 +10581,7 @@
           "integrity": "sha512-KGvQ0cB70AQfg107Xvs/Fbu+dGmZoTRJp2TaPwcwQm3/7PteUyN2BCgk8KBMPGBUXZdVwyWS8fDCGFygBm19UQ==",
           "dev": true,
           "requires": {
-            "once": "^1.3.2"
+            "once": "1.4.0"
           }
         },
         "number-is-nan": {
@@ -10645,7 +10595,6 @@
           "resolved": "https://registry.npmjs.org/number-to-bn/-/number-to-bn-1.7.0.tgz",
           "integrity": "sha1-uzYjWS9+X54AMLGXe9QaDFP+HqA=",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.6",
             "strip-hex-prefix": "1.0.0"
@@ -10655,8 +10604,7 @@
               "version": "4.11.6",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
               "integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -10678,9 +10626,9 @@
           "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
           "dev": true,
           "requires": {
-            "copy-descriptor": "^0.1.0",
-            "define-property": "^0.2.5",
-            "kind-of": "^3.0.3"
+            "copy-descriptor": "0.1.1",
+            "define-property": "0.2.5",
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "define-property": {
@@ -10689,7 +10637,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "kind-of": {
@@ -10698,7 +10646,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -10715,8 +10663,8 @@
           "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
           "dev": true,
           "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.5"
+            "define-properties": "1.1.3",
+            "es-abstract": "1.17.6"
           }
         },
         "object-keys": {
@@ -10731,7 +10679,7 @@
           "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
           "dev": true,
           "requires": {
-            "isobject": "^3.0.0"
+            "isobject": "3.0.1"
           }
         },
         "object.assign": {
@@ -10740,10 +10688,10 @@
           "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
           "dev": true,
           "requires": {
-            "define-properties": "^1.1.2",
-            "function-bind": "^1.1.1",
-            "has-symbols": "^1.0.0",
-            "object-keys": "^1.0.11"
+            "define-properties": "1.1.3",
+            "function-bind": "1.1.1",
+            "has-symbols": "1.0.1",
+            "object-keys": "1.1.1"
           },
           "dependencies": {
             "object-keys": {
@@ -10760,10 +10708,10 @@
           "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
           "dev": true,
           "requires": {
-            "array-each": "^1.0.1",
-            "array-slice": "^1.0.0",
-            "for-own": "^1.0.0",
-            "isobject": "^3.0.0"
+            "array-each": "1.0.1",
+            "array-slice": "1.1.0",
+            "for-own": "1.0.0",
+            "isobject": "3.0.1"
           }
         },
         "object.getownpropertydescriptors": {
@@ -10772,8 +10720,8 @@
           "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
           "dev": true,
           "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.0-next.1"
+            "define-properties": "1.1.3",
+            "es-abstract": "1.17.6"
           }
         },
         "object.map": {
@@ -10782,8 +10730,8 @@
           "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
           "dev": true,
           "requires": {
-            "for-own": "^1.0.0",
-            "make-iterator": "^1.0.0"
+            "for-own": "1.0.0",
+            "make-iterator": "1.0.1"
           }
         },
         "object.pick": {
@@ -10792,7 +10740,7 @@
           "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
           "dev": true,
           "requires": {
-            "isobject": "^3.0.1"
+            "isobject": "3.0.1"
           }
         },
         "object.reduce": {
@@ -10801,8 +10749,8 @@
           "integrity": "sha1-b+NI8qx/oPlcpiEiZZkJaCW7A60=",
           "dev": true,
           "requires": {
-            "for-own": "^1.0.0",
-            "make-iterator": "^1.0.0"
+            "for-own": "1.0.0",
+            "make-iterator": "1.0.1"
           }
         },
         "oboe": {
@@ -10810,9 +10758,8 @@
           "resolved": "https://registry.npmjs.org/oboe/-/oboe-2.1.4.tgz",
           "integrity": "sha1-IMiM2wwVNxuwQRklfU/dNLCqSfY=",
           "dev": true,
-          "optional": true,
           "requires": {
-            "http-https": "^1.0.0"
+            "http-https": "1.0.0"
           }
         },
         "on-finished": {
@@ -10820,7 +10767,6 @@
           "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
           "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ee-first": "1.1.1"
           }
@@ -10831,7 +10777,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "ordered-read-streams": {
@@ -10840,7 +10786,7 @@
           "integrity": "sha1-d8DLN8QVJdZBZtmQ/61+xqDhNj4=",
           "dev": true,
           "requires": {
-            "readable-stream": "^2.0.1"
+            "readable-stream": "2.3.7"
           },
           "dependencies": {
             "isarray": {
@@ -10855,13 +10801,13 @@
               "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.1",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               }
             },
             "safe-buffer": {
@@ -10876,7 +10822,7 @@
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -10893,7 +10839,7 @@
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
           "dev": true,
           "requires": {
-            "lcid": "^1.0.0"
+            "lcid": "1.0.0"
           }
         },
         "os-tmpdir": {
@@ -10923,7 +10869,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "p-finally": "^1.0.0"
+            "p-finally": "1.0.0"
           }
         },
         "parse-asn1": {
@@ -10931,14 +10877,13 @@
           "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
           "integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "asn1.js": "^4.0.0",
-            "browserify-aes": "^1.0.0",
-            "create-hash": "^1.1.0",
-            "evp_bytestokey": "^1.0.0",
-            "pbkdf2": "^3.0.3",
-            "safe-buffer": "^5.1.1"
+            "asn1.js": "4.10.1",
+            "browserify-aes": "1.2.0",
+            "create-hash": "1.2.0",
+            "evp_bytestokey": "1.0.3",
+            "pbkdf2": "3.1.1",
+            "safe-buffer": "5.2.1"
           }
         },
         "parse-filepath": {
@@ -10947,9 +10892,9 @@
           "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
           "dev": true,
           "requires": {
-            "is-absolute": "^1.0.0",
-            "map-cache": "^0.2.0",
-            "path-root": "^0.1.1"
+            "is-absolute": "1.0.0",
+            "map-cache": "0.2.2",
+            "path-root": "0.1.1"
           }
         },
         "parse-headers": {
@@ -10964,7 +10909,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.2"
           }
         },
         "parse-node-version": {
@@ -10983,8 +10928,7 @@
           "version": "1.3.3",
           "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
           "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "pascalcase": {
           "version": "0.1.1",
@@ -11004,7 +10948,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-is-absolute": {
@@ -11025,7 +10969,7 @@
           "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
           "dev": true,
           "requires": {
-            "path-root-regex": "^0.1.0"
+            "path-root-regex": "0.1.2"
           }
         },
         "path-root-regex": {
@@ -11047,9 +10991,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.2.4",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           },
           "dependencies": {
             "pify": {
@@ -11066,11 +11010,11 @@
           "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
           "dev": true,
           "requires": {
-            "create-hash": "^1.1.2",
-            "create-hmac": "^1.1.4",
-            "ripemd160": "^2.0.1",
-            "safe-buffer": "^5.0.1",
-            "sha.js": "^2.4.8"
+            "create-hash": "1.2.0",
+            "create-hmac": "1.1.7",
+            "ripemd160": "2.0.2",
+            "safe-buffer": "5.2.1",
+            "sha.js": "2.4.11"
           }
         },
         "pend": {
@@ -11098,7 +11042,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "^2.0.0"
+            "pinkie": "2.0.4"
           }
         },
         "posix-character-classes": {
@@ -11150,8 +11094,8 @@
           "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
           "dev": true,
           "requires": {
-            "is-fn": "^1.0.0",
-            "set-immediate-shim": "^1.0.1"
+            "is-fn": "1.0.0",
+            "set-immediate-shim": "1.0.1"
           }
         },
         "proxy-addr": {
@@ -11161,7 +11105,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "forwarded": "~0.1.2",
+            "forwarded": "0.1.2",
             "ipaddr.js": "1.9.1"
           }
         },
@@ -11190,12 +11134,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bn.js": "^4.1.0",
-            "browserify-rsa": "^4.0.0",
-            "create-hash": "^1.1.0",
-            "parse-asn1": "^5.0.0",
-            "randombytes": "^2.0.1",
-            "safe-buffer": "^5.1.2"
+            "bn.js": "4.11.9",
+            "browserify-rsa": "4.0.1",
+            "create-hash": "1.2.0",
+            "parse-asn1": "5.1.5",
+            "randombytes": "2.1.0",
+            "safe-buffer": "5.2.1"
           }
         },
         "pull-cat": {
@@ -11216,13 +11160,13 @@
           "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
           "dev": true,
           "requires": {
-            "level-post": "^1.0.7",
-            "pull-cat": "^1.1.9",
-            "pull-live": "^1.0.1",
-            "pull-pushable": "^2.0.0",
-            "pull-stream": "^3.4.0",
-            "pull-window": "^2.1.4",
-            "stream-to-pull-stream": "^1.7.1"
+            "level-post": "1.0.7",
+            "pull-cat": "1.1.11",
+            "pull-live": "1.0.1",
+            "pull-pushable": "2.2.0",
+            "pull-stream": "3.6.14",
+            "pull-window": "2.1.4",
+            "stream-to-pull-stream": "1.7.3"
           }
         },
         "pull-live": {
@@ -11231,8 +11175,8 @@
           "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
           "dev": true,
           "requires": {
-            "pull-cat": "^1.1.9",
-            "pull-stream": "^3.4.0"
+            "pull-cat": "1.1.11",
+            "pull-stream": "3.6.14"
           }
         },
         "pull-pushable": {
@@ -11253,7 +11197,7 @@
           "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
           "dev": true,
           "requires": {
-            "looper": "^2.0.0"
+            "looper": "2.0.0"
           }
         },
         "pump": {
@@ -11261,10 +11205,9 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.4",
+            "once": "1.4.0"
           }
         },
         "pumpify": {
@@ -11273,9 +11216,9 @@
           "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
           "dev": true,
           "requires": {
-            "duplexify": "^3.6.0",
-            "inherits": "^2.0.3",
-            "pump": "^2.0.0"
+            "duplexify": "3.7.1",
+            "inherits": "2.0.4",
+            "pump": "2.0.1"
           },
           "dependencies": {
             "pump": {
@@ -11284,8 +11227,8 @@
               "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
               "dev": true,
               "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
+                "end-of-stream": "1.4.4",
+                "once": "1.4.0"
               }
             }
           }
@@ -11300,19 +11243,17 @@
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
           "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "query-string": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
           "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "decode-uri-component": "^0.2.0",
-            "object-assign": "^4.1.0",
-            "strict-uri-encode": "^1.0.0"
+            "decode-uri-component": "0.2.0",
+            "object-assign": "4.1.1",
+            "strict-uri-encode": "1.1.0"
           }
         },
         "randombytes": {
@@ -11321,7 +11262,7 @@
           "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.1.0"
+            "safe-buffer": "5.2.1"
           }
         },
         "randomfill": {
@@ -11331,23 +11272,21 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "randombytes": "^2.0.5",
-            "safe-buffer": "^5.1.0"
+            "randombytes": "2.1.0",
+            "safe-buffer": "5.2.1"
           }
         },
         "range-parser": {
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
           "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "raw-body": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
           "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bytes": "3.1.0",
             "http-errors": "1.7.2",
@@ -11361,9 +11300,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.5.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -11372,8 +11311,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           }
         },
         "readable-stream": {
@@ -11382,9 +11321,9 @@
           "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.3",
-            "string_decoder": "^1.1.1",
-            "util-deprecate": "^1.0.1"
+            "inherits": "2.0.4",
+            "string_decoder": "1.3.0",
+            "util-deprecate": "1.0.2"
           }
         },
         "readdirp": {
@@ -11393,9 +11332,9 @@
           "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "micromatch": "^3.1.10",
-            "readable-stream": "^2.0.2"
+            "graceful-fs": "4.2.4",
+            "micromatch": "3.1.10",
+            "readable-stream": "2.3.7"
           },
           "dependencies": {
             "isarray": {
@@ -11410,13 +11349,13 @@
               "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.1",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               }
             },
             "safe-buffer": {
@@ -11431,7 +11370,7 @@
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -11442,7 +11381,7 @@
           "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
           "dev": true,
           "requires": {
-            "resolve": "^1.1.6"
+            "resolve": "1.17.0"
           }
         },
         "regenerate": {
@@ -11463,9 +11402,9 @@
           "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.18.0",
-            "babel-types": "^6.19.0",
-            "private": "^0.1.6"
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "private": "0.1.8"
           }
         },
         "regex-not": {
@@ -11474,8 +11413,8 @@
           "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
           "dev": true,
           "requires": {
-            "extend-shallow": "^3.0.2",
-            "safe-regex": "^1.1.0"
+            "extend-shallow": "3.0.2",
+            "safe-regex": "1.1.0"
           }
         },
         "regexp.prototype.flags": {
@@ -11484,8 +11423,8 @@
           "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
           "dev": true,
           "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.0-next.1"
+            "define-properties": "1.1.3",
+            "es-abstract": "1.17.6"
           }
         },
         "regexpu-core": {
@@ -11494,9 +11433,9 @@
           "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
           "dev": true,
           "requires": {
-            "regenerate": "^1.2.1",
-            "regjsgen": "^0.2.0",
-            "regjsparser": "^0.1.4"
+            "regenerate": "1.4.1",
+            "regjsgen": "0.2.0",
+            "regjsparser": "0.1.5"
           }
         },
         "regjsgen": {
@@ -11511,7 +11450,7 @@
           "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
           "dev": true,
           "requires": {
-            "jsesc": "~0.5.0"
+            "jsesc": "0.5.0"
           }
         },
         "remove-bom-buffer": {
@@ -11520,8 +11459,8 @@
           "integrity": "sha512-8v2rWhaakv18qcvNeli2mZ/TMTL2nEyAKRvzo1WtnZBl15SHyEhrCu2/xKlJyUFKHiHgfXIyuY6g2dObJJycXQ==",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5",
-            "is-utf8": "^0.2.1"
+            "is-buffer": "1.1.6",
+            "is-utf8": "0.2.1"
           }
         },
         "remove-bom-stream": {
@@ -11530,9 +11469,9 @@
           "integrity": "sha1-BfGlk/FuQuH7kOv1nejlaVJflSM=",
           "dev": true,
           "requires": {
-            "remove-bom-buffer": "^3.0.0",
-            "safe-buffer": "^5.1.0",
-            "through2": "^2.0.3"
+            "remove-bom-buffer": "3.0.0",
+            "safe-buffer": "5.2.1",
+            "through2": "2.0.5"
           }
         },
         "remove-trailing-separator": {
@@ -11559,7 +11498,7 @@
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "dev": true,
           "requires": {
-            "is-finite": "^1.0.0"
+            "is-finite": "1.1.0"
           }
         },
         "replace-ext": {
@@ -11574,9 +11513,9 @@
           "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
           "dev": true,
           "requires": {
-            "homedir-polyfill": "^1.0.1",
-            "is-absolute": "^1.0.0",
-            "remove-trailing-separator": "^1.1.0"
+            "homedir-polyfill": "1.0.3",
+            "is-absolute": "1.0.0",
+            "remove-trailing-separator": "1.1.0"
           }
         },
         "request": {
@@ -11585,26 +11524,26 @@
           "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
           "dev": true,
           "requires": {
-            "aws-sign2": "~0.7.0",
-            "aws4": "^1.8.0",
-            "caseless": "~0.12.0",
-            "combined-stream": "~1.0.6",
-            "extend": "~3.0.2",
-            "forever-agent": "~0.6.1",
-            "form-data": "~2.3.2",
-            "har-validator": "~5.1.3",
-            "http-signature": "~1.2.0",
-            "is-typedarray": "~1.0.0",
-            "isstream": "~0.1.2",
-            "json-stringify-safe": "~5.0.1",
-            "mime-types": "~2.1.19",
-            "oauth-sign": "~0.9.0",
-            "performance-now": "^2.1.0",
-            "qs": "~6.5.2",
-            "safe-buffer": "^5.1.2",
-            "tough-cookie": "~2.5.0",
-            "tunnel-agent": "^0.6.0",
-            "uuid": "^3.3.2"
+            "aws-sign2": "0.7.0",
+            "aws4": "1.10.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.8",
+            "extend": "3.0.2",
+            "forever-agent": "0.6.1",
+            "form-data": "2.3.3",
+            "har-validator": "5.1.5",
+            "http-signature": "1.2.0",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.27",
+            "oauth-sign": "0.9.0",
+            "performance-now": "2.1.0",
+            "qs": "6.5.2",
+            "safe-buffer": "5.2.1",
+            "tough-cookie": "2.5.0",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.4.0"
           },
           "dependencies": {
             "qs": {
@@ -11633,7 +11572,7 @@
           "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
           "dev": true,
           "requires": {
-            "path-parse": "^1.0.6"
+            "path-parse": "1.0.6"
           }
         },
         "resolve-dir": {
@@ -11642,8 +11581,8 @@
           "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
           "dev": true,
           "requires": {
-            "expand-tilde": "^2.0.0",
-            "global-modules": "^1.0.0"
+            "expand-tilde": "2.0.2",
+            "global-modules": "1.0.0"
           }
         },
         "resolve-options": {
@@ -11652,7 +11591,7 @@
           "integrity": "sha1-MrueOcBtZzONyTeMDW1gdFZq0TE=",
           "dev": true,
           "requires": {
-            "value-or-function": "^3.0.0"
+            "value-or-function": "3.0.0"
           }
         },
         "resolve-url": {
@@ -11668,7 +11607,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "lowercase-keys": "^1.0.0"
+            "lowercase-keys": "1.0.1"
           }
         },
         "resumer": {
@@ -11677,7 +11616,7 @@
           "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
           "dev": true,
           "requires": {
-            "through": "~2.3.4"
+            "through": "2.3.8"
           }
         },
         "ret": {
@@ -11692,7 +11631,7 @@
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "dev": true,
           "requires": {
-            "glob": "^7.1.3"
+            "glob": "7.1.6"
           }
         },
         "ripemd160": {
@@ -11701,8 +11640,8 @@
           "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
           "dev": true,
           "requires": {
-            "hash-base": "^3.0.0",
-            "inherits": "^2.0.1"
+            "hash-base": "3.1.0",
+            "inherits": "2.0.4"
           }
         },
         "rlp": {
@@ -11711,7 +11650,7 @@
           "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
           "dev": true,
           "requires": {
-            "bn.js": "^4.11.1"
+            "bn.js": "4.11.9"
           }
         },
         "rustbn.js": {
@@ -11732,7 +11671,7 @@
           "integrity": "sha512-e1wFe99A91XYYxoQbcq2ZJUWurxEyP8vfz7A7vuUe1s95q8r5ebraVaA1BukYJcpM6V16ugWoD9vngi8Ccu5fg==",
           "dev": true,
           "requires": {
-            "events": "^3.0.0"
+            "events": "3.2.0"
           }
         },
         "safe-regex": {
@@ -11741,7 +11680,7 @@
           "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
           "dev": true,
           "requires": {
-            "ret": "~0.1.10"
+            "ret": "0.1.15"
           }
         },
         "safer-buffer": {
@@ -11763,8 +11702,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "scrypt": "^6.0.2",
-            "scryptsy": "^1.2.1"
+            "scrypt": "6.0.3",
+            "scryptsy": "1.2.1"
           }
         },
         "scryptsy": {
@@ -11774,7 +11713,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "pbkdf2": "^3.0.3"
+            "pbkdf2": "3.1.1"
           }
         },
         "secp256k1": {
@@ -11783,9 +11722,9 @@
           "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
           "dev": true,
           "requires": {
-            "elliptic": "^6.5.2",
-            "node-addon-api": "^2.0.0",
-            "node-gyp-build": "^4.2.0"
+            "elliptic": "6.5.3",
+            "node-addon-api": "2.0.2",
+            "node-gyp-build": "4.2.3"
           }
         },
         "seedrandom": {
@@ -11801,7 +11740,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "commander": "^2.8.1"
+            "commander": "2.20.3"
           }
         },
         "semaphore": {
@@ -11816,7 +11755,7 @@
           "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
           "dev": true,
           "requires": {
-            "sver-compat": "^1.5.0"
+            "sver-compat": "1.5.0"
           }
         },
         "send": {
@@ -11824,21 +11763,20 @@
           "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
           "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "debug": "2.6.9",
-            "depd": "~1.1.2",
-            "destroy": "~1.0.4",
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "etag": "~1.8.1",
+            "depd": "1.1.2",
+            "destroy": "1.0.4",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "etag": "1.8.1",
             "fresh": "0.5.2",
-            "http-errors": "~1.7.2",
+            "http-errors": "1.7.2",
             "mime": "1.6.0",
             "ms": "2.1.1",
-            "on-finished": "~2.3.0",
-            "range-parser": "~1.2.1",
-            "statuses": "~1.5.0"
+            "on-finished": "2.3.0",
+            "range-parser": "1.2.1",
+            "statuses": "1.5.0"
           },
           "dependencies": {
             "debug": {
@@ -11846,7 +11784,6 @@
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
               "dev": true,
-              "optional": true,
               "requires": {
                 "ms": "2.0.0"
               },
@@ -11855,8 +11792,7 @@
                   "version": "2.0.0",
                   "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                   "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                  "dev": true,
-                  "optional": true
+                  "dev": true
                 }
               }
             },
@@ -11864,8 +11800,7 @@
               "version": "2.1.1",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
               "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -11876,9 +11811,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "encodeurl": "~1.0.2",
-            "escape-html": "~1.0.3",
-            "parseurl": "~1.3.3",
+            "encodeurl": "1.0.2",
+            "escape-html": "1.0.3",
+            "parseurl": "1.3.3",
             "send": "0.17.1"
           }
         },
@@ -11889,11 +11824,11 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "body-parser": "^1.16.0",
-            "cors": "^2.8.1",
-            "express": "^4.14.0",
-            "request": "^2.79.0",
-            "xhr": "^2.3.3"
+            "body-parser": "1.19.0",
+            "cors": "2.8.5",
+            "express": "4.17.1",
+            "request": "2.88.2",
+            "xhr": "2.5.0"
           }
         },
         "set-blocking": {
@@ -11914,10 +11849,10 @@
           "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.3",
-            "split-string": "^3.0.1"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "split-string": "3.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -11926,7 +11861,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -11941,8 +11876,7 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
           "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "sha.js": {
           "version": "2.4.11",
@@ -11950,27 +11884,25 @@
           "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "safe-buffer": "^5.0.1"
+            "inherits": "2.0.4",
+            "safe-buffer": "5.2.1"
           }
         },
         "simple-concat": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
           "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "simple-get": {
           "version": "2.8.1",
           "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
           "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "decompress-response": "^3.3.0",
-            "once": "^1.3.1",
-            "simple-concat": "^1.0.0"
+            "decompress-response": "3.3.0",
+            "once": "1.4.0",
+            "simple-concat": "1.0.1"
           }
         },
         "slash": {
@@ -11985,14 +11917,14 @@
           "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
           "dev": true,
           "requires": {
-            "base": "^0.11.1",
-            "debug": "^2.2.0",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "map-cache": "^0.2.2",
-            "source-map": "^0.5.6",
-            "source-map-resolve": "^0.5.0",
-            "use": "^3.1.0"
+            "base": "0.11.2",
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "map-cache": "0.2.2",
+            "source-map": "0.5.7",
+            "source-map-resolve": "0.5.3",
+            "use": "3.1.1"
           },
           "dependencies": {
             "debug": {
@@ -12010,7 +11942,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -12019,7 +11951,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "ms": {
@@ -12042,9 +11974,9 @@
           "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
           "dev": true,
           "requires": {
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.0",
-            "snapdragon-util": "^3.0.1"
+            "define-property": "1.0.0",
+            "isobject": "3.0.1",
+            "snapdragon-util": "3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -12053,7 +11985,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "is-accessor-descriptor": {
@@ -12062,7 +11994,7 @@
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.3"
               }
             },
             "is-data-descriptor": {
@@ -12071,7 +12003,7 @@
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.3"
               }
             },
             "is-descriptor": {
@@ -12080,9 +12012,9 @@
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.3"
               }
             }
           }
@@ -12093,7 +12025,7 @@
           "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^3.2.0"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -12102,7 +12034,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -12119,11 +12051,11 @@
           "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
           "dev": true,
           "requires": {
-            "atob": "^2.1.2",
-            "decode-uri-component": "^0.2.0",
-            "resolve-url": "^0.2.1",
-            "source-map-url": "^0.4.0",
-            "urix": "^0.1.0"
+            "atob": "2.1.2",
+            "decode-uri-component": "0.2.0",
+            "resolve-url": "0.2.1",
+            "source-map-url": "0.4.0",
+            "urix": "0.1.0"
           }
         },
         "source-map-support": {
@@ -12132,8 +12064,8 @@
           "integrity": "sha512-4h2Pbvyy15EE02G+JOZpUCmqWJuqrs+sEkzewTm++BPi7Hvn/HwcqLAcNxYAyI0x13CpPPn+kMjl+hplXMHITQ==",
           "dev": true,
           "requires": {
-            "buffer-from": "^1.0.0",
-            "source-map": "^0.6.0"
+            "buffer-from": "1.1.1",
+            "source-map": "0.6.1"
           }
         },
         "source-map-url": {
@@ -12154,8 +12086,8 @@
           "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
           "dev": true,
           "requires": {
-            "spdx-expression-parse": "^3.0.0",
-            "spdx-license-ids": "^3.0.0"
+            "spdx-expression-parse": "3.0.1",
+            "spdx-license-ids": "3.0.5"
           }
         },
         "spdx-exceptions": {
@@ -12170,8 +12102,8 @@
           "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
           "dev": true,
           "requires": {
-            "spdx-exceptions": "^2.1.0",
-            "spdx-license-ids": "^3.0.0"
+            "spdx-exceptions": "2.3.0",
+            "spdx-license-ids": "3.0.5"
           }
         },
         "spdx-license-ids": {
@@ -12186,7 +12118,7 @@
           "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
           "dev": true,
           "requires": {
-            "extend-shallow": "^3.0.0"
+            "extend-shallow": "3.0.2"
           }
         },
         "sshpk": {
@@ -12195,15 +12127,15 @@
           "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
           "dev": true,
           "requires": {
-            "asn1": "~0.2.3",
-            "assert-plus": "^1.0.0",
-            "bcrypt-pbkdf": "^1.0.0",
-            "dashdash": "^1.12.0",
-            "ecc-jsbn": "~0.1.1",
-            "getpass": "^0.1.1",
-            "jsbn": "~0.1.0",
-            "safer-buffer": "^2.0.2",
-            "tweetnacl": "~0.14.0"
+            "asn1": "0.2.4",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.2",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.2",
+            "getpass": "0.1.7",
+            "jsbn": "0.1.1",
+            "safer-buffer": "2.1.2",
+            "tweetnacl": "0.14.5"
           },
           "dependencies": {
             "tweetnacl": {
@@ -12226,8 +12158,8 @@
           "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
           "dev": true,
           "requires": {
-            "define-property": "^0.2.5",
-            "object-copy": "^0.1.0"
+            "define-property": "0.2.5",
+            "object-copy": "0.1.0"
           },
           "dependencies": {
             "define-property": {
@@ -12236,7 +12168,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             }
           }
@@ -12245,8 +12177,7 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "stream-exhaust": {
           "version": "1.0.2",
@@ -12266,8 +12197,8 @@
           "integrity": "sha512-6sNyqJpr5dIOQdgNy/xcDWwDuzAsAwVzhzrWlAPAQ7Lkjx/rv0wgvxEyKwTq6FmNd5rjTrELt/CLmaSw7crMGg==",
           "dev": true,
           "requires": {
-            "looper": "^3.0.0",
-            "pull-stream": "^3.2.3"
+            "looper": "3.0.0",
+            "pull-stream": "3.6.14"
           },
           "dependencies": {
             "looper": {
@@ -12282,8 +12213,7 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
           "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "string-width": {
           "version": "1.0.2",
@@ -12291,9 +12221,9 @@
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
           }
         },
         "string.prototype.trim": {
@@ -12302,9 +12232,9 @@
           "integrity": "sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==",
           "dev": true,
           "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.0-next.1",
-            "function-bind": "^1.1.1"
+            "define-properties": "1.1.3",
+            "es-abstract": "1.17.6",
+            "function-bind": "1.1.1"
           }
         },
         "string.prototype.trimend": {
@@ -12313,8 +12243,8 @@
           "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
           "dev": true,
           "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.5"
+            "define-properties": "1.1.3",
+            "es-abstract": "1.17.6"
           }
         },
         "string.prototype.trimstart": {
@@ -12323,8 +12253,8 @@
           "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
           "dev": true,
           "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.5"
+            "define-properties": "1.1.3",
+            "es-abstract": "1.17.6"
           }
         },
         "string_decoder": {
@@ -12333,7 +12263,7 @@
           "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.2.0"
+            "safe-buffer": "5.2.1"
           }
         },
         "strip-ansi": {
@@ -12342,7 +12272,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-bom": {
@@ -12351,7 +12281,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "strip-dirs": {
@@ -12361,7 +12291,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "is-natural-number": "^4.0.1"
+            "is-natural-number": "4.0.1"
           }
         },
         "strip-hex-prefix": {
@@ -12385,8 +12315,8 @@
           "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
           "dev": true,
           "requires": {
-            "es6-iterator": "^2.0.1",
-            "es6-symbol": "^3.1.1"
+            "es6-iterator": "2.0.3",
+            "es6-symbol": "3.1.3"
           }
         },
         "swarm-js": {
@@ -12396,18 +12326,18 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "bluebird": "^3.5.0",
-            "buffer": "^5.0.5",
-            "decompress": "^4.0.0",
-            "eth-lib": "^0.1.26",
-            "fs-extra": "^4.0.2",
-            "got": "^7.1.0",
-            "mime-types": "^2.1.16",
-            "mkdirp-promise": "^5.0.1",
-            "mock-fs": "^4.1.0",
-            "setimmediate": "^1.0.5",
-            "tar": "^4.0.2",
-            "xhr-request-promise": "^0.1.2"
+            "bluebird": "3.7.2",
+            "buffer": "5.6.0",
+            "decompress": "4.2.1",
+            "eth-lib": "0.1.29",
+            "fs-extra": "4.0.3",
+            "got": "7.1.0",
+            "mime-types": "2.1.27",
+            "mkdirp-promise": "5.0.1",
+            "mock-fs": "4.12.0",
+            "setimmediate": "1.0.5",
+            "tar": "4.4.13",
+            "xhr-request-promise": "0.1.3"
           },
           "dependencies": {
             "get-stream": {
@@ -12424,20 +12354,20 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "decompress-response": "^3.2.0",
-                "duplexer3": "^0.1.4",
-                "get-stream": "^3.0.0",
-                "is-plain-obj": "^1.1.0",
-                "is-retry-allowed": "^1.0.0",
-                "is-stream": "^1.0.0",
-                "isurl": "^1.0.0-alpha5",
-                "lowercase-keys": "^1.0.0",
-                "p-cancelable": "^0.3.0",
-                "p-timeout": "^1.1.1",
-                "safe-buffer": "^5.0.1",
-                "timed-out": "^4.0.0",
-                "url-parse-lax": "^1.0.0",
-                "url-to-options": "^1.0.1"
+                "decompress-response": "3.3.0",
+                "duplexer3": "0.1.4",
+                "get-stream": "3.0.0",
+                "is-plain-obj": "1.1.0",
+                "is-retry-allowed": "1.2.0",
+                "is-stream": "1.1.0",
+                "isurl": "1.0.0",
+                "lowercase-keys": "1.0.1",
+                "p-cancelable": "0.3.0",
+                "p-timeout": "1.2.1",
+                "safe-buffer": "5.2.1",
+                "timed-out": "4.0.1",
+                "url-parse-lax": "1.0.0",
+                "url-to-options": "1.0.1"
               }
             },
             "p-cancelable": {
@@ -12461,7 +12391,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "prepend-http": "^1.0.1"
+                "prepend-http": "1.0.4"
               }
             }
           }
@@ -12472,21 +12402,21 @@
           "integrity": "sha512-0/Y20PwRIUkQcTCSi4AASs+OANZZwqPKaipGCEwp10dQMipVvSZwUUCi01Y/OklIGyHKFhIcjock+DKnBfLAFw==",
           "dev": true,
           "requires": {
-            "deep-equal": "~1.1.1",
-            "defined": "~1.0.0",
-            "dotignore": "~0.1.2",
-            "for-each": "~0.3.3",
-            "function-bind": "~1.1.1",
-            "glob": "~7.1.6",
-            "has": "~1.0.3",
-            "inherits": "~2.0.4",
-            "is-regex": "~1.0.5",
-            "minimist": "~1.2.5",
-            "object-inspect": "~1.7.0",
-            "resolve": "~1.17.0",
-            "resumer": "~0.0.0",
-            "string.prototype.trim": "~1.2.1",
-            "through": "~2.3.8"
+            "deep-equal": "1.1.1",
+            "defined": "1.0.0",
+            "dotignore": "0.1.2",
+            "for-each": "0.3.3",
+            "function-bind": "1.1.1",
+            "glob": "7.1.6",
+            "has": "1.0.3",
+            "inherits": "2.0.4",
+            "is-regex": "1.0.5",
+            "minimist": "1.2.5",
+            "object-inspect": "1.7.0",
+            "resolve": "1.17.0",
+            "resumer": "0.0.0",
+            "string.prototype.trim": "1.2.1",
+            "through": "2.3.8"
           },
           "dependencies": {
             "is-regex": {
@@ -12495,7 +12425,7 @@
               "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
               "dev": true,
               "requires": {
-                "has": "^1.0.3"
+                "has": "1.0.3"
               }
             },
             "object-inspect": {
@@ -12513,13 +12443,13 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.1.1",
-            "fs-minipass": "^1.2.5",
-            "minipass": "^2.8.6",
-            "minizlib": "^1.2.1",
-            "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.2",
-            "yallist": "^3.0.3"
+            "chownr": "1.1.4",
+            "fs-minipass": "1.2.7",
+            "minipass": "2.9.0",
+            "minizlib": "1.3.3",
+            "mkdirp": "0.5.5",
+            "safe-buffer": "5.2.1",
+            "yallist": "3.1.1"
           },
           "dependencies": {
             "mkdirp": {
@@ -12529,7 +12459,7 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "minimist": "^1.2.5"
+                "minimist": "1.2.5"
               }
             }
           }
@@ -12539,55 +12469,50 @@
           "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
           "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "bl": "^1.0.0",
-            "buffer-alloc": "^1.2.0",
-            "end-of-stream": "^1.0.0",
-            "fs-constants": "^1.0.0",
-            "readable-stream": "^2.3.0",
-            "to-buffer": "^1.1.1",
-            "xtend": "^4.0.0"
+            "bl": "1.2.2",
+            "buffer-alloc": "1.2.0",
+            "end-of-stream": "1.4.4",
+            "fs-constants": "1.0.0",
+            "readable-stream": "2.3.7",
+            "to-buffer": "1.1.1",
+            "xtend": "4.0.2"
           },
           "dependencies": {
             "isarray": {
               "version": "1.0.0",
               "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
               "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "readable-stream": {
               "version": "2.3.7",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
               "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
-              "optional": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.1",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               }
             },
             "safe-buffer": {
               "version": "5.1.2",
               "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
               "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "string_decoder": {
               "version": "1.1.1",
               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
-              "optional": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -12604,8 +12529,8 @@
           "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
           "dev": true,
           "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
+            "readable-stream": "2.3.7",
+            "xtend": "4.0.2"
           },
           "dependencies": {
             "isarray": {
@@ -12620,13 +12545,13 @@
               "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.1",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               }
             },
             "safe-buffer": {
@@ -12641,7 +12566,7 @@
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -12652,8 +12577,8 @@
           "integrity": "sha512-jaRjI2WxN3W1V8/FMZ9HKIBXixtiqs3SQSX4/YGIiP3gL6djW48VoZq9tDqeCWs3MT8YY5wb/zli8VW8snY1CA==",
           "dev": true,
           "requires": {
-            "through2": "~2.0.0",
-            "xtend": "~4.0.0"
+            "through2": "2.0.5",
+            "xtend": "4.0.2"
           }
         },
         "time-stamp": {
@@ -12666,8 +12591,7 @@
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
           "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "tmp": {
           "version": "0.1.0",
@@ -12675,7 +12599,7 @@
           "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
           "dev": true,
           "requires": {
-            "rimraf": "^2.6.3"
+            "rimraf": "2.7.1"
           }
         },
         "to-absolute-glob": {
@@ -12684,16 +12608,15 @@
           "integrity": "sha1-GGX0PZ50sIItufFFt4z/fQ98hJs=",
           "dev": true,
           "requires": {
-            "is-absolute": "^1.0.0",
-            "is-negated-glob": "^1.0.0"
+            "is-absolute": "1.0.0",
+            "is-negated-glob": "1.0.0"
           }
         },
         "to-buffer": {
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
           "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "to-fast-properties": {
           "version": "1.0.3",
@@ -12707,7 +12630,7 @@
           "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -12716,7 +12639,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -12734,10 +12657,10 @@
           "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
           "dev": true,
           "requires": {
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "regex-not": "^1.0.2",
-            "safe-regex": "^1.1.0"
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "regex-not": "1.0.2",
+            "safe-regex": "1.1.0"
           }
         },
         "to-regex-range": {
@@ -12746,8 +12669,8 @@
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
           "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1"
           }
         },
         "to-through": {
@@ -12756,15 +12679,14 @@
           "integrity": "sha1-/JKtq6ByZHvAtn1rA2ZKoZUJOvY=",
           "dev": true,
           "requires": {
-            "through2": "^2.0.3"
+            "through2": "2.0.5"
           }
         },
         "toidentifier": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
           "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "tough-cookie": {
           "version": "2.5.0",
@@ -12772,8 +12694,8 @@
           "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
           "dev": true,
           "requires": {
-            "psl": "^1.1.28",
-            "punycode": "^2.1.1"
+            "psl": "1.8.0",
+            "punycode": "2.1.1"
           }
         },
         "trim-right": {
@@ -12788,7 +12710,7 @@
           "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "requires": {
-            "safe-buffer": "^5.0.1"
+            "safe-buffer": "5.2.1"
           }
         },
         "tweetnacl": {
@@ -12814,10 +12736,9 @@
           "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
           "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
           "dev": true,
-          "optional": true,
           "requires": {
             "media-typer": "0.3.0",
-            "mime-types": "~2.1.24"
+            "mime-types": "2.1.27"
           }
         },
         "typedarray": {
@@ -12832,7 +12753,7 @@
           "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
           "dev": true,
           "requires": {
-            "is-typedarray": "^1.0.0"
+            "is-typedarray": "1.0.0"
           }
         },
         "typewise": {
@@ -12841,7 +12762,7 @@
           "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
           "dev": true,
           "requires": {
-            "typewise-core": "^1.2.0"
+            "typewise-core": "1.2.0"
           }
         },
         "typewise-core": {
@@ -12870,8 +12791,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "buffer": "^5.2.1",
-            "through": "^2.3.8"
+            "buffer": "5.6.0",
+            "through": "2.3.8"
           }
         },
         "unc-path-regex": {
@@ -12884,8 +12805,7 @@
           "version": "1.9.1",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
           "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "undertaker": {
           "version": "1.2.1",
@@ -12893,15 +12813,15 @@
           "integrity": "sha512-71WxIzDkgYk9ZS+spIB8iZXchFhAdEo2YU8xYqBYJ39DIUIqziK78ftm26eecoIY49X0J2MLhG4hr18Yp6/CMA==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.0.1",
-            "arr-map": "^2.0.0",
-            "bach": "^1.0.0",
-            "collection-map": "^1.0.0",
-            "es6-weak-map": "^2.0.1",
-            "last-run": "^1.1.0",
-            "object.defaults": "^1.0.0",
-            "object.reduce": "^1.0.0",
-            "undertaker-registry": "^1.0.0"
+            "arr-flatten": "1.1.0",
+            "arr-map": "2.0.2",
+            "bach": "1.2.0",
+            "collection-map": "1.0.0",
+            "es6-weak-map": "2.0.3",
+            "last-run": "1.1.1",
+            "object.defaults": "1.1.0",
+            "object.reduce": "1.0.1",
+            "undertaker-registry": "1.0.1"
           }
         },
         "undertaker-registry": {
@@ -12916,10 +12836,10 @@
           "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
           "dev": true,
           "requires": {
-            "arr-union": "^3.1.0",
-            "get-value": "^2.0.6",
-            "is-extendable": "^0.1.1",
-            "set-value": "^2.0.1"
+            "arr-union": "3.1.0",
+            "get-value": "2.0.6",
+            "is-extendable": "0.1.1",
+            "set-value": "2.0.1"
           }
         },
         "unique-stream": {
@@ -12928,8 +12848,8 @@
           "integrity": "sha512-2nY4TnBE70yoxHkDli7DMazpWiP7xMdCYqU2nBRO0UB+ZpEkGsSija7MvmvnZFUeC+mrgiUfcHSr3LmRFIg4+A==",
           "dev": true,
           "requires": {
-            "json-stable-stringify-without-jsonify": "^1.0.1",
-            "through2-filter": "^3.0.0"
+            "json-stable-stringify-without-jsonify": "1.0.1",
+            "through2-filter": "3.0.0"
           }
         },
         "universalify": {
@@ -12949,8 +12869,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
           "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "unset-value": {
           "version": "1.0.0",
@@ -12958,8 +12877,8 @@
           "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
           "dev": true,
           "requires": {
-            "has-value": "^0.3.1",
-            "isobject": "^3.0.0"
+            "has-value": "0.3.1",
+            "isobject": "3.0.1"
           },
           "dependencies": {
             "has-value": {
@@ -12968,9 +12887,9 @@
               "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
               "dev": true,
               "requires": {
-                "get-value": "^2.0.3",
-                "has-values": "^0.1.4",
-                "isobject": "^2.0.0"
+                "get-value": "2.0.6",
+                "has-values": "0.1.4",
+                "isobject": "2.1.0"
               },
               "dependencies": {
                 "isobject": {
@@ -13010,7 +12929,7 @@
           "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
           "dev": true,
           "requires": {
-            "punycode": "^2.1.0"
+            "punycode": "2.1.1"
           }
         },
         "urix": {
@@ -13026,15 +12945,14 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "prepend-http": "^2.0.0"
+            "prepend-http": "2.0.0"
           }
         },
         "url-set-query": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/url-set-query/-/url-set-query-1.0.0.tgz",
           "integrity": "sha1-AW6M/Xwg7gXK/neV6JK9BwL6ozk=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "url-to-options": {
           "version": "1.0.1",
@@ -13053,8 +12971,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
           "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "util-deprecate": {
           "version": "1.0.2",
@@ -13068,10 +12985,10 @@
           "integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
           "dev": true,
           "requires": {
-            "define-properties": "^1.1.3",
-            "es-abstract": "^1.17.2",
-            "has-symbols": "^1.0.1",
-            "object.getownpropertydescriptors": "^2.1.0"
+            "define-properties": "1.1.3",
+            "es-abstract": "1.17.6",
+            "has-symbols": "1.0.1",
+            "object.getownpropertydescriptors": "2.1.0"
           }
         },
         "utils-merge": {
@@ -13093,7 +13010,7 @@
           "integrity": "sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==",
           "dev": true,
           "requires": {
-            "homedir-polyfill": "^1.0.1"
+            "homedir-polyfill": "1.0.3"
           }
         },
         "validate-npm-package-license": {
@@ -13102,8 +13019,8 @@
           "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
           "dev": true,
           "requires": {
-            "spdx-correct": "^3.0.0",
-            "spdx-expression-parse": "^3.0.0"
+            "spdx-correct": "3.1.1",
+            "spdx-expression-parse": "3.0.1"
           }
         },
         "value-or-function": {
@@ -13116,8 +13033,7 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
           "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "verror": {
           "version": "1.10.0",
@@ -13125,9 +13041,9 @@
           "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "dev": true,
           "requires": {
-            "assert-plus": "^1.0.0",
+            "assert-plus": "1.0.0",
             "core-util-is": "1.0.2",
-            "extsprintf": "^1.2.0"
+            "extsprintf": "1.3.0"
           }
         },
         "vinyl": {
@@ -13136,12 +13052,12 @@
           "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
           "dev": true,
           "requires": {
-            "clone": "^2.1.1",
-            "clone-buffer": "^1.0.0",
-            "clone-stats": "^1.0.0",
-            "cloneable-readable": "^1.0.0",
-            "remove-trailing-separator": "^1.0.1",
-            "replace-ext": "^1.0.0"
+            "clone": "2.1.2",
+            "clone-buffer": "1.0.0",
+            "clone-stats": "1.0.0",
+            "cloneable-readable": "1.1.3",
+            "remove-trailing-separator": "1.1.0",
+            "replace-ext": "1.0.1"
           }
         },
         "vinyl-fs": {
@@ -13150,23 +13066,23 @@
           "integrity": "sha512-vIu34EkyNyJxmP0jscNzWBSygh7VWhqun6RmqVfXePrOwi9lhvRs//dOaGOTRUQr4tx7/zd26Tk5WeSVZitgng==",
           "dev": true,
           "requires": {
-            "fs-mkdirp-stream": "^1.0.0",
-            "glob-stream": "^6.1.0",
-            "graceful-fs": "^4.0.0",
-            "is-valid-glob": "^1.0.0",
-            "lazystream": "^1.0.0",
-            "lead": "^1.0.0",
-            "object.assign": "^4.0.4",
-            "pumpify": "^1.3.5",
-            "readable-stream": "^2.3.3",
-            "remove-bom-buffer": "^3.0.0",
-            "remove-bom-stream": "^1.2.0",
-            "resolve-options": "^1.1.0",
-            "through2": "^2.0.0",
-            "to-through": "^2.0.0",
-            "value-or-function": "^3.0.0",
-            "vinyl": "^2.0.0",
-            "vinyl-sourcemap": "^1.1.0"
+            "fs-mkdirp-stream": "1.0.0",
+            "glob-stream": "6.1.0",
+            "graceful-fs": "4.2.4",
+            "is-valid-glob": "1.0.0",
+            "lazystream": "1.0.0",
+            "lead": "1.0.0",
+            "object.assign": "4.1.0",
+            "pumpify": "1.5.1",
+            "readable-stream": "2.3.7",
+            "remove-bom-buffer": "3.0.0",
+            "remove-bom-stream": "1.2.0",
+            "resolve-options": "1.1.0",
+            "through2": "2.0.5",
+            "to-through": "2.0.0",
+            "value-or-function": "3.0.0",
+            "vinyl": "2.2.0",
+            "vinyl-sourcemap": "1.1.0"
           },
           "dependencies": {
             "isarray": {
@@ -13181,13 +13097,13 @@
               "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.1",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               }
             },
             "safe-buffer": {
@@ -13202,7 +13118,7 @@
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
               }
             }
           }
@@ -13213,13 +13129,13 @@
           "integrity": "sha1-kqgAWTo4cDqM2xHYswCtS+Y7PhY=",
           "dev": true,
           "requires": {
-            "append-buffer": "^1.0.2",
-            "convert-source-map": "^1.5.0",
-            "graceful-fs": "^4.1.6",
-            "normalize-path": "^2.1.1",
-            "now-and-later": "^2.0.0",
-            "remove-bom-buffer": "^3.0.0",
-            "vinyl": "^2.0.0"
+            "append-buffer": "1.0.2",
+            "convert-source-map": "1.7.0",
+            "graceful-fs": "4.2.4",
+            "normalize-path": "2.1.1",
+            "now-and-later": "2.0.1",
+            "remove-bom-buffer": "3.0.0",
+            "vinyl": "2.2.0"
           },
           "dependencies": {
             "normalize-path": {
@@ -13228,7 +13144,7 @@
               "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
               "dev": true,
               "requires": {
-                "remove-trailing-separator": "^1.0.1"
+                "remove-trailing-separator": "1.1.0"
               }
             }
           }
@@ -13240,7 +13156,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "@types/node": "^12.6.1",
+            "@types/node": "12.12.53",
             "web3-bzz": "1.2.4",
             "web3-core": "1.2.4",
             "web3-eth": "1.2.4",
@@ -13266,7 +13182,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "@types/node": "^10.12.18",
+            "@types/node": "10.17.28",
             "got": "9.6.0",
             "swarm-js": "0.1.39",
             "underscore": "1.9.1"
@@ -13286,11 +13202,10 @@
           "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.4.tgz",
           "integrity": "sha512-CHc27sMuET2cs1IKrkz7xzmTdMfZpYswe7f0HcuyneTwS1yTlTnHyqjAaTy0ZygAb/x4iaVox+Gvr4oSAqSI+A==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "@types/bignumber.js": "^5.0.0",
-            "@types/bn.js": "^4.11.4",
-            "@types/node": "^12.6.1",
+            "@types/bignumber.js": "5.0.0",
+            "@types/bn.js": "4.11.6",
+            "@types/node": "12.12.53",
             "web3-core-helpers": "1.2.4",
             "web3-core-method": "1.2.4",
             "web3-core-requestmanager": "1.2.4",
@@ -13301,8 +13216,7 @@
               "version": "12.12.53",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
               "integrity": "sha512-51MYTDTyCziHb70wtGNFRwB4l+5JNvdqzFSkbDvpbftEgVUBEE+T5f7pROhWMp/fxp07oNIEQZd5bbfAH22ohQ==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -13311,7 +13225,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.4.tgz",
           "integrity": "sha512-U7wbsK8IbZvF3B7S+QMSNP0tni/6VipnJkB0tZVEpHEIV2WWeBHYmZDnULWcsS/x/jn9yKhJlXIxWGsEAMkjiw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-eth-iban": "1.2.4",
@@ -13323,7 +13236,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.4.tgz",
           "integrity": "sha512-8p9kpL7di2qOVPWgcM08kb+yKom0rxRCMv6m/K+H+yLSxev9TgMbCgMSbPWAHlyiF3SJHw7APFKahK5Z+8XT5A==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.4",
@@ -13337,7 +13249,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.4.tgz",
           "integrity": "sha512-gEUlm27DewUsfUgC3T8AxkKi8Ecx+e+ZCaunB7X4Qk3i9F4C+5PSMGguolrShZ7Zb6717k79Y86f3A00O0VAZw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "any-promise": "1.3.0",
             "eventemitter3": "3.1.2"
@@ -13348,7 +13259,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.4.tgz",
           "integrity": "sha512-eZJDjyNTDtmSmzd3S488nR/SMJtNnn/GuwxnMh3AzYCqG3ZMfOylqTad2eYJPvc2PM5/Gj1wAMQcRpwOjjLuPg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.4",
@@ -13362,7 +13272,6 @@
           "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.4.tgz",
           "integrity": "sha512-3D607J2M8ymY9V+/WZq4MLlBulwCkwEjjC2U+cXqgVO1rCyVqbxZNCmHyNYHjDDCxSEbks9Ju5xqJxDSxnyXEw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "eventemitter3": "3.1.2",
             "underscore": "1.9.1",
@@ -13396,7 +13305,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.2.4.tgz",
           "integrity": "sha512-8eLIY4xZKoU3DSVu1pORluAw9Ru0/v4CGdw5so31nn+7fR8zgHMgwbFe0aOqWQ5VU42PzMMXeIJwt4AEi2buFg==",
           "dev": true,
-          "optional": true,
           "requires": {
             "ethers": "4.0.0-beta.3",
             "underscore": "1.9.1",
@@ -13407,27 +13315,24 @@
               "version": "10.17.28",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
               "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ==",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aes-js": {
               "version": "3.0.0",
               "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
               "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "elliptic": {
               "version": "6.3.3",
               "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.3.3.tgz",
               "integrity": "sha1-VILZZG1UvLif19mU/J4ulWiHbj8=",
               "dev": true,
-              "optional": true,
               "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "inherits": "^2.0.1"
+                "bn.js": "4.11.9",
+                "brorand": "1.1.0",
+                "hash.js": "1.1.3",
+                "inherits": "2.0.4"
               }
             },
             "ethers": {
@@ -13435,11 +13340,10 @@
               "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.0-beta.3.tgz",
               "integrity": "sha512-YYPogooSknTwvHg3+Mv71gM/3Wcrx+ZpCzarBj3mqs9njjRkrOo2/eufzhHloOCo3JSoNI4TQJJ6yU5ABm3Uog==",
               "dev": true,
-              "optional": true,
               "requires": {
-                "@types/node": "^10.3.2",
+                "@types/node": "10.17.28",
                 "aes-js": "3.0.0",
-                "bn.js": "^4.4.0",
+                "bn.js": "4.11.9",
                 "elliptic": "6.3.3",
                 "hash.js": "1.1.3",
                 "js-sha3": "0.5.7",
@@ -13454,39 +13358,34 @@
               "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
               "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
               "dev": true,
-              "optional": true,
               "requires": {
-                "inherits": "^2.0.3",
-                "minimalistic-assert": "^1.0.0"
+                "inherits": "2.0.4",
+                "minimalistic-assert": "1.0.1"
               }
             },
             "js-sha3": {
               "version": "0.5.7",
               "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
               "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "scrypt-js": {
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.3.tgz",
               "integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "setimmediate": {
               "version": "1.0.4",
               "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
               "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "uuid": {
               "version": "2.0.1",
               "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
               "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -13497,12 +13396,12 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "@web3-js/scrypt-shim": "^0.1.0",
+            "@web3-js/scrypt-shim": "0.1.0",
             "any-promise": "1.3.0",
             "crypto-browserify": "3.12.0",
             "eth-lib": "0.2.7",
-            "ethereumjs-common": "^1.3.2",
-            "ethereumjs-tx": "^2.1.1",
+            "ethereumjs-common": "1.5.0",
+            "ethereumjs-tx": "2.1.2",
             "underscore": "1.9.1",
             "uuid": "3.3.2",
             "web3-core": "1.2.4",
@@ -13518,9 +13417,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "bn.js": "^4.11.6",
-                "elliptic": "^6.4.0",
-                "xhr-request-promise": "^0.1.2"
+                "bn.js": "4.11.9",
+                "elliptic": "6.5.3",
+                "xhr-request-promise": "0.1.3"
               }
             },
             "uuid": {
@@ -13537,9 +13436,8 @@
           "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.4.tgz",
           "integrity": "sha512-b/9zC0qjVetEYnzRA1oZ8gF1OSSUkwSYi5LGr4GeckLkzXP7osEnp9lkO/AQcE4GpG+l+STnKPnASXJGZPgBRQ==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "@types/bn.js": "^4.11.4",
+            "@types/bn.js": "4.11.6",
             "underscore": "1.9.1",
             "web3-core": "1.2.4",
             "web3-core-helpers": "1.2.4",
@@ -13572,7 +13470,6 @@
           "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.4.tgz",
           "integrity": "sha512-D9HIyctru/FLRpXakRwmwdjb5bWU2O6UE/3AXvRm6DCOf2e+7Ve11qQrPtaubHfpdW3KWjDKvlxV9iaFv/oTMQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.8",
             "web3-utils": "1.2.4"
@@ -13582,8 +13479,7 @@
               "version": "4.11.8",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
               "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -13592,9 +13488,8 @@
           "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.4.tgz",
           "integrity": "sha512-5Russ7ZECwHaZXcN3DLuLS7390Vzgrzepl4D87SD6Sn1DHsCZtvfdPIYwoTmKNp69LG3mORl7U23Ga5YxqkICw==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "@types/node": "^12.6.1",
+            "@types/node": "12.12.53",
             "web3-core": "1.2.4",
             "web3-core-helpers": "1.2.4",
             "web3-core-method": "1.2.4",
@@ -13606,8 +13501,7 @@
               "version": "12.12.53",
               "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.53.tgz",
               "integrity": "sha512-51MYTDTyCziHb70wtGNFRwB4l+5JNvdqzFSkbDvpbftEgVUBEE+T5f7pROhWMp/fxp07oNIEQZd5bbfAH22ohQ==",
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },
@@ -13616,7 +13510,6 @@
           "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.4.tgz",
           "integrity": "sha512-wKOsqhyXWPSYTGbp7ofVvni17yfRptpqoUdp3SC8RAhDmGkX6irsiT9pON79m6b3HUHfLoBilFQyt/fTUZOf7A==",
           "dev": true,
-          "optional": true,
           "requires": {
             "web3-core": "1.2.4",
             "web3-core-method": "1.2.4",
@@ -13629,26 +13522,26 @@
           "integrity": "sha512-iSv31h2qXkr9vrL6UZDm4leZMc32SjWJFGOp/D92JXfcEboCqraZyuExDkpxKw8ziTufXieNM7LSXNHzszYdJw==",
           "dev": true,
           "requires": {
-            "async": "^2.5.0",
-            "backoff": "^2.5.0",
-            "clone": "^2.0.0",
-            "cross-fetch": "^2.1.0",
-            "eth-block-tracker": "^3.0.0",
-            "eth-json-rpc-infura": "^3.1.0",
-            "eth-sig-util": "^1.4.2",
-            "ethereumjs-block": "^1.2.2",
-            "ethereumjs-tx": "^1.2.0",
-            "ethereumjs-util": "^5.1.5",
-            "ethereumjs-vm": "^2.3.4",
-            "json-rpc-error": "^2.0.0",
-            "json-stable-stringify": "^1.0.1",
-            "promise-to-callback": "^1.0.0",
-            "readable-stream": "^2.2.9",
-            "request": "^2.85.0",
-            "semaphore": "^1.0.3",
-            "ws": "^5.1.1",
-            "xhr": "^2.2.0",
-            "xtend": "^4.0.1"
+            "async": "2.6.2",
+            "backoff": "2.5.0",
+            "clone": "2.1.2",
+            "cross-fetch": "2.2.3",
+            "eth-block-tracker": "3.0.1",
+            "eth-json-rpc-infura": "3.2.1",
+            "eth-sig-util": "1.4.2",
+            "ethereumjs-block": "1.7.1",
+            "ethereumjs-tx": "1.3.7",
+            "ethereumjs-util": "5.2.1",
+            "ethereumjs-vm": "2.6.0",
+            "json-rpc-error": "2.0.0",
+            "json-stable-stringify": "1.0.1",
+            "promise-to-callback": "1.0.0",
+            "readable-stream": "2.3.7",
+            "request": "2.88.2",
+            "semaphore": "1.1.0",
+            "ws": "5.2.2",
+            "xhr": "2.5.0",
+            "xtend": "4.0.2"
           },
           "dependencies": {
             "eth-sig-util": {
@@ -13657,8 +13550,8 @@
               "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
               "dev": true,
               "requires": {
-                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-                "ethereumjs-util": "^5.1.1"
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1ce6a1d64235fabe2aaf827fd606def55693508f",
+                "ethereumjs-util": "5.2.1"
               }
             },
             "ethereum-common": {
@@ -13668,12 +13561,11 @@
               "dev": true
             },
             "ethereumjs-abi": {
-              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1cfbb13862f90f0b391d8a699544d5fe4dfb8c7b",
-              "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+              "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#1ce6a1d64235fabe2aaf827fd606def55693508f",
               "dev": true,
               "requires": {
-                "bn.js": "^4.11.8",
-                "ethereumjs-util": "^6.0.0"
+                "bn.js": "4.11.9",
+                "ethereumjs-util": "6.2.1"
               },
               "dependencies": {
                 "ethereumjs-util": {
@@ -13682,13 +13574,13 @@
                   "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
                   "dev": true,
                   "requires": {
-                    "@types/bn.js": "^4.11.3",
-                    "bn.js": "^4.11.0",
-                    "create-hash": "^1.1.2",
-                    "elliptic": "^6.5.2",
-                    "ethereum-cryptography": "^0.1.3",
+                    "@types/bn.js": "4.11.6",
+                    "bn.js": "4.11.9",
+                    "create-hash": "1.2.0",
+                    "elliptic": "6.5.3",
+                    "ethereum-cryptography": "0.1.3",
                     "ethjs-util": "0.1.6",
-                    "rlp": "^2.2.3"
+                    "rlp": "2.2.6"
                   }
                 }
               }
@@ -13699,9 +13591,9 @@
               "integrity": "sha512-bgDojnXGjhMwo6eXQC0bY6UK2liSFUSMwwylOmQvZbSl/D7NXQ3+vrGO46ZeOgjGfxXmgIeVNDIiHw7fNZM4VA==",
               "dev": true,
               "requires": {
-                "ethereumjs-util": "^5.0.0",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
+                "ethereumjs-util": "5.2.1",
+                "rlp": "2.2.6",
+                "safe-buffer": "5.2.1"
               }
             },
             "ethereumjs-block": {
@@ -13710,11 +13602,11 @@
               "integrity": "sha512-B+sSdtqm78fmKkBq78/QLKJbu/4Ts4P2KFISdgcuZUPDm9x+N7qgBPIIFUGbaakQh8bzuquiRVbdmvPKqbILRg==",
               "dev": true,
               "requires": {
-                "async": "^2.0.1",
+                "async": "2.6.2",
                 "ethereum-common": "0.2.0",
-                "ethereumjs-tx": "^1.2.2",
-                "ethereumjs-util": "^5.0.0",
-                "merkle-patricia-tree": "^2.1.2"
+                "ethereumjs-tx": "1.3.7",
+                "ethereumjs-util": "5.2.1",
+                "merkle-patricia-tree": "2.3.2"
               }
             },
             "ethereumjs-tx": {
@@ -13723,8 +13615,8 @@
               "integrity": "sha512-wvLMxzt1RPhAQ9Yi3/HKZTn0FZYpnsmQdbKYfUUpi4j1SEIcbkd9tndVjcPrufY3V7j2IebOpC00Zp2P/Ay2kA==",
               "dev": true,
               "requires": {
-                "ethereum-common": "^0.0.18",
-                "ethereumjs-util": "^5.0.0"
+                "ethereum-common": "0.0.18",
+                "ethereumjs-util": "5.2.1"
               },
               "dependencies": {
                 "ethereum-common": {
@@ -13741,13 +13633,13 @@
               "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
               "dev": true,
               "requires": {
-                "bn.js": "^4.11.0",
-                "create-hash": "^1.1.2",
-                "elliptic": "^6.5.2",
-                "ethereum-cryptography": "^0.1.3",
-                "ethjs-util": "^0.1.3",
-                "rlp": "^2.0.0",
-                "safe-buffer": "^5.1.1"
+                "bn.js": "4.11.9",
+                "create-hash": "1.2.0",
+                "elliptic": "6.5.3",
+                "ethereum-cryptography": "0.1.3",
+                "ethjs-util": "0.1.6",
+                "rlp": "2.2.6",
+                "safe-buffer": "5.2.1"
               }
             },
             "ethereumjs-vm": {
@@ -13756,17 +13648,17 @@
               "integrity": "sha512-r/XIUik/ynGbxS3y+mvGnbOKnuLo40V5Mj1J25+HEO63aWYREIqvWeRO/hnROlMBE5WoniQmPmhiaN0ctiHaXw==",
               "dev": true,
               "requires": {
-                "async": "^2.1.2",
-                "async-eventemitter": "^0.2.2",
-                "ethereumjs-account": "^2.0.3",
-                "ethereumjs-block": "~2.2.0",
-                "ethereumjs-common": "^1.1.0",
-                "ethereumjs-util": "^6.0.0",
-                "fake-merkle-patricia-tree": "^1.0.1",
-                "functional-red-black-tree": "^1.0.1",
-                "merkle-patricia-tree": "^2.3.2",
-                "rustbn.js": "~0.2.0",
-                "safe-buffer": "^5.1.1"
+                "async": "2.6.2",
+                "async-eventemitter": "0.2.4",
+                "ethereumjs-account": "2.0.5",
+                "ethereumjs-block": "2.2.2",
+                "ethereumjs-common": "1.5.0",
+                "ethereumjs-util": "6.2.1",
+                "fake-merkle-patricia-tree": "1.0.1",
+                "functional-red-black-tree": "1.0.1",
+                "merkle-patricia-tree": "2.3.2",
+                "rustbn.js": "0.2.0",
+                "safe-buffer": "5.2.1"
               },
               "dependencies": {
                 "ethereumjs-block": {
@@ -13775,11 +13667,11 @@
                   "integrity": "sha512-2p49ifhek3h2zeg/+da6XpdFR3GlqY3BIEiqxGF8j9aSRIgkb7M1Ky+yULBKJOu8PAZxfhsYA+HxUk2aCQp3vg==",
                   "dev": true,
                   "requires": {
-                    "async": "^2.0.1",
-                    "ethereumjs-common": "^1.5.0",
-                    "ethereumjs-tx": "^2.1.1",
-                    "ethereumjs-util": "^5.0.0",
-                    "merkle-patricia-tree": "^2.1.2"
+                    "async": "2.6.2",
+                    "ethereumjs-common": "1.5.0",
+                    "ethereumjs-tx": "2.1.2",
+                    "ethereumjs-util": "5.2.1",
+                    "merkle-patricia-tree": "2.3.2"
                   },
                   "dependencies": {
                     "ethereumjs-util": {
@@ -13788,13 +13680,13 @@
                       "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
                       "dev": true,
                       "requires": {
-                        "bn.js": "^4.11.0",
-                        "create-hash": "^1.1.2",
-                        "elliptic": "^6.5.2",
-                        "ethereum-cryptography": "^0.1.3",
-                        "ethjs-util": "^0.1.3",
-                        "rlp": "^2.0.0",
-                        "safe-buffer": "^5.1.1"
+                        "bn.js": "4.11.9",
+                        "create-hash": "1.2.0",
+                        "elliptic": "6.5.3",
+                        "ethereum-cryptography": "0.1.3",
+                        "ethjs-util": "0.1.6",
+                        "rlp": "2.2.6",
+                        "safe-buffer": "5.2.1"
                       }
                     }
                   }
@@ -13805,8 +13697,8 @@
                   "integrity": "sha512-zZEK1onCeiORb0wyCXUvg94Ve5It/K6GD1K+26KfFKodiBiS6d9lfCXlUKGBBdQ+bv7Day+JK0tj1K+BeNFRAw==",
                   "dev": true,
                   "requires": {
-                    "ethereumjs-common": "^1.5.0",
-                    "ethereumjs-util": "^6.0.0"
+                    "ethereumjs-common": "1.5.0",
+                    "ethereumjs-util": "6.2.1"
                   }
                 },
                 "ethereumjs-util": {
@@ -13815,13 +13707,13 @@
                   "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
                   "dev": true,
                   "requires": {
-                    "@types/bn.js": "^4.11.3",
-                    "bn.js": "^4.11.0",
-                    "create-hash": "^1.1.2",
-                    "elliptic": "^6.5.2",
-                    "ethereum-cryptography": "^0.1.3",
+                    "@types/bn.js": "4.11.6",
+                    "bn.js": "4.11.9",
+                    "create-hash": "1.2.0",
+                    "elliptic": "6.5.3",
+                    "ethereum-cryptography": "0.1.3",
                     "ethjs-util": "0.1.6",
-                    "rlp": "^2.2.3"
+                    "rlp": "2.2.6"
                   }
                 }
               }
@@ -13838,13 +13730,13 @@
               "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.1",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               },
               "dependencies": {
                 "safe-buffer": {
@@ -13861,7 +13753,7 @@
               "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "dev": true,
               "requires": {
-                "safe-buffer": "~5.1.0"
+                "safe-buffer": "5.1.2"
               },
               "dependencies": {
                 "safe-buffer": {
@@ -13878,7 +13770,7 @@
               "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
               "dev": true,
               "requires": {
-                "async-limiter": "~1.0.0"
+                "async-limiter": "1.0.1"
               }
             }
           }
@@ -13888,7 +13780,6 @@
           "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.4.tgz",
           "integrity": "sha512-dzVCkRrR/cqlIrcrWNiPt9gyt0AZTE0J+MfAu9rR6CyIgtnm1wFUVVGaxYRxuTGQRO4Dlo49gtoGwaGcyxqiTw==",
           "dev": true,
-          "optional": true,
           "requires": {
             "web3-core-helpers": "1.2.4",
             "xhr2-cookies": "1.1.0"
@@ -13899,7 +13790,6 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.4.tgz",
           "integrity": "sha512-8J3Dguffin51gckTaNrO3oMBo7g+j0UNk6hXmdmQMMNEtrYqw4ctT6t06YOf9GgtOMjSAc1YEh3LPrvgIsR7og==",
           "dev": true,
-          "optional": true,
           "requires": {
             "oboe": "2.1.4",
             "underscore": "1.9.1",
@@ -13911,9 +13801,8 @@
           "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.4.tgz",
           "integrity": "sha512-F/vQpDzeK+++oeeNROl1IVTufFCwCR2hpWe5yRXN0ApLwHqXrMI7UwQNdJ9iyibcWjJf/ECbauEEQ8CHgE+MYQ==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "@web3-js/websocket": "^1.0.29",
+            "@web3-js/websocket": "1.0.30",
             "underscore": "1.9.1",
             "web3-core-helpers": "1.2.4"
           }
@@ -13936,14 +13825,13 @@
           "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.4.tgz",
           "integrity": "sha512-+S86Ip+jqfIPQWvw2N/xBQq5JNqCO0dyvukGdJm8fEWHZbckT4WxSpHbx+9KLEWY4H4x9pUwnoRkK87pYyHfgQ==",
           "dev": true,
-          "optional": true,
           "requires": {
             "bn.js": "4.11.8",
             "eth-lib": "0.2.7",
-            "ethereum-bloom-filters": "^1.0.6",
+            "ethereum-bloom-filters": "1.0.7",
             "ethjs-unit": "0.1.6",
             "number-to-bn": "1.7.0",
-            "randombytes": "^2.1.0",
+            "randombytes": "2.1.0",
             "underscore": "1.9.1",
             "utf8": "3.0.0"
           },
@@ -13952,19 +13840,17 @@
               "version": "4.11.8",
               "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
               "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "eth-lib": {
               "version": "0.2.7",
               "resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.7.tgz",
               "integrity": "sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=",
               "dev": true,
-              "optional": true,
               "requires": {
-                "bn.js": "^4.11.6",
-                "elliptic": "^6.4.0",
-                "xhr-request-promise": "^0.1.2"
+                "bn.js": "4.11.8",
+                "elliptic": "6.5.3",
+                "xhr-request-promise": "0.1.3"
               }
             }
           }
@@ -13975,11 +13861,11 @@
           "integrity": "sha512-WhU8jKXC8sTh6ocLSqpZRlOKMNYGwUvjA5+XcIgIk/G3JCaDfkZUr0zA19sVSxJ0TEvm0i5IBzr54RZC4vzW7g==",
           "dev": true,
           "requires": {
-            "debug": "^2.2.0",
-            "gulp": "^4.0.2",
-            "nan": "^2.11.0",
-            "typedarray-to-buffer": "^3.1.5",
-            "yaeti": "^0.0.6"
+            "debug": "2.6.9",
+            "gulp": "4.0.2",
+            "nan": "2.14.1",
+            "typedarray-to-buffer": "3.1.5",
+            "yaeti": "0.0.6"
           },
           "dependencies": {
             "debug": {
@@ -14011,7 +13897,7 @@
           "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "dev": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "isexe": "2.0.0"
           }
         },
         "which-module": {
@@ -14026,8 +13912,8 @@
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
           }
         },
         "wrappy": {
@@ -14043,9 +13929,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "async-limiter": "~1.0.0",
-            "safe-buffer": "~5.1.0",
-            "ultron": "~1.1.0"
+            "async-limiter": "1.0.1",
+            "safe-buffer": "5.1.2",
+            "ultron": "1.1.1"
           },
           "dependencies": {
             "safe-buffer": {
@@ -14063,10 +13949,10 @@
           "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
           "dev": true,
           "requires": {
-            "global": "~4.3.0",
-            "is-function": "^1.0.1",
-            "parse-headers": "^2.0.0",
-            "xtend": "^4.0.0"
+            "global": "4.3.2",
+            "is-function": "1.0.2",
+            "parse-headers": "2.0.3",
+            "xtend": "4.0.2"
           }
         },
         "xhr-request": {
@@ -14074,15 +13960,14 @@
           "resolved": "https://registry.npmjs.org/xhr-request/-/xhr-request-1.1.0.tgz",
           "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "buffer-to-arraybuffer": "^0.0.5",
-            "object-assign": "^4.1.1",
-            "query-string": "^5.0.1",
-            "simple-get": "^2.7.0",
-            "timed-out": "^4.0.1",
-            "url-set-query": "^1.0.0",
-            "xhr": "^2.0.4"
+            "buffer-to-arraybuffer": "0.0.5",
+            "object-assign": "4.1.1",
+            "query-string": "5.1.1",
+            "simple-get": "2.8.1",
+            "timed-out": "4.0.1",
+            "url-set-query": "1.0.0",
+            "xhr": "2.5.0"
           }
         },
         "xhr-request-promise": {
@@ -14090,9 +13975,8 @@
           "resolved": "https://registry.npmjs.org/xhr-request-promise/-/xhr-request-promise-0.1.3.tgz",
           "integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
           "dev": true,
-          "optional": true,
           "requires": {
-            "xhr-request": "^1.1.0"
+            "xhr-request": "1.1.0"
           }
         },
         "xhr2-cookies": {
@@ -14100,17 +13984,15 @@
           "resolved": "https://registry.npmjs.org/xhr2-cookies/-/xhr2-cookies-1.1.0.tgz",
           "integrity": "sha1-fXdEnQmZGX8VXLc7I99yUF7YnUg=",
           "dev": true,
-          "optional": true,
           "requires": {
-            "cookiejar": "^2.1.1"
+            "cookiejar": "2.1.2"
           }
         },
         "xmlhttprequest": {
           "version": "1.8.0",
           "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
           "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "xtend": {
           "version": "4.0.2",
@@ -14142,18 +14024,18 @@
           "integrity": "sha512-huO4Fr1f9PmiJJdll5kwoS2e4GqzGSsMT3PPMpOwoVkOK8ckqAewMTZyA6LXVQWflleb/Z8oPBEvNsMft0XE+g==",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^1.4.0",
-            "read-pkg-up": "^1.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^1.0.2",
-            "which-module": "^1.0.0",
-            "y18n": "^3.2.1",
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.3",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
             "yargs-parser": "5.0.0-security.0"
           }
         },
@@ -14163,8 +14045,8 @@
           "integrity": "sha512-T69y4Ps64LNesYxeYGYPvfoMTt/7y1XtfpIslUeK4um+9Hu7hlGoRtaDLvdXb7+/tfq4opVa2HRY5xGip022rQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^3.0.0",
-            "object.assign": "^4.1.0"
+            "camelcase": "3.0.0",
+            "object.assign": "4.1.0"
           }
         },
         "yauzl": {
@@ -14174,8 +14056,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "buffer-crc32": "~0.2.3",
-            "fd-slicer": "~1.1.0"
+            "buffer-crc32": "0.2.13",
+            "fd-slicer": "1.1.0"
           }
         }
       }
@@ -14198,7 +14080,7 @@
       "integrity": "sha512-zmZIaQTWnNQb4R4fJUEp/FC51eZsc6EkErspy3xtIYStaq8EB/hDIWipxsal+E8rz0qD7f2sL/NA9Xee4RInJw==",
       "dev": true,
       "requires": {
-        "npm-conf": "^1.1.0"
+        "npm-conf": "1.1.3"
       }
     },
     "get-stream": {
@@ -14219,7 +14101,7 @@
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "glob": {
@@ -14228,12 +14110,12 @@
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.4",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "glob-parent": {
@@ -14242,7 +14124,7 @@
       "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
       "dev": true,
       "requires": {
-        "is-glob": "^4.0.1"
+        "is-glob": "4.0.1"
       }
     },
     "global": {
@@ -14251,8 +14133,8 @@
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "dev": true,
       "requires": {
-        "min-document": "^2.19.0",
-        "process": "~0.5.1"
+        "min-document": "2.19.0",
+        "process": "0.5.2"
       }
     },
     "global-dirs": {
@@ -14261,7 +14143,7 @@
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
       "dev": true,
       "requires": {
-        "ini": "^1.3.4"
+        "ini": "1.3.5"
       }
     },
     "got": {
@@ -14270,23 +14152,23 @@
       "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
       "dev": true,
       "requires": {
-        "@sindresorhus/is": "^0.7.0",
-        "cacheable-request": "^2.1.1",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "into-stream": "^3.1.0",
-        "is-retry-allowed": "^1.1.0",
-        "isurl": "^1.0.0-alpha5",
-        "lowercase-keys": "^1.0.0",
-        "mimic-response": "^1.0.0",
-        "p-cancelable": "^0.4.0",
-        "p-timeout": "^2.0.1",
-        "pify": "^3.0.0",
-        "safe-buffer": "^5.1.1",
-        "timed-out": "^4.0.1",
-        "url-parse-lax": "^3.0.0",
-        "url-to-options": "^1.0.1"
+        "@sindresorhus/is": "0.7.0",
+        "cacheable-request": "2.1.4",
+        "decompress-response": "3.3.0",
+        "duplexer3": "0.1.4",
+        "get-stream": "3.0.0",
+        "into-stream": "3.1.0",
+        "is-retry-allowed": "1.2.0",
+        "isurl": "1.0.0",
+        "lowercase-keys": "1.0.1",
+        "mimic-response": "1.0.1",
+        "p-cancelable": "0.4.1",
+        "p-timeout": "2.0.1",
+        "pify": "3.0.0",
+        "safe-buffer": "5.2.1",
+        "timed-out": "4.0.1",
+        "url-parse-lax": "3.0.0",
+        "url-to-options": "1.0.1"
       }
     },
     "graceful-fs": {
@@ -14313,8 +14195,8 @@
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "dev": true,
       "requires": {
-        "ajv": "^6.12.3",
-        "har-schema": "^2.0.0"
+        "ajv": "6.12.4",
+        "har-schema": "2.0.0"
       }
     },
     "has": {
@@ -14323,7 +14205,7 @@
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "1.1.1"
       }
     },
     "has-ansi": {
@@ -14332,7 +14214,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -14367,7 +14249,7 @@
       "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "dev": true,
       "requires": {
-        "has-symbol-support-x": "^1.4.1"
+        "has-symbol-support-x": "1.4.2"
       }
     },
     "has-unicode": {
@@ -14382,9 +14264,9 @@
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
       "requires": {
-        "get-value": "^2.0.6",
-        "has-values": "^1.0.0",
-        "isobject": "^3.0.0"
+        "get-value": "2.0.6",
+        "has-values": "1.0.0",
+        "isobject": "3.0.1"
       }
     },
     "has-values": {
@@ -14393,8 +14275,8 @@
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
       "requires": {
-        "is-number": "^3.0.0",
-        "kind-of": "^4.0.0"
+        "is-number": "3.0.0",
+        "kind-of": "4.0.0"
       },
       "dependencies": {
         "is-buffer": {
@@ -14409,7 +14291,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "kind-of": {
@@ -14418,7 +14300,7 @@
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -14429,7 +14311,7 @@
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -14440,9 +14322,9 @@
       "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.6.0",
-        "safe-buffer": "^5.2.0"
+        "inherits": "2.0.4",
+        "readable-stream": "3.6.0",
+        "safe-buffer": "5.2.1"
       }
     },
     "hash.js": {
@@ -14451,8 +14333,8 @@
       "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "minimalistic-assert": "^1.0.1"
+        "inherits": "2.0.4",
+        "minimalistic-assert": "1.0.1"
       }
     },
     "he": {
@@ -14467,9 +14349,9 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "^1.0.3",
-        "minimalistic-assert": "^1.0.0",
-        "minimalistic-crypto-utils": "^1.0.1"
+        "hash.js": "1.1.7",
+        "minimalistic-assert": "1.0.1",
+        "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "hosted-git-info": {
@@ -14490,10 +14372,10 @@
       "integrity": "sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==",
       "dev": true,
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "1.1.2",
         "inherits": "2.0.4",
         "setprototypeof": "1.1.1",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "1.5.0",
         "toidentifier": "1.0.0"
       }
     },
@@ -14503,9 +14385,9 @@
       "integrity": "sha1-zBzjjkU7+YSg93AtLdWcc9CBKEo=",
       "dev": true,
       "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3"
+        "agent-base": "2.1.1",
+        "debug": "2.6.9",
+        "extend": "3.0.2"
       },
       "dependencies": {
         "debug": {
@@ -14531,9 +14413,9 @@
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.16.1"
       }
     },
     "https-proxy-agent": {
@@ -14542,9 +14424,9 @@
       "integrity": "sha1-NffabEjOTdv6JkiRrFk+5f+GceY=",
       "dev": true,
       "requires": {
-        "agent-base": "2",
-        "debug": "2",
-        "extend": "3"
+        "agent-base": "2.1.1",
+        "debug": "2.6.9",
+        "extend": "3.0.2"
       },
       "dependencies": {
         "debug": {
@@ -14570,7 +14452,7 @@
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "dev": true,
       "requires": {
-        "safer-buffer": ">= 2.1.2 < 3"
+        "safer-buffer": "2.1.2"
       }
     },
     "idna-uts46-hx": {
@@ -14620,8 +14502,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -14642,8 +14524,8 @@
       "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
       "dev": true,
       "requires": {
-        "from2": "^2.1.1",
-        "p-is-promise": "^1.1.0"
+        "from2": "2.3.0",
+        "p-is-promise": "1.1.0"
       }
     },
     "invariant": {
@@ -14652,7 +14534,7 @@
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "dev": true,
       "requires": {
-        "loose-envify": "^1.0.0"
+        "loose-envify": "1.4.0"
       }
     },
     "invert-kv": {
@@ -14667,7 +14549,7 @@
       "integrity": "sha512-b23PteSnYXSONJ6JQXRAlvJhuw8KOtkqa87W4wDtvMrud/DTJd5X+NpOOI+O/zZwVq6v0VLAaJ+1EDViKEuN9g==",
       "dev": true,
       "requires": {
-        "fp-ts": "^1.0.0"
+        "fp-ts": "1.19.3"
       }
     },
     "is-absolute": {
@@ -14676,8 +14558,8 @@
       "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
       "dev": true,
       "requires": {
-        "is-relative": "^0.2.1",
-        "is-windows": "^0.2.0"
+        "is-relative": "0.2.1",
+        "is-windows": "0.2.0"
       }
     },
     "is-accessor-descriptor": {
@@ -14686,7 +14568,7 @@
       "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "is-buffer": {
@@ -14701,7 +14583,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -14718,7 +14600,7 @@
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
       "dev": true,
       "requires": {
-        "binary-extensions": "^2.0.0"
+        "binary-extensions": "2.1.0"
       }
     },
     "is-buffer": {
@@ -14739,7 +14621,7 @@
       "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
       "dev": true,
       "requires": {
-        "ci-info": "^1.5.0"
+        "ci-info": "1.6.0"
       }
     },
     "is-data-descriptor": {
@@ -14748,7 +14630,7 @@
       "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "is-buffer": {
@@ -14763,7 +14645,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -14780,9 +14662,9 @@
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "dev": true,
       "requires": {
-        "is-accessor-descriptor": "^0.1.6",
-        "is-data-descriptor": "^0.1.4",
-        "kind-of": "^5.0.0"
+        "is-accessor-descriptor": "0.1.6",
+        "is-data-descriptor": "0.1.4",
+        "kind-of": "5.1.0"
       },
       "dependencies": {
         "kind-of": {
@@ -14823,7 +14705,7 @@
       "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
       "dev": true,
       "requires": {
-        "is-extglob": "^2.1.1"
+        "is-extglob": "2.1.1"
       }
     },
     "is-hex-prefixed": {
@@ -14838,8 +14720,8 @@
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
       "dev": true,
       "requires": {
-        "global-dirs": "^0.1.0",
-        "is-path-inside": "^1.0.0"
+        "global-dirs": "0.1.1",
+        "is-path-inside": "1.0.1"
       }
     },
     "is-natural-number": {
@@ -14884,7 +14766,7 @@
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
       "dev": true,
       "requires": {
-        "path-is-inside": "^1.0.1"
+        "path-is-inside": "1.0.2"
       }
     },
     "is-plain-obj": {
@@ -14899,7 +14781,7 @@
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "is-redirect": {
@@ -14914,7 +14796,7 @@
       "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.1"
+        "has-symbols": "1.0.1"
       }
     },
     "is-relative": {
@@ -14923,7 +14805,7 @@
       "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
       "dev": true,
       "requires": {
-        "is-unc-path": "^0.1.1"
+        "is-unc-path": "0.1.2"
       }
     },
     "is-retry-allowed": {
@@ -14944,7 +14826,7 @@
       "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.1"
+        "has-symbols": "1.0.1"
       }
     },
     "is-typedarray": {
@@ -14959,7 +14841,7 @@
       "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
       "dev": true,
       "requires": {
-        "unc-path-regex": "^0.1.0"
+        "unc-path-regex": "0.1.2"
       }
     },
     "is-url": {
@@ -15010,8 +14892,8 @@
       "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
       "dev": true,
       "requires": {
-        "has-to-string-tag-x": "^1.2.0",
-        "is-object": "^1.0.1"
+        "has-to-string-tag-x": "1.4.1",
+        "is-object": "1.0.1"
       }
     },
     "js-sha3": {
@@ -15032,8 +14914,8 @@
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "jsbn": {
@@ -15072,7 +14954,7 @@
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.2.4"
       }
     },
     "jspm-config": {
@@ -15081,15 +14963,15 @@
       "integrity": "sha1-RMJpAuSujs4jZs7cn/FrEKXzkcY=",
       "dev": true,
       "requires": {
-        "any-promise": "^1.3.0",
-        "graceful-fs": "^4.1.4",
-        "make-error-cause": "^1.2.1",
-        "object.pick": "^1.1.2",
-        "parse-json": "^2.2.0",
-        "strip-bom": "^3.0.0",
-        "thenify": "^3.2.0",
-        "throat": "^3.0.0",
-        "xtend": "^4.0.1"
+        "any-promise": "1.3.0",
+        "graceful-fs": "4.2.4",
+        "make-error-cause": "1.2.2",
+        "object.pick": "1.3.0",
+        "parse-json": "2.2.0",
+        "strip-bom": "3.0.0",
+        "thenify": "3.3.1",
+        "throat": "3.2.0",
+        "xtend": "4.0.2"
       },
       "dependencies": {
         "parse-json": {
@@ -15098,7 +14980,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.2"
           }
         },
         "strip-bom": {
@@ -15127,8 +15009,8 @@
       "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
       "dev": true,
       "requires": {
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
+        "node-addon-api": "2.0.2",
+        "node-gyp-build": "4.2.3"
       }
     },
     "keyv": {
@@ -15152,7 +15034,7 @@
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.9"
+        "graceful-fs": "4.2.4"
       }
     },
     "klaw-sync": {
@@ -15161,7 +15043,7 @@
       "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11"
+        "graceful-fs": "4.2.4"
       }
     },
     "latest-version": {
@@ -15170,7 +15052,7 @@
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
       "dev": true,
       "requires": {
-        "package-json": "^4.0.0"
+        "package-json": "4.0.1"
       }
     },
     "lcid": {
@@ -15179,7 +15061,7 @@
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
       "dev": true,
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "1.0.0"
       }
     },
     "level-codec": {
@@ -15194,7 +15076,7 @@
       "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
       "dev": true,
       "requires": {
-        "errno": "~0.1.1"
+        "errno": "0.1.7"
       }
     },
     "level-iterator-stream": {
@@ -15203,10 +15085,10 @@
       "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "level-errors": "^1.0.3",
-        "readable-stream": "^1.0.33",
-        "xtend": "^4.0.0"
+        "inherits": "2.0.4",
+        "level-errors": "1.0.5",
+        "readable-stream": "1.1.14",
+        "xtend": "4.0.2"
       },
       "dependencies": {
         "isarray": {
@@ -15221,10 +15103,10 @@
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.4",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -15241,8 +15123,8 @@
       "integrity": "sha512-LbtfK9+3Ug1UmvvhR2DqLqXiPW1OJ5jEh0a3m9ZgAipiwpSxGj/qaVVy54RG5vAQN1nCuXqjvprCuKSCxcJHBg==",
       "dev": true,
       "requires": {
-        "level-packager": "~4.0.0",
-        "memdown": "~3.0.0"
+        "level-packager": "4.0.1",
+        "memdown": "3.0.0"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -15251,7 +15133,7 @@
           "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
           "dev": true,
           "requires": {
-            "xtend": "~4.0.0"
+            "xtend": "4.0.2"
           }
         },
         "immediate": {
@@ -15266,12 +15148,12 @@
           "integrity": "sha512-tbV02LfZMWLcHcq4tw++NuqMO+FZX8tNJEiD2aNRm48ZZusVg5N8NART+dmBkepJVye986oixErf7jfXboMGMA==",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "~5.0.0",
-            "functional-red-black-tree": "~1.0.1",
-            "immediate": "~3.2.3",
-            "inherits": "~2.0.1",
-            "ltgt": "~2.2.0",
-            "safe-buffer": "~5.1.1"
+            "abstract-leveldown": "5.0.0",
+            "functional-red-black-tree": "1.0.1",
+            "immediate": "3.2.3",
+            "inherits": "2.0.4",
+            "ltgt": "2.2.1",
+            "safe-buffer": "5.1.2"
           }
         },
         "safe-buffer": {
@@ -15288,8 +15170,8 @@
       "integrity": "sha512-svCRKfYLn9/4CoFfi+d8krOtrp6RoX8+xm0Na5cgXMqSyRru0AnDYdLl+YI8u1FyS6gGZ94ILLZDE5dh2but3Q==",
       "dev": true,
       "requires": {
-        "encoding-down": "~5.0.0",
-        "levelup": "^3.0.0"
+        "encoding-down": "5.0.4",
+        "levelup": "3.1.1"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -15298,7 +15180,7 @@
           "integrity": "sha512-5mU5P1gXtsMIXg65/rsYGsi93+MlogXZ9FA8JnwKurHQg64bfXwGYVdVdijNTVNOlAsuIiOwHdvFFD5JqCJQ7A==",
           "dev": true,
           "requires": {
-            "xtend": "~4.0.0"
+            "xtend": "4.0.2"
           }
         },
         "deferred-leveldown": {
@@ -15307,8 +15189,8 @@
           "integrity": "sha512-5fMC8ek8alH16QiV0lTCis610D1Zt1+LA4MS4d63JgS32lrCjTFDUFz2ao09/j2I4Bqb5jL4FZYwu7Jz0XO1ww==",
           "dev": true,
           "requires": {
-            "abstract-leveldown": "~5.0.0",
-            "inherits": "^2.0.3"
+            "abstract-leveldown": "5.0.0",
+            "inherits": "2.0.4"
           }
         },
         "level-errors": {
@@ -15317,7 +15199,7 @@
           "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
           "dev": true,
           "requires": {
-            "errno": "~0.1.1"
+            "errno": "0.1.7"
           }
         },
         "level-iterator-stream": {
@@ -15326,9 +15208,9 @@
           "integrity": "sha512-nEIQvxEED9yRThxvOrq8Aqziy4EGzrxSZK+QzEFAVuJvQ8glfyZ96GB6BoI4sBbLfjMXm2w4vu3Tkcm9obcY0g==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.1",
-            "readable-stream": "^2.3.6",
-            "xtend": "^4.0.0"
+            "inherits": "2.0.4",
+            "readable-stream": "2.3.7",
+            "xtend": "4.0.2"
           }
         },
         "levelup": {
@@ -15337,10 +15219,10 @@
           "integrity": "sha512-9N10xRkUU4dShSRRFTBdNaBxofz+PGaIZO962ckboJZiNmLuhVT6FZ6ZKAsICKfUBO76ySaYU6fJWX/jnj3Lcg==",
           "dev": true,
           "requires": {
-            "deferred-leveldown": "~4.0.0",
-            "level-errors": "~2.0.0",
-            "level-iterator-stream": "~3.0.0",
-            "xtend": "~4.0.0"
+            "deferred-leveldown": "4.0.2",
+            "level-errors": "2.0.1",
+            "level-iterator-stream": "3.0.1",
+            "xtend": "4.0.2"
           }
         },
         "readable-stream": {
@@ -15349,13 +15231,13 @@
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.4",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.1",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "safe-buffer": {
@@ -15370,7 +15252,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -15381,8 +15263,8 @@
       "integrity": "sha1-Ny5RIXeSSgBCSwtDrvK7QkltIos=",
       "dev": true,
       "requires": {
-        "readable-stream": "~1.0.15",
-        "xtend": "~2.1.1"
+        "readable-stream": "1.0.34",
+        "xtend": "2.1.2"
       },
       "dependencies": {
         "isarray": {
@@ -15397,10 +15279,10 @@
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.4",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -15415,7 +15297,7 @@
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "dev": true,
           "requires": {
-            "object-keys": "~0.4.0"
+            "object-keys": "0.4.0"
           }
         }
       }
@@ -15426,13 +15308,13 @@
       "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
       "dev": true,
       "requires": {
-        "deferred-leveldown": "~1.2.1",
-        "level-codec": "~7.0.0",
-        "level-errors": "~1.0.3",
-        "level-iterator-stream": "~1.3.0",
-        "prr": "~1.0.1",
-        "semver": "~5.4.1",
-        "xtend": "~4.0.0"
+        "deferred-leveldown": "1.2.2",
+        "level-codec": "7.0.1",
+        "level-errors": "1.0.5",
+        "level-iterator-stream": "1.3.1",
+        "prr": "1.0.1",
+        "semver": "5.4.1",
+        "xtend": "4.0.2"
       },
       "dependencies": {
         "semver": {
@@ -15455,11 +15337,11 @@
       "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "parse-json": "^2.2.0",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0",
-        "strip-bom": "^2.0.0"
+        "graceful-fs": "4.2.4",
+        "parse-json": "2.2.0",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "strip-bom": "2.0.0"
       },
       "dependencies": {
         "pify": {
@@ -15476,8 +15358,8 @@
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
       "dev": true,
       "requires": {
-        "p-locate": "^2.0.0",
-        "path-exists": "^3.0.0"
+        "p-locate": "2.0.0",
+        "path-exists": "3.0.0"
       }
     },
     "lockfile": {
@@ -15486,7 +15368,7 @@
       "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
       "dev": true,
       "requires": {
-        "signal-exit": "^3.0.2"
+        "signal-exit": "3.0.3"
       }
     },
     "lodash": {
@@ -15507,7 +15389,7 @@
       "integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.2"
+        "chalk": "2.4.2"
       }
     },
     "log-update": {
@@ -15516,8 +15398,8 @@
       "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
       "dev": true,
       "requires": {
-        "ansi-escapes": "^1.0.0",
-        "cli-cursor": "^1.0.2"
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
       }
     },
     "loose-envify": {
@@ -15526,7 +15408,7 @@
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
       "dev": true,
       "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
+        "js-tokens": "4.0.0"
       }
     },
     "lowercase-keys": {
@@ -15541,8 +15423,8 @@
       "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
-        "pseudomap": "^1.0.2",
-        "yallist": "^2.1.2"
+        "pseudomap": "1.0.2",
+        "yallist": "2.1.2"
       },
       "dependencies": {
         "yallist": {
@@ -15571,7 +15453,7 @@
       "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
-        "pify": "^3.0.0"
+        "pify": "3.0.0"
       }
     },
     "make-error": {
@@ -15586,7 +15468,7 @@
       "integrity": "sha1-3wOI/NCzeBbf8KX7gQiTl3fcvJ0=",
       "dev": true,
       "requires": {
-        "make-error": "^1.2.0"
+        "make-error": "1.3.6"
       }
     },
     "map-cache": {
@@ -15601,7 +15483,7 @@
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
       "dev": true,
       "requires": {
-        "object-visit": "^1.0.0"
+        "object-visit": "1.0.1"
       }
     },
     "mcl-wasm": {
@@ -15610,7 +15492,7 @@
       "integrity": "sha512-9qawGEhPpuLagURi0l6JPRGCHnEuYCI6gZ/STeKt/5ho/g3ybTOOavvxM/NwPGs6jVtMaQwmXqi7jx5I+yax6A==",
       "dev": true,
       "requires": {
-        "nyc": "^11.8.0"
+        "nyc": "11.9.0"
       }
     },
     "md5.js": {
@@ -15619,9 +15501,9 @@
       "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
       "dev": true,
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.1.2"
+        "hash-base": "3.1.0",
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.1"
       }
     },
     "memdown": {
@@ -15630,12 +15512,12 @@
       "integrity": "sha1-tOThkhdGZP+65BNhqlAPMRnv4hU=",
       "dev": true,
       "requires": {
-        "abstract-leveldown": "~2.7.1",
-        "functional-red-black-tree": "^1.0.1",
-        "immediate": "^3.2.3",
-        "inherits": "~2.0.1",
-        "ltgt": "~2.2.0",
-        "safe-buffer": "~5.1.1"
+        "abstract-leveldown": "2.7.2",
+        "functional-red-black-tree": "1.0.1",
+        "immediate": "3.3.0",
+        "inherits": "2.0.4",
+        "ltgt": "2.2.1",
+        "safe-buffer": "5.1.2"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -15644,7 +15526,7 @@
           "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
           "dev": true,
           "requires": {
-            "xtend": "~4.0.0"
+            "xtend": "4.0.2"
           }
         },
         "safe-buffer": {
@@ -15667,13 +15549,13 @@
       "integrity": "sha512-soRaMuNf/ILmw3KWbybaCjhx86EYeBbD8ph0edQCTed0JN/rxDt1EBN52Ajre3VyGo+91f8+/rfPIRQnnGMqmQ==",
       "dev": true,
       "requires": {
-        "async": "^2.6.1",
-        "ethereumjs-util": "^5.2.0",
-        "level-mem": "^3.0.1",
-        "level-ws": "^1.0.0",
-        "readable-stream": "^3.0.6",
-        "rlp": "^2.0.0",
-        "semaphore": ">=1.0.1"
+        "async": "2.6.3",
+        "ethereumjs-util": "5.2.1",
+        "level-mem": "3.0.1",
+        "level-ws": "1.0.0",
+        "readable-stream": "3.6.0",
+        "rlp": "2.2.6",
+        "semaphore": "1.1.0"
       },
       "dependencies": {
         "bn.js": {
@@ -15688,13 +15570,13 @@
           "integrity": "sha512-v3kT+7zdyCm1HIqWlLNrHGqHGLpGYIhjeHxQjnDXjLT2FyGJDsd3LWMYUo7pAFRrk86CR3nUJfhC81CCoJNNGQ==",
           "dev": true,
           "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "^0.1.3",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1"
+            "bn.js": "4.11.9",
+            "create-hash": "1.2.0",
+            "elliptic": "6.5.3",
+            "ethereum-cryptography": "0.1.3",
+            "ethjs-util": "0.1.6",
+            "rlp": "2.2.6",
+            "safe-buffer": "5.2.1"
           }
         },
         "level-ws": {
@@ -15703,9 +15585,9 @@
           "integrity": "sha512-RXEfCmkd6WWFlArh3X8ONvQPm8jNpfA0s/36M4QzLqrLEIt1iJE9WBHLZ5vZJK6haMjJPJGJCQWfjMNnRcq/9Q==",
           "dev": true,
           "requires": {
-            "inherits": "^2.0.3",
-            "readable-stream": "^2.2.8",
-            "xtend": "^4.0.1"
+            "inherits": "2.0.4",
+            "readable-stream": "2.3.7",
+            "xtend": "4.0.2"
           },
           "dependencies": {
             "readable-stream": {
@@ -15714,13 +15596,13 @@
               "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
               "dev": true,
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.4",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.1",
+                "safe-buffer": "5.1.2",
+                "string_decoder": "1.1.1",
+                "util-deprecate": "1.0.2"
               }
             },
             "safe-buffer": {
@@ -15737,7 +15619,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           },
           "dependencies": {
             "safe-buffer": {
@@ -15756,8 +15638,8 @@
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.0.0",
-        "brorand": "^1.0.1"
+        "bn.js": "4.11.9",
+        "brorand": "1.1.0"
       },
       "dependencies": {
         "bn.js": {
@@ -15795,7 +15677,7 @@
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "dev": true,
       "requires": {
-        "dom-walk": "^0.1.0"
+        "dom-walk": "0.1.2"
       }
     },
     "minimalistic-assert": {
@@ -15816,7 +15698,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -15831,8 +15713,8 @@
       "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
-        "for-in": "^1.0.2",
-        "is-extendable": "^1.0.1"
+        "for-in": "1.0.2",
+        "is-extendable": "1.0.1"
       },
       "dependencies": {
         "is-extendable": {
@@ -15841,7 +15723,7 @@
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
           "dev": true,
           "requires": {
-            "is-plain-object": "^2.0.4"
+            "is-plain-object": "2.0.4"
           }
         }
       }
@@ -15852,7 +15734,7 @@
       "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "^1.2.5"
+        "minimist": "1.2.5"
       }
     },
     "mocha": {
@@ -15899,14 +15781,14 @@
           "integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
           "dev": true,
           "requires": {
-            "anymatch": "~3.1.1",
-            "braces": "~3.0.2",
-            "fsevents": "~2.1.1",
-            "glob-parent": "~5.1.0",
-            "is-binary-path": "~2.1.0",
-            "is-glob": "~4.0.1",
-            "normalize-path": "~3.0.0",
-            "readdirp": "~3.2.0"
+            "anymatch": "3.1.1",
+            "braces": "3.0.2",
+            "fsevents": "2.1.3",
+            "glob-parent": "5.1.1",
+            "is-binary-path": "2.1.0",
+            "is-glob": "4.0.1",
+            "normalize-path": "3.0.0",
+            "readdirp": "3.2.0"
           }
         },
         "debug": {
@@ -15915,7 +15797,7 @@
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "find-up": {
@@ -15924,7 +15806,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "locate-path": "3.0.0"
           }
         },
         "locate-path": {
@@ -15933,8 +15815,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "object-keys": {
@@ -15949,10 +15831,10 @@
           "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
           "dev": true,
           "requires": {
-            "define-properties": "^1.1.2",
-            "function-bind": "^1.1.1",
-            "has-symbols": "^1.0.0",
-            "object-keys": "^1.0.11"
+            "define-properties": "1.1.3",
+            "function-bind": "1.1.1",
+            "has-symbols": "1.0.1",
+            "object-keys": "1.1.1"
           }
         },
         "p-limit": {
@@ -15961,7 +15843,7 @@
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "p-try": "2.2.0"
           }
         },
         "p-locate": {
@@ -15970,7 +15852,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "p-limit": "2.3.0"
           }
         },
         "p-try": {
@@ -15985,7 +15867,7 @@
           "integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
           "dev": true,
           "requires": {
-            "picomatch": "^2.0.4"
+            "picomatch": "2.2.2"
           }
         }
       }
@@ -16009,17 +15891,17 @@
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
-        "arr-diff": "^4.0.0",
-        "array-unique": "^0.3.2",
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "fragment-cache": "^0.2.1",
-        "is-windows": "^1.0.2",
-        "kind-of": "^6.0.2",
-        "object.pick": "^1.3.0",
-        "regex-not": "^1.0.0",
-        "snapdragon": "^0.8.1",
-        "to-regex": "^3.0.1"
+        "arr-diff": "4.0.0",
+        "array-unique": "0.3.2",
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "fragment-cache": "0.2.1",
+        "is-windows": "1.0.2",
+        "kind-of": "6.0.3",
+        "object.pick": "1.3.0",
+        "regex-not": "1.0.2",
+        "snapdragon": "0.8.2",
+        "to-regex": "3.0.2"
       },
       "dependencies": {
         "is-windows": {
@@ -16048,8 +15930,8 @@
       "integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
       "dev": true,
       "requires": {
-        "object.getownpropertydescriptors": "^2.0.3",
-        "semver": "^5.7.0"
+        "object.getownpropertydescriptors": "2.1.0",
+        "semver": "5.7.1"
       }
     },
     "node-fetch": {
@@ -16070,10 +15952,10 @@
       "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
+        "hosted-git-info": "2.8.8",
+        "resolve": "1.17.0",
+        "semver": "5.7.1",
+        "validate-npm-package-license": "3.0.4"
       }
     },
     "normalize-path": {
@@ -16088,9 +15970,9 @@
       "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
       "dev": true,
       "requires": {
-        "prepend-http": "^2.0.0",
-        "query-string": "^5.0.1",
-        "sort-keys": "^2.0.0"
+        "prepend-http": "2.0.0",
+        "query-string": "5.1.1",
+        "sort-keys": "2.0.0"
       },
       "dependencies": {
         "sort-keys": {
@@ -16099,7 +15981,7 @@
           "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
           "dev": true,
           "requires": {
-            "is-plain-obj": "^1.0.0"
+            "is-plain-obj": "1.1.0"
           }
         }
       }
@@ -16110,8 +15992,8 @@
       "integrity": "sha512-Yic4bZHJOt9RCFbRP3GgpqhScOY4HH3V2P8yBj6CeYq118Qr+BLXqT2JvpJ00mryLESpgOxf5XlFv4ZjXxLScw==",
       "dev": true,
       "requires": {
-        "config-chain": "^1.1.11",
-        "pify": "^3.0.0"
+        "config-chain": "1.1.12",
+        "pify": "3.0.0"
       }
     },
     "npm-run-path": {
@@ -16120,7 +16002,7 @@
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "dev": true,
       "requires": {
-        "path-key": "^2.0.0"
+        "path-key": "2.0.1"
       }
     },
     "number-is-nan": {
@@ -16153,33 +16035,33 @@
       "integrity": "sha512-w8OdJAhXL5izerzZMdqzYKMj/pgHJyY3qEPYBjLLxrhcVoHEY9pU5ENIiZyCgG9OR7x3VcUMoD40o6PtVpfR4g==",
       "dev": true,
       "requires": {
-        "archy": "^1.0.0",
-        "arrify": "^1.0.1",
-        "caching-transform": "^1.0.0",
-        "convert-source-map": "^1.5.1",
-        "debug-log": "^1.0.1",
-        "default-require-extensions": "^1.0.0",
-        "find-cache-dir": "^0.1.1",
-        "find-up": "^2.1.0",
-        "foreground-child": "^1.5.3",
-        "glob": "^7.0.6",
-        "istanbul-lib-coverage": "^1.1.2",
-        "istanbul-lib-hook": "^1.1.0",
-        "istanbul-lib-instrument": "^1.10.0",
-        "istanbul-lib-report": "^1.1.3",
-        "istanbul-lib-source-maps": "^1.2.3",
-        "istanbul-reports": "^1.4.0",
-        "md5-hex": "^1.2.0",
-        "merge-source-map": "^1.1.0",
-        "micromatch": "^3.1.10",
-        "mkdirp": "^0.5.0",
-        "resolve-from": "^2.0.0",
-        "rimraf": "^2.6.2",
-        "signal-exit": "^3.0.1",
-        "spawn-wrap": "^1.4.2",
-        "test-exclude": "^4.2.0",
+        "archy": "1.0.0",
+        "arrify": "1.0.1",
+        "caching-transform": "1.0.1",
+        "convert-source-map": "1.5.1",
+        "debug-log": "1.0.1",
+        "default-require-extensions": "1.0.0",
+        "find-cache-dir": "0.1.1",
+        "find-up": "2.1.0",
+        "foreground-child": "1.5.6",
+        "glob": "7.1.2",
+        "istanbul-lib-coverage": "1.2.0",
+        "istanbul-lib-hook": "1.1.0",
+        "istanbul-lib-instrument": "1.10.1",
+        "istanbul-lib-report": "1.1.3",
+        "istanbul-lib-source-maps": "1.2.3",
+        "istanbul-reports": "1.4.0",
+        "md5-hex": "1.3.0",
+        "merge-source-map": "1.1.0",
+        "micromatch": "3.1.10",
+        "mkdirp": "0.5.1",
+        "resolve-from": "2.0.0",
+        "rimraf": "2.6.2",
+        "signal-exit": "3.0.2",
+        "spawn-wrap": "1.4.2",
+        "test-exclude": "4.2.1",
         "yargs": "11.1.0",
-        "yargs-parser": "^8.0.0"
+        "yargs-parser": "8.1.0"
       },
       "dependencies": {
         "align-text": {
@@ -16187,11 +16069,10 @@
           "resolved": false,
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
-          "optional": true,
           "requires": {
-            "kind-of": "^3.0.2",
-            "longest": "^1.0.1",
-            "repeat-string": "^1.5.2"
+            "kind-of": "3.2.2",
+            "longest": "1.0.1",
+            "repeat-string": "1.6.1"
           }
         },
         "amdefine": {
@@ -16218,7 +16099,7 @@
           "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
           "dev": true,
           "requires": {
-            "default-require-extensions": "^1.0.0"
+            "default-require-extensions": "1.0.0"
           }
         },
         "archy": {
@@ -16281,9 +16162,9 @@
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.2"
+            "chalk": "1.1.3",
+            "esutils": "2.0.2",
+            "js-tokens": "3.0.2"
           }
         },
         "babel-generator": {
@@ -16292,14 +16173,14 @@
           "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
           "dev": true,
           "requires": {
-            "babel-messages": "^6.23.0",
-            "babel-runtime": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "detect-indent": "^4.0.0",
-            "jsesc": "^1.3.0",
-            "lodash": "^4.17.4",
-            "source-map": "^0.5.7",
-            "trim-right": "^1.0.1"
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "detect-indent": "4.0.0",
+            "jsesc": "1.3.0",
+            "lodash": "4.17.10",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
           }
         },
         "babel-messages": {
@@ -16308,7 +16189,7 @@
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.22.0"
+            "babel-runtime": "6.26.0"
           }
         },
         "babel-runtime": {
@@ -16317,8 +16198,8 @@
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "dev": true,
           "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
+            "core-js": "2.5.6",
+            "regenerator-runtime": "0.11.1"
           }
         },
         "babel-template": {
@@ -16327,11 +16208,11 @@
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "lodash": "^4.17.4"
+            "babel-runtime": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "lodash": "4.17.10"
           }
         },
         "babel-traverse": {
@@ -16340,15 +16221,15 @@
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "dev": true,
           "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-messages": "^6.23.0",
-            "babel-runtime": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "debug": "^2.6.8",
-            "globals": "^9.18.0",
-            "invariant": "^2.2.2",
-            "lodash": "^4.17.4"
+            "babel-code-frame": "6.26.0",
+            "babel-messages": "6.23.0",
+            "babel-runtime": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "debug": "2.6.9",
+            "globals": "9.18.0",
+            "invariant": "2.2.4",
+            "lodash": "4.17.10"
           }
         },
         "babel-types": {
@@ -16357,10 +16238,10 @@
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "dev": true,
           "requires": {
-            "babel-runtime": "^6.26.0",
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.4",
-            "to-fast-properties": "^1.0.3"
+            "babel-runtime": "6.26.0",
+            "esutils": "2.0.2",
+            "lodash": "4.17.10",
+            "to-fast-properties": "1.0.3"
           }
         },
         "babylon": {
@@ -16381,13 +16262,13 @@
           "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
           "dev": true,
           "requires": {
-            "cache-base": "^1.0.1",
-            "class-utils": "^0.3.5",
-            "component-emitter": "^1.2.1",
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.1",
-            "mixin-deep": "^1.2.0",
-            "pascalcase": "^0.1.1"
+            "cache-base": "1.0.1",
+            "class-utils": "0.3.6",
+            "component-emitter": "1.2.1",
+            "define-property": "1.0.0",
+            "isobject": "3.0.1",
+            "mixin-deep": "1.3.1",
+            "pascalcase": "0.1.1"
           },
           "dependencies": {
             "define-property": {
@@ -16396,7 +16277,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "is-accessor-descriptor": {
@@ -16405,7 +16286,7 @@
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
@@ -16414,7 +16295,7 @@
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-descriptor": {
@@ -16423,9 +16304,9 @@
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "isobject": {
@@ -16448,7 +16329,7 @@
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "requires": {
-            "balanced-match": "^1.0.0",
+            "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
           }
         },
@@ -16458,16 +16339,16 @@
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "dev": true,
           "requires": {
-            "arr-flatten": "^1.1.0",
-            "array-unique": "^0.3.2",
-            "extend-shallow": "^2.0.1",
-            "fill-range": "^4.0.0",
-            "isobject": "^3.0.1",
-            "repeat-element": "^1.1.2",
-            "snapdragon": "^0.8.1",
-            "snapdragon-node": "^2.0.1",
-            "split-string": "^3.0.2",
-            "to-regex": "^3.0.1"
+            "arr-flatten": "1.1.0",
+            "array-unique": "0.3.2",
+            "extend-shallow": "2.0.1",
+            "fill-range": "4.0.0",
+            "isobject": "3.0.1",
+            "repeat-element": "1.1.2",
+            "snapdragon": "0.8.2",
+            "snapdragon-node": "2.1.1",
+            "split-string": "3.1.0",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "extend-shallow": {
@@ -16476,7 +16357,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -16493,15 +16374,15 @@
           "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
           "dev": true,
           "requires": {
-            "collection-visit": "^1.0.0",
-            "component-emitter": "^1.2.1",
-            "get-value": "^2.0.6",
-            "has-value": "^1.0.0",
-            "isobject": "^3.0.1",
-            "set-value": "^2.0.0",
-            "to-object-path": "^0.3.0",
-            "union-value": "^1.0.0",
-            "unset-value": "^1.0.0"
+            "collection-visit": "1.0.0",
+            "component-emitter": "1.2.1",
+            "get-value": "2.0.6",
+            "has-value": "1.0.0",
+            "isobject": "3.0.1",
+            "set-value": "2.0.0",
+            "to-object-path": "0.3.0",
+            "union-value": "1.0.0",
+            "unset-value": "1.0.0"
           },
           "dependencies": {
             "isobject": {
@@ -16518,9 +16399,9 @@
           "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
           "dev": true,
           "requires": {
-            "md5-hex": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "write-file-atomic": "^1.1.4"
+            "md5-hex": "1.3.0",
+            "mkdirp": "0.5.1",
+            "write-file-atomic": "1.3.4"
           }
         },
         "camelcase": {
@@ -16537,8 +16418,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "^0.1.3",
-            "lazy-cache": "^1.0.3"
+            "align-text": "0.1.4",
+            "lazy-cache": "1.0.4"
           }
         },
         "chalk": {
@@ -16547,11 +16428,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "class-utils": {
@@ -16560,10 +16441,10 @@
           "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
           "dev": true,
           "requires": {
-            "arr-union": "^3.1.0",
-            "define-property": "^0.2.5",
-            "isobject": "^3.0.0",
-            "static-extend": "^0.1.1"
+            "arr-union": "3.1.0",
+            "define-property": "0.2.5",
+            "isobject": "3.0.1",
+            "static-extend": "0.1.2"
           },
           "dependencies": {
             "define-property": {
@@ -16572,7 +16453,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "isobject": {
@@ -16590,8 +16471,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
+            "center-align": "0.1.3",
+            "right-align": "0.1.3",
             "wordwrap": "0.0.2"
           },
           "dependencies": {
@@ -16616,8 +16497,8 @@
           "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
           "dev": true,
           "requires": {
-            "map-visit": "^1.0.0",
-            "object-visit": "^1.0.0"
+            "map-visit": "1.0.0",
+            "object-visit": "1.0.1"
           }
         },
         "commondir": {
@@ -16662,8 +16543,8 @@
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "dev": true,
           "requires": {
-            "lru-cache": "^4.0.1",
-            "which": "^1.2.9"
+            "lru-cache": "4.1.3",
+            "which": "1.3.0"
           }
         },
         "debug": {
@@ -16699,7 +16580,7 @@
           "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
           "dev": true,
           "requires": {
-            "strip-bom": "^2.0.0"
+            "strip-bom": "2.0.0"
           }
         },
         "define-property": {
@@ -16708,8 +16589,8 @@
           "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.2",
-            "isobject": "^3.0.1"
+            "is-descriptor": "1.0.2",
+            "isobject": "3.0.1"
           },
           "dependencies": {
             "is-accessor-descriptor": {
@@ -16718,7 +16599,7 @@
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
@@ -16727,7 +16608,7 @@
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-descriptor": {
@@ -16736,9 +16617,9 @@
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "isobject": {
@@ -16761,7 +16642,7 @@
           "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "dev": true,
           "requires": {
-            "repeating": "^2.0.0"
+            "repeating": "2.0.1"
           }
         },
         "error-ex": {
@@ -16770,7 +16651,7 @@
           "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
           "dev": true,
           "requires": {
-            "is-arrayish": "^0.2.1"
+            "is-arrayish": "0.2.1"
           }
         },
         "escape-string-regexp": {
@@ -16791,13 +16672,13 @@
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "dev": true,
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
-            "is-stream": "^1.1.0",
-            "npm-run-path": "^2.0.0",
-            "p-finally": "^1.0.0",
-            "signal-exit": "^3.0.0",
-            "strip-eof": "^1.0.0"
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
           },
           "dependencies": {
             "cross-spawn": {
@@ -16806,9 +16687,9 @@
               "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
               "dev": true,
               "requires": {
-                "lru-cache": "^4.0.1",
-                "shebang-command": "^1.2.0",
-                "which": "^1.2.9"
+                "lru-cache": "4.1.3",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
               }
             }
           }
@@ -16819,13 +16700,13 @@
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
           "requires": {
-            "debug": "^2.3.3",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "posix-character-classes": "^0.1.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "posix-character-classes": "0.1.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -16834,7 +16715,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -16843,7 +16724,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -16854,8 +16735,8 @@
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "dev": true,
           "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
+            "assign-symbols": "1.0.0",
+            "is-extendable": "1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -16864,7 +16745,7 @@
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "dev": true,
               "requires": {
-                "is-plain-object": "^2.0.4"
+                "is-plain-object": "2.0.4"
               }
             }
           }
@@ -16875,14 +16756,14 @@
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "dev": true,
           "requires": {
-            "array-unique": "^0.3.2",
-            "define-property": "^1.0.0",
-            "expand-brackets": "^2.1.4",
-            "extend-shallow": "^2.0.1",
-            "fragment-cache": "^0.2.1",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "array-unique": "0.3.2",
+            "define-property": "1.0.0",
+            "expand-brackets": "2.1.4",
+            "extend-shallow": "2.0.1",
+            "fragment-cache": "0.2.1",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "define-property": {
@@ -16891,7 +16772,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "extend-shallow": {
@@ -16900,7 +16781,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "is-accessor-descriptor": {
@@ -16909,7 +16790,7 @@
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
@@ -16918,7 +16799,7 @@
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-descriptor": {
@@ -16927,9 +16808,9 @@
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "kind-of": {
@@ -16946,10 +16827,10 @@
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1",
-            "to-regex-range": "^2.1.0"
+            "extend-shallow": "2.0.1",
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1",
+            "to-regex-range": "2.1.1"
           },
           "dependencies": {
             "extend-shallow": {
@@ -16958,7 +16839,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -16969,9 +16850,9 @@
           "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "dev": true,
           "requires": {
-            "commondir": "^1.0.1",
-            "mkdirp": "^0.5.1",
-            "pkg-dir": "^1.0.0"
+            "commondir": "1.0.1",
+            "mkdirp": "0.5.1",
+            "pkg-dir": "1.0.0"
           }
         },
         "find-up": {
@@ -16980,7 +16861,7 @@
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
+            "locate-path": "2.0.0"
           }
         },
         "for-in": {
@@ -16995,8 +16876,8 @@
           "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
           "dev": true,
           "requires": {
-            "cross-spawn": "^4",
-            "signal-exit": "^3.0.0"
+            "cross-spawn": "4.0.2",
+            "signal-exit": "3.0.2"
           }
         },
         "fragment-cache": {
@@ -17005,7 +16886,7 @@
           "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
           "dev": true,
           "requires": {
-            "map-cache": "^0.2.2"
+            "map-cache": "0.2.2"
           }
         },
         "fs.realpath": {
@@ -17038,12 +16919,12 @@
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         },
         "globals": {
@@ -17064,10 +16945,10 @@
           "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
           "dev": true,
           "requires": {
-            "async": "^1.4.0",
-            "optimist": "^0.6.1",
-            "source-map": "^0.4.4",
-            "uglify-js": "^2.6"
+            "async": "1.5.2",
+            "optimist": "0.6.1",
+            "source-map": "0.4.4",
+            "uglify-js": "2.8.29"
           },
           "dependencies": {
             "source-map": {
@@ -17076,7 +16957,7 @@
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "dev": true,
               "requires": {
-                "amdefine": ">=0.0.4"
+                "amdefine": "1.0.1"
               }
             }
           }
@@ -17087,7 +16968,7 @@
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "has-flag": {
@@ -17102,9 +16983,9 @@
           "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.6",
-            "has-values": "^1.0.0",
-            "isobject": "^3.0.0"
+            "get-value": "2.0.6",
+            "has-values": "1.0.0",
+            "isobject": "3.0.1"
           },
           "dependencies": {
             "isobject": {
@@ -17121,8 +17002,8 @@
           "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
           "dev": true,
           "requires": {
-            "is-number": "^3.0.0",
-            "kind-of": "^4.0.0"
+            "is-number": "3.0.0",
+            "kind-of": "4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -17131,7 +17012,7 @@
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -17140,7 +17021,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -17151,7 +17032,7 @@
               "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "dev": true,
               "requires": {
-                "is-buffer": "^1.1.5"
+                "is-buffer": "1.1.6"
               }
             }
           }
@@ -17174,8 +17055,8 @@
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
-            "once": "^1.3.0",
-            "wrappy": "1"
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
           }
         },
         "inherits": {
@@ -17190,7 +17071,7 @@
           "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
           "dev": true,
           "requires": {
-            "loose-envify": "^1.0.0"
+            "loose-envify": "1.3.1"
           }
         },
         "invert-kv": {
@@ -17205,7 +17086,7 @@
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-arrayish": {
@@ -17226,7 +17107,7 @@
           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "dev": true,
           "requires": {
-            "builtin-modules": "^1.0.0"
+            "builtin-modules": "1.1.1"
           }
         },
         "is-data-descriptor": {
@@ -17235,7 +17116,7 @@
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-descriptor": {
@@ -17244,9 +17125,9 @@
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           },
           "dependencies": {
             "kind-of": {
@@ -17269,7 +17150,7 @@
           "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
           "dev": true,
           "requires": {
-            "number-is-nan": "^1.0.0"
+            "number-is-nan": "1.0.1"
           }
         },
         "is-fullwidth-code-point": {
@@ -17284,7 +17165,7 @@
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "is-odd": {
@@ -17293,7 +17174,7 @@
           "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
           "dev": true,
           "requires": {
-            "is-number": "^4.0.0"
+            "is-number": "4.0.0"
           },
           "dependencies": {
             "is-number": {
@@ -17310,7 +17191,7 @@
           "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
           "dev": true,
           "requires": {
-            "isobject": "^3.0.1"
+            "isobject": "3.0.1"
           },
           "dependencies": {
             "isobject": {
@@ -17369,7 +17250,7 @@
           "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
           "dev": true,
           "requires": {
-            "append-transform": "^0.4.0"
+            "append-transform": "0.4.0"
           }
         },
         "istanbul-lib-instrument": {
@@ -17378,13 +17259,13 @@
           "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
           "dev": true,
           "requires": {
-            "babel-generator": "^6.18.0",
-            "babel-template": "^6.16.0",
-            "babel-traverse": "^6.18.0",
-            "babel-types": "^6.18.0",
-            "babylon": "^6.18.0",
-            "istanbul-lib-coverage": "^1.2.0",
-            "semver": "^5.3.0"
+            "babel-generator": "6.26.1",
+            "babel-template": "6.26.0",
+            "babel-traverse": "6.26.0",
+            "babel-types": "6.26.0",
+            "babylon": "6.18.0",
+            "istanbul-lib-coverage": "1.2.0",
+            "semver": "5.5.0"
           }
         },
         "istanbul-lib-report": {
@@ -17393,10 +17274,10 @@
           "integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
           "dev": true,
           "requires": {
-            "istanbul-lib-coverage": "^1.1.2",
-            "mkdirp": "^0.5.1",
-            "path-parse": "^1.0.5",
-            "supports-color": "^3.1.2"
+            "istanbul-lib-coverage": "1.2.0",
+            "mkdirp": "0.5.1",
+            "path-parse": "1.0.5",
+            "supports-color": "3.2.3"
           },
           "dependencies": {
             "supports-color": {
@@ -17405,7 +17286,7 @@
               "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
               "dev": true,
               "requires": {
-                "has-flag": "^1.0.0"
+                "has-flag": "1.0.0"
               }
             }
           }
@@ -17416,11 +17297,11 @@
           "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
           "dev": true,
           "requires": {
-            "debug": "^3.1.0",
-            "istanbul-lib-coverage": "^1.1.2",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.6.1",
-            "source-map": "^0.5.3"
+            "debug": "3.1.0",
+            "istanbul-lib-coverage": "1.2.0",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.2",
+            "source-map": "0.5.7"
           },
           "dependencies": {
             "debug": {
@@ -17440,7 +17321,7 @@
           "integrity": "sha512-OPzVo1fPZ2H+owr8q/LYKLD+vquv9Pj4F+dj808MdHbuQLD7S4ACRjcX+0Tne5Vxt2lxXvdZaL7v+FOOAV281w==",
           "dev": true,
           "requires": {
-            "handlebars": "^4.0.3"
+            "handlebars": "4.0.11"
           }
         },
         "js-tokens": {
@@ -17461,7 +17342,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         },
         "lazy-cache": {
@@ -17477,7 +17358,7 @@
           "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "dev": true,
           "requires": {
-            "invert-kv": "^1.0.0"
+            "invert-kv": "1.0.0"
           }
         },
         "load-json-file": {
@@ -17486,11 +17367,11 @@
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
           }
         },
         "locate-path": {
@@ -17499,8 +17380,8 @@
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "dev": true,
           "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "2.0.0",
+            "path-exists": "3.0.0"
           },
           "dependencies": {
             "path-exists": {
@@ -17521,8 +17402,7 @@
           "version": "1.0.1",
           "resolved": false,
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "loose-envify": {
           "version": "1.3.1",
@@ -17530,7 +17410,7 @@
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "dev": true,
           "requires": {
-            "js-tokens": "^3.0.0"
+            "js-tokens": "3.0.2"
           }
         },
         "lru-cache": {
@@ -17539,8 +17419,8 @@
           "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "dev": true,
           "requires": {
-            "pseudomap": "^1.0.2",
-            "yallist": "^2.1.2"
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
           }
         },
         "map-cache": {
@@ -17555,7 +17435,7 @@
           "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
           "dev": true,
           "requires": {
-            "object-visit": "^1.0.0"
+            "object-visit": "1.0.1"
           }
         },
         "md5-hex": {
@@ -17564,7 +17444,7 @@
           "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "dev": true,
           "requires": {
-            "md5-o-matic": "^0.1.1"
+            "md5-o-matic": "0.1.1"
           }
         },
         "md5-o-matic": {
@@ -17579,7 +17459,7 @@
           "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
           "dev": true,
           "requires": {
-            "mimic-fn": "^1.0.0"
+            "mimic-fn": "1.2.0"
           }
         },
         "merge-source-map": {
@@ -17588,7 +17468,7 @@
           "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
           "dev": true,
           "requires": {
-            "source-map": "^0.6.1"
+            "source-map": "0.6.1"
           },
           "dependencies": {
             "source-map": {
@@ -17605,19 +17485,19 @@
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "braces": "^2.3.1",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "extglob": "^2.0.4",
-            "fragment-cache": "^0.2.1",
-            "kind-of": "^6.0.2",
-            "nanomatch": "^1.2.9",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.2"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "braces": "2.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "extglob": "2.0.4",
+            "fragment-cache": "0.2.1",
+            "kind-of": "6.0.2",
+            "nanomatch": "1.2.9",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -17640,7 +17520,7 @@
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
-            "brace-expansion": "^1.1.7"
+            "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
@@ -17655,8 +17535,8 @@
           "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
           "dev": true,
           "requires": {
-            "for-in": "^1.0.2",
-            "is-extendable": "^1.0.1"
+            "for-in": "1.0.2",
+            "is-extendable": "1.0.1"
           },
           "dependencies": {
             "is-extendable": {
@@ -17665,7 +17545,7 @@
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "dev": true,
               "requires": {
-                "is-plain-object": "^2.0.4"
+                "is-plain-object": "2.0.4"
               }
             }
           }
@@ -17691,18 +17571,18 @@
           "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
           "dev": true,
           "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "fragment-cache": "^0.2.1",
-            "is-odd": "^2.0.0",
-            "is-windows": "^1.0.2",
-            "kind-of": "^6.0.2",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
+            "arr-diff": "4.0.0",
+            "array-unique": "0.3.2",
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "fragment-cache": "0.2.1",
+            "is-odd": "2.0.0",
+            "is-windows": "1.0.2",
+            "kind-of": "6.0.2",
+            "object.pick": "1.3.0",
+            "regex-not": "1.0.2",
+            "snapdragon": "0.8.2",
+            "to-regex": "3.0.2"
           },
           "dependencies": {
             "arr-diff": {
@@ -17731,10 +17611,10 @@
           "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "dev": true,
           "requires": {
-            "hosted-git-info": "^2.1.4",
-            "is-builtin-module": "^1.0.0",
-            "semver": "2 || 3 || 4 || 5",
-            "validate-npm-package-license": "^3.0.1"
+            "hosted-git-info": "2.6.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.5.0",
+            "validate-npm-package-license": "3.0.3"
           }
         },
         "npm-run-path": {
@@ -17743,7 +17623,7 @@
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "dev": true,
           "requires": {
-            "path-key": "^2.0.0"
+            "path-key": "2.0.1"
           }
         },
         "number-is-nan": {
@@ -17764,9 +17644,9 @@
           "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
           "dev": true,
           "requires": {
-            "copy-descriptor": "^0.1.0",
-            "define-property": "^0.2.5",
-            "kind-of": "^3.0.3"
+            "copy-descriptor": "0.1.1",
+            "define-property": "0.2.5",
+            "kind-of": "3.2.2"
           },
           "dependencies": {
             "define-property": {
@@ -17775,7 +17655,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             }
           }
@@ -17786,7 +17666,7 @@
           "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
           "dev": true,
           "requires": {
-            "isobject": "^3.0.0"
+            "isobject": "3.0.1"
           },
           "dependencies": {
             "isobject": {
@@ -17803,7 +17683,7 @@
           "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
           "dev": true,
           "requires": {
-            "isobject": "^3.0.1"
+            "isobject": "3.0.1"
           },
           "dependencies": {
             "isobject": {
@@ -17820,7 +17700,7 @@
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
-            "wrappy": "1"
+            "wrappy": "1.0.2"
           }
         },
         "optimist": {
@@ -17829,8 +17709,8 @@
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "dev": true,
           "requires": {
-            "minimist": "~0.0.1",
-            "wordwrap": "~0.0.2"
+            "minimist": "0.0.8",
+            "wordwrap": "0.0.3"
           }
         },
         "os-homedir": {
@@ -17845,9 +17725,9 @@
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "0.7.0",
+            "lcid": "1.0.0",
+            "mem": "1.1.0"
           }
         },
         "p-finally": {
@@ -17862,7 +17742,7 @@
           "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
           "dev": true,
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "1.0.0"
           }
         },
         "p-locate": {
@@ -17871,7 +17751,7 @@
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "dev": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "1.2.0"
           }
         },
         "p-try": {
@@ -17886,7 +17766,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.1"
           }
         },
         "pascalcase": {
@@ -17901,7 +17781,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-is-absolute": {
@@ -17928,9 +17808,9 @@
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "pify": {
@@ -17951,7 +17831,7 @@
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "dev": true,
           "requires": {
-            "pinkie": "^2.0.0"
+            "pinkie": "2.0.4"
           }
         },
         "pkg-dir": {
@@ -17960,7 +17840,7 @@
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0"
+            "find-up": "1.1.2"
           },
           "dependencies": {
             "find-up": {
@@ -17969,8 +17849,8 @@
               "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
               }
             }
           }
@@ -17993,9 +17873,9 @@
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "dev": true,
           "requires": {
-            "load-json-file": "^1.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
           }
         },
         "read-pkg-up": {
@@ -18004,8 +17884,8 @@
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
           },
           "dependencies": {
             "find-up": {
@@ -18014,8 +17894,8 @@
               "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "dev": true,
               "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
               }
             }
           }
@@ -18032,8 +17912,8 @@
           "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
           "dev": true,
           "requires": {
-            "extend-shallow": "^3.0.2",
-            "safe-regex": "^1.1.0"
+            "extend-shallow": "3.0.2",
+            "safe-regex": "1.1.0"
           }
         },
         "repeat-element": {
@@ -18054,7 +17934,7 @@
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "dev": true,
           "requires": {
-            "is-finite": "^1.0.0"
+            "is-finite": "1.0.2"
           }
         },
         "require-directory": {
@@ -18094,7 +17974,7 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "align-text": "^0.1.1"
+            "align-text": "0.1.4"
           }
         },
         "rimraf": {
@@ -18103,7 +17983,7 @@
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "7.1.2"
           }
         },
         "safe-regex": {
@@ -18112,7 +17992,7 @@
           "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
           "dev": true,
           "requires": {
-            "ret": "~0.1.10"
+            "ret": "0.1.15"
           }
         },
         "semver": {
@@ -18133,10 +18013,10 @@
           "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
           "dev": true,
           "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.3",
-            "split-string": "^3.0.1"
+            "extend-shallow": "2.0.1",
+            "is-extendable": "0.1.1",
+            "is-plain-object": "2.0.4",
+            "split-string": "3.1.0"
           },
           "dependencies": {
             "extend-shallow": {
@@ -18145,7 +18025,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -18156,7 +18036,7 @@
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "dev": true,
           "requires": {
-            "shebang-regex": "^1.0.0"
+            "shebang-regex": "1.0.0"
           }
         },
         "shebang-regex": {
@@ -18183,14 +18063,14 @@
           "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
           "dev": true,
           "requires": {
-            "base": "^0.11.1",
-            "debug": "^2.2.0",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "map-cache": "^0.2.2",
-            "source-map": "^0.5.6",
-            "source-map-resolve": "^0.5.0",
-            "use": "^3.1.0"
+            "base": "0.11.2",
+            "debug": "2.6.9",
+            "define-property": "0.2.5",
+            "extend-shallow": "2.0.1",
+            "map-cache": "0.2.2",
+            "source-map": "0.5.7",
+            "source-map-resolve": "0.5.1",
+            "use": "3.1.0"
           },
           "dependencies": {
             "define-property": {
@@ -18199,7 +18079,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             },
             "extend-shallow": {
@@ -18208,7 +18088,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             }
           }
@@ -18219,9 +18099,9 @@
           "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
           "dev": true,
           "requires": {
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.0",
-            "snapdragon-util": "^3.0.1"
+            "define-property": "1.0.0",
+            "isobject": "3.0.1",
+            "snapdragon-util": "3.0.1"
           },
           "dependencies": {
             "define-property": {
@@ -18230,7 +18110,7 @@
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^1.0.0"
+                "is-descriptor": "1.0.2"
               }
             },
             "is-accessor-descriptor": {
@@ -18239,7 +18119,7 @@
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
@@ -18248,7 +18128,7 @@
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-descriptor": {
@@ -18257,9 +18137,9 @@
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "isobject": {
@@ -18282,7 +18162,7 @@
           "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^3.2.0"
+            "kind-of": "3.2.2"
           }
         },
         "source-map": {
@@ -18297,11 +18177,11 @@
           "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
           "dev": true,
           "requires": {
-            "atob": "^2.0.0",
-            "decode-uri-component": "^0.2.0",
-            "resolve-url": "^0.2.1",
-            "source-map-url": "^0.4.0",
-            "urix": "^0.1.0"
+            "atob": "2.1.1",
+            "decode-uri-component": "0.2.0",
+            "resolve-url": "0.2.1",
+            "source-map-url": "0.4.0",
+            "urix": "0.1.0"
           }
         },
         "source-map-url": {
@@ -18316,12 +18196,12 @@
           "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
           "dev": true,
           "requires": {
-            "foreground-child": "^1.5.6",
-            "mkdirp": "^0.5.0",
-            "os-homedir": "^1.0.1",
-            "rimraf": "^2.6.2",
-            "signal-exit": "^3.0.2",
-            "which": "^1.3.0"
+            "foreground-child": "1.5.6",
+            "mkdirp": "0.5.1",
+            "os-homedir": "1.0.2",
+            "rimraf": "2.6.2",
+            "signal-exit": "3.0.2",
+            "which": "1.3.0"
           }
         },
         "spdx-correct": {
@@ -18330,8 +18210,8 @@
           "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "dev": true,
           "requires": {
-            "spdx-expression-parse": "^3.0.0",
-            "spdx-license-ids": "^3.0.0"
+            "spdx-expression-parse": "3.0.0",
+            "spdx-license-ids": "3.0.0"
           }
         },
         "spdx-exceptions": {
@@ -18346,8 +18226,8 @@
           "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "dev": true,
           "requires": {
-            "spdx-exceptions": "^2.1.0",
-            "spdx-license-ids": "^3.0.0"
+            "spdx-exceptions": "2.1.0",
+            "spdx-license-ids": "3.0.0"
           }
         },
         "spdx-license-ids": {
@@ -18362,7 +18242,7 @@
           "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
           "dev": true,
           "requires": {
-            "extend-shallow": "^3.0.0"
+            "extend-shallow": "3.0.2"
           }
         },
         "static-extend": {
@@ -18371,8 +18251,8 @@
           "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
           "dev": true,
           "requires": {
-            "define-property": "^0.2.5",
-            "object-copy": "^0.1.0"
+            "define-property": "0.2.5",
+            "object-copy": "0.1.0"
           },
           "dependencies": {
             "define-property": {
@@ -18381,7 +18261,7 @@
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "dev": true,
               "requires": {
-                "is-descriptor": "^0.1.0"
+                "is-descriptor": "0.1.6"
               }
             }
           }
@@ -18392,8 +18272,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           },
           "dependencies": {
             "ansi-regex": {
@@ -18408,7 +18288,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             }
           }
@@ -18419,7 +18299,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "strip-bom": {
@@ -18428,7 +18308,7 @@
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "dev": true,
           "requires": {
-            "is-utf8": "^0.2.0"
+            "is-utf8": "0.2.1"
           }
         },
         "strip-eof": {
@@ -18449,11 +18329,11 @@
           "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
           "dev": true,
           "requires": {
-            "arrify": "^1.0.1",
-            "micromatch": "^3.1.8",
-            "object-assign": "^4.1.0",
-            "read-pkg-up": "^1.0.1",
-            "require-main-filename": "^1.0.1"
+            "arrify": "1.0.1",
+            "micromatch": "3.1.10",
+            "object-assign": "4.1.1",
+            "read-pkg-up": "1.0.1",
+            "require-main-filename": "1.0.1"
           },
           "dependencies": {
             "arr-diff": {
@@ -18474,16 +18354,16 @@
               "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
               "dev": true,
               "requires": {
-                "arr-flatten": "^1.1.0",
-                "array-unique": "^0.3.2",
-                "extend-shallow": "^2.0.1",
-                "fill-range": "^4.0.0",
-                "isobject": "^3.0.1",
-                "repeat-element": "^1.1.2",
-                "snapdragon": "^0.8.1",
-                "snapdragon-node": "^2.0.1",
-                "split-string": "^3.0.2",
-                "to-regex": "^3.0.1"
+                "arr-flatten": "1.1.0",
+                "array-unique": "0.3.2",
+                "extend-shallow": "2.0.1",
+                "fill-range": "4.0.0",
+                "isobject": "3.0.1",
+                "repeat-element": "1.1.2",
+                "snapdragon": "0.8.2",
+                "snapdragon-node": "2.1.1",
+                "split-string": "3.1.0",
+                "to-regex": "3.0.2"
               },
               "dependencies": {
                 "extend-shallow": {
@@ -18492,7 +18372,7 @@
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
-                    "is-extendable": "^0.1.0"
+                    "is-extendable": "0.1.1"
                   }
                 }
               }
@@ -18503,13 +18383,13 @@
               "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
               "dev": true,
               "requires": {
-                "debug": "^2.3.3",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "posix-character-classes": "^0.1.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "debug": "2.6.9",
+                "define-property": "0.2.5",
+                "extend-shallow": "2.0.1",
+                "posix-character-classes": "0.1.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
               },
               "dependencies": {
                 "define-property": {
@@ -18518,7 +18398,7 @@
                   "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                   "dev": true,
                   "requires": {
-                    "is-descriptor": "^0.1.0"
+                    "is-descriptor": "0.1.6"
                   }
                 },
                 "extend-shallow": {
@@ -18527,7 +18407,7 @@
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
-                    "is-extendable": "^0.1.0"
+                    "is-extendable": "0.1.1"
                   }
                 },
                 "is-accessor-descriptor": {
@@ -18536,7 +18416,7 @@
                   "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                   "dev": true,
                   "requires": {
-                    "kind-of": "^3.0.2"
+                    "kind-of": "3.2.2"
                   },
                   "dependencies": {
                     "kind-of": {
@@ -18545,7 +18425,7 @@
                       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                       "dev": true,
                       "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                       }
                     }
                   }
@@ -18556,7 +18436,7 @@
                   "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                   "dev": true,
                   "requires": {
-                    "kind-of": "^3.0.2"
+                    "kind-of": "3.2.2"
                   },
                   "dependencies": {
                     "kind-of": {
@@ -18565,7 +18445,7 @@
                       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                       "dev": true,
                       "requires": {
-                        "is-buffer": "^1.1.5"
+                        "is-buffer": "1.1.6"
                       }
                     }
                   }
@@ -18576,9 +18456,9 @@
                   "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                   "dev": true,
                   "requires": {
-                    "is-accessor-descriptor": "^0.1.6",
-                    "is-data-descriptor": "^0.1.4",
-                    "kind-of": "^5.0.0"
+                    "is-accessor-descriptor": "0.1.6",
+                    "is-data-descriptor": "0.1.4",
+                    "kind-of": "5.1.0"
                   }
                 },
                 "kind-of": {
@@ -18595,14 +18475,14 @@
               "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
               "dev": true,
               "requires": {
-                "array-unique": "^0.3.2",
-                "define-property": "^1.0.0",
-                "expand-brackets": "^2.1.4",
-                "extend-shallow": "^2.0.1",
-                "fragment-cache": "^0.2.1",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
+                "array-unique": "0.3.2",
+                "define-property": "1.0.0",
+                "expand-brackets": "2.1.4",
+                "extend-shallow": "2.0.1",
+                "fragment-cache": "0.2.1",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
               },
               "dependencies": {
                 "define-property": {
@@ -18611,7 +18491,7 @@
                   "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                   "dev": true,
                   "requires": {
-                    "is-descriptor": "^1.0.0"
+                    "is-descriptor": "1.0.2"
                   }
                 },
                 "extend-shallow": {
@@ -18620,7 +18500,7 @@
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
-                    "is-extendable": "^0.1.0"
+                    "is-extendable": "0.1.1"
                   }
                 }
               }
@@ -18631,10 +18511,10 @@
               "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
               "dev": true,
               "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1",
-                "to-regex-range": "^2.1.0"
+                "extend-shallow": "2.0.1",
+                "is-number": "3.0.0",
+                "repeat-string": "1.6.1",
+                "to-regex-range": "2.1.1"
               },
               "dependencies": {
                 "extend-shallow": {
@@ -18643,7 +18523,7 @@
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "dev": true,
                   "requires": {
-                    "is-extendable": "^0.1.0"
+                    "is-extendable": "0.1.1"
                   }
                 }
               }
@@ -18654,7 +18534,7 @@
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
@@ -18663,7 +18543,7 @@
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "dev": true,
               "requires": {
-                "kind-of": "^6.0.0"
+                "kind-of": "6.0.2"
               }
             },
             "is-descriptor": {
@@ -18672,9 +18552,9 @@
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "dev": true,
               "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "is-number": {
@@ -18683,7 +18563,7 @@
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               },
               "dependencies": {
                 "kind-of": {
@@ -18692,7 +18572,7 @@
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "dev": true,
                   "requires": {
-                    "is-buffer": "^1.1.5"
+                    "is-buffer": "1.1.6"
                   }
                 }
               }
@@ -18715,19 +18595,19 @@
               "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
               "dev": true,
               "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "braces": "^2.3.1",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "extglob": "^2.0.4",
-                "fragment-cache": "^0.2.1",
-                "kind-of": "^6.0.2",
-                "nanomatch": "^1.2.9",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.2"
+                "arr-diff": "4.0.0",
+                "array-unique": "0.3.2",
+                "braces": "2.3.2",
+                "define-property": "2.0.2",
+                "extend-shallow": "3.0.2",
+                "extglob": "2.0.4",
+                "fragment-cache": "0.2.1",
+                "kind-of": "6.0.2",
+                "nanomatch": "1.2.9",
+                "object.pick": "1.3.0",
+                "regex-not": "1.0.2",
+                "snapdragon": "0.8.2",
+                "to-regex": "3.0.2"
               }
             }
           }
@@ -18744,7 +18624,7 @@
           "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
           "dev": true,
           "requires": {
-            "kind-of": "^3.0.2"
+            "kind-of": "3.2.2"
           }
         },
         "to-regex": {
@@ -18753,10 +18633,10 @@
           "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
           "dev": true,
           "requires": {
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "regex-not": "^1.0.2",
-            "safe-regex": "^1.1.0"
+            "define-property": "2.0.2",
+            "extend-shallow": "3.0.2",
+            "regex-not": "1.0.2",
+            "safe-regex": "1.1.0"
           }
         },
         "to-regex-range": {
@@ -18765,8 +18645,8 @@
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "dev": true,
           "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
+            "is-number": "3.0.0",
+            "repeat-string": "1.6.1"
           },
           "dependencies": {
             "is-number": {
@@ -18775,7 +18655,7 @@
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "dev": true,
               "requires": {
-                "kind-of": "^3.0.2"
+                "kind-of": "3.2.2"
               }
             }
           }
@@ -18793,9 +18673,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
+            "source-map": "0.5.7",
+            "uglify-to-browserify": "1.0.2",
+            "yargs": "3.10.0"
           },
           "dependencies": {
             "yargs": {
@@ -18805,9 +18685,9 @@
               "dev": true,
               "optional": true,
               "requires": {
-                "camelcase": "^1.0.2",
-                "cliui": "^2.1.0",
-                "decamelize": "^1.0.0",
+                "camelcase": "1.2.1",
+                "cliui": "2.1.0",
+                "decamelize": "1.2.0",
                 "window-size": "0.1.0"
               }
             }
@@ -18826,10 +18706,10 @@
           "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
           "dev": true,
           "requires": {
-            "arr-union": "^3.1.0",
-            "get-value": "^2.0.6",
-            "is-extendable": "^0.1.1",
-            "set-value": "^0.4.3"
+            "arr-union": "3.1.0",
+            "get-value": "2.0.6",
+            "is-extendable": "0.1.1",
+            "set-value": "0.4.3"
           },
           "dependencies": {
             "extend-shallow": {
@@ -18838,7 +18718,7 @@
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "dev": true,
               "requires": {
-                "is-extendable": "^0.1.0"
+                "is-extendable": "0.1.1"
               }
             },
             "set-value": {
@@ -18847,10 +18727,10 @@
               "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
               "dev": true,
               "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.1",
-                "to-object-path": "^0.3.0"
+                "extend-shallow": "2.0.1",
+                "is-extendable": "0.1.1",
+                "is-plain-object": "2.0.4",
+                "to-object-path": "0.3.0"
               }
             }
           }
@@ -18861,8 +18741,8 @@
           "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
           "dev": true,
           "requires": {
-            "has-value": "^0.3.1",
-            "isobject": "^3.0.0"
+            "has-value": "0.3.1",
+            "isobject": "3.0.1"
           },
           "dependencies": {
             "has-value": {
@@ -18871,9 +18751,9 @@
               "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
               "dev": true,
               "requires": {
-                "get-value": "^2.0.3",
-                "has-values": "^0.1.4",
-                "isobject": "^2.0.0"
+                "get-value": "2.0.6",
+                "has-values": "0.1.4",
+                "isobject": "2.1.0"
               },
               "dependencies": {
                 "isobject": {
@@ -18913,7 +18793,7 @@
           "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.2"
+            "kind-of": "6.0.2"
           },
           "dependencies": {
             "kind-of": {
@@ -18930,8 +18810,8 @@
           "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
           "dev": true,
           "requires": {
-            "spdx-correct": "^3.0.0",
-            "spdx-expression-parse": "^3.0.0"
+            "spdx-correct": "3.0.0",
+            "spdx-expression-parse": "3.0.0"
           }
         },
         "which": {
@@ -18940,7 +18820,7 @@
           "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "dev": true,
           "requires": {
-            "isexe": "^2.0.0"
+            "isexe": "2.0.0"
           }
         },
         "which-module": {
@@ -18968,8 +18848,8 @@
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "dev": true,
           "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1"
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
           },
           "dependencies": {
             "is-fullwidth-code-point": {
@@ -18978,7 +18858,7 @@
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "dev": true,
               "requires": {
-                "number-is-nan": "^1.0.0"
+                "number-is-nan": "1.0.1"
               }
             },
             "string-width": {
@@ -18987,9 +18867,9 @@
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "dev": true,
               "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
+                "code-point-at": "1.1.0",
+                "is-fullwidth-code-point": "1.0.0",
+                "strip-ansi": "3.0.1"
               }
             }
           }
@@ -19006,9 +18886,9 @@
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.11",
-            "imurmurhash": "^0.1.4",
-            "slide": "^1.1.5"
+            "graceful-fs": "4.1.11",
+            "imurmurhash": "0.1.4",
+            "slide": "1.1.6"
           }
         },
         "y18n": {
@@ -19029,18 +18909,18 @@
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "dev": true,
           "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
+            "cliui": "4.1.0",
+            "decamelize": "1.2.0",
+            "find-up": "2.1.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "2.1.0",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "2.1.1",
+            "which-module": "2.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "9.0.2"
           },
           "dependencies": {
             "ansi-regex": {
@@ -19061,9 +18941,9 @@
               "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
               "dev": true,
               "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "wrap-ansi": "2.1.0"
               }
             },
             "strip-ansi": {
@@ -19072,7 +18952,7 @@
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "dev": true,
               "requires": {
-                "ansi-regex": "^3.0.0"
+                "ansi-regex": "3.0.0"
               }
             },
             "yargs-parser": {
@@ -19081,7 +18961,7 @@
               "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
               "dev": true,
               "requires": {
-                "camelcase": "^4.1.0"
+                "camelcase": "4.1.0"
               }
             }
           }
@@ -19092,7 +18972,7 @@
           "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
+            "camelcase": "4.1.0"
           },
           "dependencies": {
             "camelcase": {
@@ -19123,9 +19003,9 @@
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
       "requires": {
-        "copy-descriptor": "^0.1.0",
-        "define-property": "^0.2.5",
-        "kind-of": "^3.0.3"
+        "copy-descriptor": "0.1.1",
+        "define-property": "0.2.5",
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "define-property": {
@@ -19134,7 +19014,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "is-buffer": {
@@ -19149,7 +19029,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -19172,7 +19052,7 @@
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.0"
+        "isobject": "3.0.1"
       }
     },
     "object.assign": {
@@ -19181,10 +19061,10 @@
       "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.18.0-next.0",
-        "has-symbols": "^1.0.1",
-        "object-keys": "^1.1.1"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.18.0-next.0",
+        "has-symbols": "1.0.1",
+        "object-keys": "1.1.1"
       },
       "dependencies": {
         "es-abstract": {
@@ -19193,18 +19073,18 @@
           "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
           "dev": true,
           "requires": {
-            "es-to-primitive": "^1.2.1",
-            "function-bind": "^1.1.1",
-            "has": "^1.0.3",
-            "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
-            "is-negative-zero": "^2.0.0",
-            "is-regex": "^1.1.1",
-            "object-inspect": "^1.8.0",
-            "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
-            "string.prototype.trimend": "^1.0.1",
-            "string.prototype.trimstart": "^1.0.1"
+            "es-to-primitive": "1.2.1",
+            "function-bind": "1.1.1",
+            "has": "1.0.3",
+            "has-symbols": "1.0.1",
+            "is-callable": "1.2.1",
+            "is-negative-zero": "2.0.0",
+            "is-regex": "1.1.1",
+            "object-inspect": "1.8.0",
+            "object-keys": "1.1.1",
+            "object.assign": "4.1.1",
+            "string.prototype.trimend": "1.0.1",
+            "string.prototype.trimstart": "1.0.1"
           }
         },
         "object-keys": {
@@ -19221,8 +19101,8 @@
       "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.17.6"
       }
     },
     "object.pick": {
@@ -19231,7 +19111,7 @@
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
       "requires": {
-        "isobject": "^3.0.1"
+        "isobject": "3.0.1"
       }
     },
     "once": {
@@ -19240,7 +19120,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "onetime": {
@@ -19255,7 +19135,7 @@
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
-        "lcid": "^1.0.0"
+        "lcid": "1.0.0"
       }
     },
     "os-tmpdir": {
@@ -19276,7 +19156,7 @@
       "integrity": "sha512-NQCqOFhbpVTMX4qMe8PF8lbGtzZ+LCiN7pcNrb/413Na7+TRoe1xkKUzuWa/YEJdGQ0FvKtj35EEbDoVPO2kbA==",
       "dev": true,
       "requires": {
-        "p-timeout": "^2.0.1"
+        "p-timeout": "2.0.1"
       }
     },
     "p-finally": {
@@ -19297,7 +19177,7 @@
       "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
-        "p-try": "^1.0.0"
+        "p-try": "1.0.0"
       }
     },
     "p-locate": {
@@ -19306,7 +19186,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "^1.1.0"
+        "p-limit": "1.3.0"
       }
     },
     "p-timeout": {
@@ -19315,7 +19195,7 @@
       "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
       "dev": true,
       "requires": {
-        "p-finally": "^1.0.0"
+        "p-finally": "1.0.0"
       }
     },
     "p-try": {
@@ -19330,10 +19210,10 @@
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
       "dev": true,
       "requires": {
-        "got": "^6.7.1",
-        "registry-auth-token": "^3.0.1",
-        "registry-url": "^3.0.3",
-        "semver": "^5.1.0"
+        "got": "6.7.1",
+        "registry-auth-token": "3.4.0",
+        "registry-url": "3.1.0",
+        "semver": "5.7.1"
       },
       "dependencies": {
         "get-stream": {
@@ -19348,17 +19228,17 @@
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "dev": true,
           "requires": {
-            "create-error-class": "^3.0.0",
-            "duplexer3": "^0.1.4",
-            "get-stream": "^3.0.0",
-            "is-redirect": "^1.0.0",
-            "is-retry-allowed": "^1.0.0",
-            "is-stream": "^1.0.0",
-            "lowercase-keys": "^1.0.0",
-            "safe-buffer": "^5.0.1",
-            "timed-out": "^4.0.0",
-            "unzip-response": "^2.0.1",
-            "url-parse-lax": "^1.0.0"
+            "create-error-class": "3.0.2",
+            "duplexer3": "0.1.4",
+            "get-stream": "3.0.0",
+            "is-redirect": "1.0.0",
+            "is-retry-allowed": "1.2.0",
+            "is-stream": "1.1.0",
+            "lowercase-keys": "1.0.1",
+            "safe-buffer": "5.2.1",
+            "timed-out": "4.0.1",
+            "unzip-response": "2.0.1",
+            "url-parse-lax": "1.0.0"
           }
         },
         "prepend-http": {
@@ -19373,7 +19253,7 @@
           "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "dev": true,
           "requires": {
-            "prepend-http": "^1.0.1"
+            "prepend-http": "1.0.4"
           }
         }
       }
@@ -19396,7 +19276,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "^1.2.0"
+        "error-ex": "1.3.2"
       }
     },
     "pascalcase": {
@@ -19411,18 +19291,18 @@
       "integrity": "sha512-YqScVYkVcClUY0v8fF0kWOjDYopzIM8e3bj/RU1DPeEF14+dCGm6UeOYm4jvCyxqIEQ5/eJzmbWfDWnUleFNMg==",
       "dev": true,
       "requires": {
-        "@yarnpkg/lockfile": "^1.1.0",
-        "chalk": "^2.4.2",
-        "cross-spawn": "^6.0.5",
-        "find-yarn-workspace-root": "^1.2.1",
-        "fs-extra": "^7.0.1",
-        "is-ci": "^2.0.0",
-        "klaw-sync": "^6.0.0",
-        "minimist": "^1.2.0",
-        "rimraf": "^2.6.3",
-        "semver": "^5.6.0",
-        "slash": "^2.0.0",
-        "tmp": "^0.0.33"
+        "@yarnpkg/lockfile": "1.1.0",
+        "chalk": "2.4.2",
+        "cross-spawn": "6.0.5",
+        "find-yarn-workspace-root": "1.2.1",
+        "fs-extra": "7.0.1",
+        "is-ci": "2.0.0",
+        "klaw-sync": "6.0.0",
+        "minimist": "1.2.5",
+        "rimraf": "2.7.1",
+        "semver": "5.7.1",
+        "slash": "2.0.0",
+        "tmp": "0.0.33"
       },
       "dependencies": {
         "ci-info": {
@@ -19437,11 +19317,11 @@
           "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
           "dev": true,
           "requires": {
-            "nice-try": "^1.0.4",
-            "path-key": "^2.0.1",
-            "semver": "^5.5.0",
-            "shebang-command": "^1.2.0",
-            "which": "^1.2.9"
+            "nice-try": "1.0.5",
+            "path-key": "2.0.1",
+            "semver": "5.7.1",
+            "shebang-command": "1.2.0",
+            "which": "1.3.1"
           }
         },
         "is-ci": {
@@ -19450,7 +19330,7 @@
           "integrity": "sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==",
           "dev": true,
           "requires": {
-            "ci-info": "^2.0.0"
+            "ci-info": "2.0.0"
           }
         },
         "slash": {
@@ -19503,9 +19383,9 @@
       "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "pify": "^2.0.0",
-        "pinkie-promise": "^2.0.0"
+        "graceful-fs": "4.2.4",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
       },
       "dependencies": {
         "pify": {
@@ -19528,11 +19408,11 @@
       "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
       "dev": true,
       "requires": {
-        "create-hash": "^1.1.2",
-        "create-hmac": "^1.1.4",
-        "ripemd160": "^2.0.1",
-        "safe-buffer": "^5.0.1",
-        "sha.js": "^2.4.8"
+        "create-hash": "1.2.0",
+        "create-hmac": "1.1.7",
+        "ripemd160": "2.0.2",
+        "safe-buffer": "5.2.1",
+        "sha.js": "2.4.11"
       }
     },
     "pend": {
@@ -19571,7 +19451,7 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "dev": true,
       "requires": {
-        "pinkie": "^2.0.0"
+        "pinkie": "2.0.4"
       }
     },
     "popsicle": {
@@ -19580,10 +19460,10 @@
       "integrity": "sha512-petRj39w05GvH1WKuGFmzxR9+k+R9E7zX5XWTFee7P/qf88hMuLT7aAO/RsmldpQMtJsWQISkTQlfMRECKlxhw==",
       "dev": true,
       "requires": {
-        "concat-stream": "^1.4.7",
-        "form-data": "^2.0.0",
-        "make-error-cause": "^1.2.1",
-        "tough-cookie": "^2.0.0"
+        "concat-stream": "1.6.2",
+        "form-data": "2.3.3",
+        "make-error-cause": "1.2.2",
+        "tough-cookie": "2.5.0"
       }
     },
     "popsicle-proxy-agent": {
@@ -19592,8 +19472,8 @@
       "integrity": "sha1-uRM8VdlFdZq37mG3cRNkYg066tw=",
       "dev": true,
       "requires": {
-        "http-proxy-agent": "^1.0.0",
-        "https-proxy-agent": "^1.0.0"
+        "http-proxy-agent": "1.0.0",
+        "https-proxy-agent": "1.0.0"
       }
     },
     "popsicle-retry": {
@@ -19602,8 +19482,8 @@
       "integrity": "sha1-4G6GZTO0KnoSPrMwy+Y6fOvLoQw=",
       "dev": true,
       "requires": {
-        "any-promise": "^1.1.0",
-        "xtend": "^4.0.1"
+        "any-promise": "1.3.0",
+        "xtend": "4.0.2"
       }
     },
     "popsicle-rewrite": {
@@ -19648,14 +19528,14 @@
       "integrity": "sha512-GTcL3OzxPn54TMlopE+wcXOUfEnpw05jvJw3KJrXkWTHER1CbkuAFRP4xiFtbJYq35ssSRO5FN4yMshx2grTIw==",
       "dev": true,
       "requires": {
-        "@solidity-parser/parser": "^0.8.0",
-        "dir-to-object": "^2.0.0",
-        "emoji-regex": "^9.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "extract-comments": "^1.1.0",
-        "prettier": "^2.0.5",
-        "semver": "^7.3.2",
-        "string-width": "^4.2.0"
+        "@solidity-parser/parser": "0.8.0",
+        "dir-to-object": "2.0.0",
+        "emoji-regex": "9.0.0",
+        "escape-string-regexp": "4.0.0",
+        "extract-comments": "1.1.0",
+        "prettier": "2.1.1",
+        "semver": "7.3.2",
+        "string-width": "4.2.0"
       },
       "dependencies": {
         "@solidity-parser/parser": {
@@ -19706,9 +19586,9 @@
           "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^8.0.0",
-            "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "emoji-regex": "8.0.0",
+            "is-fullwidth-code-point": "3.0.0",
+            "strip-ansi": "6.0.0"
           },
           "dependencies": {
             "emoji-regex": {
@@ -19725,7 +19605,7 @@
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "5.0.0"
           }
         }
       }
@@ -19790,9 +19670,9 @@
       "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
       "dev": true,
       "requires": {
-        "decode-uri-component": "^0.2.0",
-        "object-assign": "^4.1.0",
-        "strict-uri-encode": "^1.0.0"
+        "decode-uri-component": "0.2.0",
+        "object-assign": "4.1.1",
+        "strict-uri-encode": "1.1.0"
       }
     },
     "querystring": {
@@ -19807,7 +19687,7 @@
       "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.1.0"
+        "safe-buffer": "5.2.1"
       }
     },
     "raw-body": {
@@ -19828,10 +19708,10 @@
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.5",
+        "strip-json-comments": "2.0.1"
       }
     },
     "read-pkg": {
@@ -19840,9 +19720,9 @@
       "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
       "dev": true,
       "requires": {
-        "load-json-file": "^1.0.0",
-        "normalize-package-data": "^2.3.2",
-        "path-type": "^1.0.0"
+        "load-json-file": "1.1.0",
+        "normalize-package-data": "2.5.0",
+        "path-type": "1.1.0"
       }
     },
     "read-pkg-up": {
@@ -19851,8 +19731,8 @@
       "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
       "dev": true,
       "requires": {
-        "find-up": "^1.0.0",
-        "read-pkg": "^1.0.0"
+        "find-up": "1.1.2",
+        "read-pkg": "1.1.0"
       },
       "dependencies": {
         "find-up": {
@@ -19861,8 +19741,8 @@
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
           "dev": true,
           "requires": {
-            "path-exists": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
           }
         },
         "path-exists": {
@@ -19871,7 +19751,7 @@
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "dev": true,
           "requires": {
-            "pinkie-promise": "^2.0.0"
+            "pinkie-promise": "2.0.1"
           }
         }
       }
@@ -19882,9 +19762,9 @@
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
+        "inherits": "2.0.4",
+        "string_decoder": "1.3.0",
+        "util-deprecate": "1.0.2"
       }
     },
     "readdirp": {
@@ -19893,7 +19773,7 @@
       "integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
       "dev": true,
       "requires": {
-        "picomatch": "^2.2.1"
+        "picomatch": "2.2.2"
       }
     },
     "regex-not": {
@@ -19902,8 +19782,8 @@
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.2",
-        "safe-regex": "^1.1.0"
+        "extend-shallow": "3.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "registry-auth-token": {
@@ -19912,8 +19792,8 @@
       "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
       "dev": true,
       "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
+        "rc": "1.2.8",
+        "safe-buffer": "5.2.1"
       }
     },
     "registry-url": {
@@ -19922,7 +19802,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "^1.0.1"
+        "rc": "1.2.8"
       }
     },
     "repeat-element": {
@@ -19943,26 +19823,26 @@
       "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
       "dev": true,
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.10.1",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.8",
+        "extend": "3.0.2",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.3",
+        "har-validator": "5.1.5",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.27",
+        "oauth-sign": "0.9.0",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.2.1",
+        "tough-cookie": "2.5.0",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.4.0"
       },
       "dependencies": {
         "qs": {
@@ -19997,7 +19877,7 @@
       "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.6"
+        "path-parse": "1.0.6"
       }
     },
     "resolve-url": {
@@ -20012,7 +19892,7 @@
       "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
       "dev": true,
       "requires": {
-        "lowercase-keys": "^1.0.0"
+        "lowercase-keys": "1.0.1"
       }
     },
     "restore-cursor": {
@@ -20021,8 +19901,8 @@
       "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
       "dev": true,
       "requires": {
-        "exit-hook": "^1.0.0",
-        "onetime": "^1.0.0"
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
       }
     },
     "ret": {
@@ -20037,7 +19917,7 @@
       "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.3"
+        "glob": "7.1.3"
       }
     },
     "ripemd160": {
@@ -20046,8 +19926,8 @@
       "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
       "dev": true,
       "requires": {
-        "hash-base": "^3.0.0",
-        "inherits": "^2.0.1"
+        "hash-base": "3.1.0",
+        "inherits": "2.0.4"
       }
     },
     "rlp": {
@@ -20056,7 +19936,7 @@
       "integrity": "sha512-HAfAmL6SDYNWPUOJNrM500x4Thn4PZsEy5pijPh40U9WfNk0z15hUYzO9xVIMAdIHdFtD8CBDHd75Td1g36Mjg==",
       "dev": true,
       "requires": {
-        "bn.js": "^4.11.1"
+        "bn.js": "4.11.9"
       },
       "dependencies": {
         "bn.js": {
@@ -20085,7 +19965,7 @@
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
-        "ret": "~0.1.10"
+        "ret": "0.1.15"
       }
     },
     "safer-buffer": {
@@ -20101,7 +19981,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "^2.0.8"
+        "nan": "2.14.1"
       }
     },
     "scrypt-js": {
@@ -20116,9 +19996,9 @@
       "integrity": "sha512-UDar4sKvWAksIlfX3xIaQReADn+WFnHvbVujpcbr+9Sf/69odMwy2MUsz5CKLQgX9nsIyrjuxL2imVyoNHa3fg==",
       "dev": true,
       "requires": {
-        "elliptic": "^6.5.2",
-        "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
+        "elliptic": "6.5.3",
+        "node-addon-api": "2.0.2",
+        "node-gyp-build": "4.2.3"
       }
     },
     "seek-bzip": {
@@ -20127,7 +20007,7 @@
       "integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
       "dev": true,
       "requires": {
-        "commander": "^2.8.1"
+        "commander": "2.20.3"
       }
     },
     "semaphore": {
@@ -20148,7 +20028,7 @@
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
       "dev": true,
       "requires": {
-        "semver": "^5.0.3"
+        "semver": "5.7.1"
       }
     },
     "set-blocking": {
@@ -20163,10 +20043,10 @@
       "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
+        "extend-shallow": "2.0.1",
+        "is-extendable": "0.1.1",
+        "is-plain-object": "2.0.4",
+        "split-string": "3.1.0"
       },
       "dependencies": {
         "extend-shallow": {
@@ -20175,7 +20055,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         }
       }
@@ -20198,8 +20078,8 @@
       "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
       "dev": true,
       "requires": {
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
+        "inherits": "2.0.4",
+        "safe-buffer": "5.2.1"
       }
     },
     "shebang-command": {
@@ -20208,7 +20088,7 @@
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "dev": true,
       "requires": {
-        "shebang-regex": "^1.0.0"
+        "shebang-regex": "1.0.0"
       }
     },
     "shebang-regex": {
@@ -20235,9 +20115,9 @@
       "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
       "dev": true,
       "requires": {
-        "decompress-response": "^3.3.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
+        "decompress-response": "3.3.0",
+        "once": "1.4.0",
+        "simple-concat": "1.0.0"
       }
     },
     "slash": {
@@ -20252,7 +20132,7 @@
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0"
+        "is-fullwidth-code-point": "2.0.0"
       }
     },
     "snapdragon": {
@@ -20261,14 +20141,14 @@
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "dev": true,
       "requires": {
-        "base": "^0.11.1",
-        "debug": "^2.2.0",
-        "define-property": "^0.2.5",
-        "extend-shallow": "^2.0.1",
-        "map-cache": "^0.2.2",
-        "source-map": "^0.5.6",
-        "source-map-resolve": "^0.5.0",
-        "use": "^3.1.0"
+        "base": "0.11.2",
+        "debug": "2.6.9",
+        "define-property": "0.2.5",
+        "extend-shallow": "2.0.1",
+        "map-cache": "0.2.2",
+        "source-map": "0.5.7",
+        "source-map-resolve": "0.5.3",
+        "use": "3.1.1"
       },
       "dependencies": {
         "debug": {
@@ -20286,7 +20166,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         },
         "extend-shallow": {
@@ -20295,7 +20175,7 @@
           "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
           "dev": true,
           "requires": {
-            "is-extendable": "^0.1.0"
+            "is-extendable": "0.1.1"
           }
         },
         "ms": {
@@ -20318,9 +20198,9 @@
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
       "requires": {
-        "define-property": "^1.0.0",
-        "isobject": "^3.0.0",
-        "snapdragon-util": "^3.0.1"
+        "define-property": "1.0.0",
+        "isobject": "3.0.1",
+        "snapdragon-util": "3.0.1"
       },
       "dependencies": {
         "define-property": {
@@ -20329,7 +20209,7 @@
           "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.0"
+            "is-descriptor": "1.0.2"
           }
         },
         "is-accessor-descriptor": {
@@ -20338,7 +20218,7 @@
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-data-descriptor": {
@@ -20347,7 +20227,7 @@
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "dev": true,
           "requires": {
-            "kind-of": "^6.0.0"
+            "kind-of": "6.0.3"
           }
         },
         "is-descriptor": {
@@ -20356,9 +20236,9 @@
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "^1.0.0",
-            "is-data-descriptor": "^1.0.0",
-            "kind-of": "^6.0.2"
+            "is-accessor-descriptor": "1.0.0",
+            "is-data-descriptor": "1.0.0",
+            "kind-of": "6.0.3"
           }
         }
       }
@@ -20369,7 +20249,7 @@
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "dev": true,
       "requires": {
-        "kind-of": "^3.2.0"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "is-buffer": {
@@ -20384,7 +20264,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -20395,13 +20275,13 @@
       "integrity": "sha512-7URBAisWVjO7dwWNpEkQ5dpRSpSF4Wm0aD5EB82D5BQKh+q7jhOxhgkG4K5gax/geM0kPZUAxnaLcgl2ZXBgMQ==",
       "dev": true,
       "requires": {
-        "command-exists": "^1.2.8",
+        "command-exists": "1.2.9",
         "commander": "3.0.2",
-        "fs-extra": "^0.30.0",
+        "fs-extra": "0.30.0",
         "js-sha3": "0.8.0",
-        "memorystream": "^0.3.1",
-        "require-from-string": "^2.0.0",
-        "semver": "^5.5.0",
+        "memorystream": "0.3.1",
+        "require-from-string": "2.0.2",
+        "semver": "5.7.1",
         "tmp": "0.0.33"
       },
       "dependencies": {
@@ -20417,11 +20297,11 @@
           "integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^2.1.0",
-            "klaw": "^1.0.0",
-            "path-is-absolute": "^1.0.0",
-            "rimraf": "^2.2.8"
+            "graceful-fs": "4.2.4",
+            "jsonfile": "2.4.0",
+            "klaw": "1.3.1",
+            "path-is-absolute": "1.0.1",
+            "rimraf": "2.7.1"
           }
         },
         "jsonfile": {
@@ -20430,7 +20310,7 @@
           "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.2.4"
           }
         }
       }
@@ -20441,7 +20321,7 @@
       "integrity": "sha1-RBttTTRnmPG05J6JIK37oOVD+a0=",
       "dev": true,
       "requires": {
-        "is-plain-obj": "^1.0.0"
+        "is-plain-obj": "1.1.0"
       }
     },
     "sort-keys-length": {
@@ -20450,7 +20330,7 @@
       "integrity": "sha1-nLb09OnkgVWmqgZx7dM2/xR5oYg=",
       "dev": true,
       "requires": {
-        "sort-keys": "^1.0.0"
+        "sort-keys": "1.1.2"
       }
     },
     "source-map": {
@@ -20465,11 +20345,11 @@
       "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
       "dev": true,
       "requires": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0",
-        "resolve-url": "^0.2.1",
-        "source-map-url": "^0.4.0",
-        "urix": "^0.1.0"
+        "atob": "2.1.2",
+        "decode-uri-component": "0.2.0",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.4.0",
+        "urix": "0.1.0"
       }
     },
     "source-map-support": {
@@ -20478,8 +20358,8 @@
       "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
+        "buffer-from": "1.1.1",
+        "source-map": "0.6.1"
       }
     },
     "source-map-url": {
@@ -20494,8 +20374,8 @@
       "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "dev": true,
       "requires": {
-        "spdx-expression-parse": "^3.0.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-expression-parse": "3.0.1",
+        "spdx-license-ids": "3.0.5"
       }
     },
     "spdx-exceptions": {
@@ -20510,8 +20390,8 @@
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "requires": {
-        "spdx-exceptions": "^2.1.0",
-        "spdx-license-ids": "^3.0.0"
+        "spdx-exceptions": "2.3.0",
+        "spdx-license-ids": "3.0.5"
       }
     },
     "spdx-license-ids": {
@@ -20526,7 +20406,7 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
       "requires": {
-        "extend-shallow": "^3.0.0"
+        "extend-shallow": "3.0.2"
       }
     },
     "sprintf-js": {
@@ -20541,15 +20421,15 @@
       "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
       "dev": true,
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.4",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.2",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       },
       "dependencies": {
         "tweetnacl": {
@@ -20566,8 +20446,8 @@
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
       "requires": {
-        "define-property": "^0.2.5",
-        "object-copy": "^0.1.0"
+        "define-property": "0.2.5",
+        "object-copy": "0.1.0"
       },
       "dependencies": {
         "define-property": {
@@ -20576,7 +20456,7 @@
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
           "dev": true,
           "requires": {
-            "is-descriptor": "^0.1.0"
+            "is-descriptor": "0.1.6"
           }
         }
       }
@@ -20605,8 +20485,8 @@
       "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
       "dev": true,
       "requires": {
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "is-fullwidth-code-point": "2.0.0",
+        "strip-ansi": "4.0.0"
       }
     },
     "string.prototype.trimend": {
@@ -20615,8 +20495,8 @@
       "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.17.6"
       }
     },
     "string.prototype.trimstart": {
@@ -20625,8 +20505,8 @@
       "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.17.6"
       }
     },
     "string_decoder": {
@@ -20635,7 +20515,7 @@
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dev": true,
       "requires": {
-        "safe-buffer": "~5.2.0"
+        "safe-buffer": "5.2.1"
       }
     },
     "strip-ansi": {
@@ -20644,7 +20524,7 @@
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "^3.0.0"
+        "ansi-regex": "3.0.0"
       }
     },
     "strip-bom": {
@@ -20653,7 +20533,7 @@
       "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
       "dev": true,
       "requires": {
-        "is-utf8": "^0.2.0"
+        "is-utf8": "0.2.1"
       }
     },
     "strip-dirs": {
@@ -20662,7 +20542,7 @@
       "integrity": "sha512-JOCxOeKLm2CAS73y/U4ZeZPTkE+gNVCzKt7Eox84Iej1LT/2pTWYpZKJuxwQpvX1LiZb1xokNR7RLfuBAa7T3g==",
       "dev": true,
       "requires": {
-        "is-natural-number": "^4.0.1"
+        "is-natural-number": "4.0.1"
       }
     },
     "strip-eof": {
@@ -20692,7 +20572,7 @@
       "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.2"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "supports-color": {
@@ -20701,7 +20581,7 @@
       "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
       "dev": true,
       "requires": {
-        "has-flag": "^3.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "tar-stream": {
@@ -20710,13 +20590,13 @@
       "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
       "dev": true,
       "requires": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.2.0",
-        "end-of-stream": "^1.0.0",
-        "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.1",
-        "xtend": "^4.0.0"
+        "bl": "1.2.3",
+        "buffer-alloc": "1.2.0",
+        "end-of-stream": "1.4.4",
+        "fs-constants": "1.0.0",
+        "readable-stream": "2.3.7",
+        "to-buffer": "1.1.1",
+        "xtend": "4.0.2"
       },
       "dependencies": {
         "readable-stream": {
@@ -20725,13 +20605,13 @@
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.4",
+            "isarray": "1.0.0",
+            "process-nextick-args": "2.0.1",
+            "safe-buffer": "5.1.2",
+            "string_decoder": "1.1.1",
+            "util-deprecate": "1.0.2"
           }
         },
         "safe-buffer": {
@@ -20746,7 +20626,7 @@
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "5.1.2"
           }
         }
       }
@@ -20757,7 +20637,7 @@
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
       "dev": true,
       "requires": {
-        "execa": "^0.7.0"
+        "execa": "0.7.0"
       }
     },
     "test-value": {
@@ -20766,8 +20646,8 @@
       "integrity": "sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=",
       "dev": true,
       "requires": {
-        "array-back": "^1.0.3",
-        "typical": "^2.6.0"
+        "array-back": "1.0.4",
+        "typical": "2.6.1"
       },
       "dependencies": {
         "array-back": {
@@ -20776,7 +20656,7 @@
           "integrity": "sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=",
           "dev": true,
           "requires": {
-            "typical": "^2.6.0"
+            "typical": "2.6.1"
           }
         }
       }
@@ -20793,7 +20673,7 @@
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
       "dev": true,
       "requires": {
-        "any-promise": "^1.0.0"
+        "any-promise": "1.3.0"
       }
     },
     "throat": {
@@ -20820,7 +20700,7 @@
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
       "dev": true,
       "requires": {
-        "os-tmpdir": "~1.0.2"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-buffer": {
@@ -20835,7 +20715,7 @@
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
       "dev": true,
       "requires": {
-        "kind-of": "^3.0.2"
+        "kind-of": "3.2.2"
       },
       "dependencies": {
         "is-buffer": {
@@ -20850,7 +20730,7 @@
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
+            "is-buffer": "1.1.6"
           }
         }
       }
@@ -20861,10 +20741,10 @@
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "dev": true,
       "requires": {
-        "define-property": "^2.0.2",
-        "extend-shallow": "^3.0.2",
-        "regex-not": "^1.0.2",
-        "safe-regex": "^1.1.0"
+        "define-property": "2.0.2",
+        "extend-shallow": "3.0.2",
+        "regex-not": "1.0.2",
+        "safe-regex": "1.1.0"
       }
     },
     "to-regex-range": {
@@ -20873,7 +20753,7 @@
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "requires": {
-        "is-number": "^7.0.0"
+        "is-number": "7.0.0"
       }
     },
     "toidentifier": {
@@ -20888,7 +20768,7 @@
       "integrity": "sha1-RJy+LbrlqMgDjjDXH6D/RklHxN4=",
       "dev": true,
       "requires": {
-        "nopt": "~1.0.10"
+        "nopt": "1.0.10"
       },
       "dependencies": {
         "nopt": {
@@ -20897,7 +20777,7 @@
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "dev": true,
           "requires": {
-            "abbrev": "1"
+            "abbrev": "1.1.1"
           }
         }
       }
@@ -20908,8 +20788,8 @@
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "dev": true,
       "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
+        "psl": "1.8.0",
+        "punycode": "2.1.1"
       }
     },
     "trim-repeated": {
@@ -20918,7 +20798,7 @@
       "integrity": "sha1-42RqLqTokTEr9+rObPsFOAvAHCE=",
       "dev": true,
       "requires": {
-        "escape-string-regexp": "^1.0.2"
+        "escape-string-regexp": "1.0.5"
       }
     },
     "ts-essentials": {
@@ -20933,15 +20813,15 @@
       "integrity": "sha512-Gi+aZCELpVL7Mqb+GuMgM+n8JZ/arZZib1iD/R9Ok8JDjOCOCrqS9b1lr72ku7J45WeDCFZxyJoRsiQvhokCnw==",
       "dev": true,
       "requires": {
-        "@types/mkdirp": "^0.5.2",
-        "@types/prettier": "^1.13.2",
-        "@types/resolve": "^0.0.8",
-        "chalk": "^2.4.1",
-        "glob": "^7.1.2",
-        "mkdirp": "^0.5.1",
-        "prettier": "^1.14.2",
-        "resolve": "^1.8.1",
-        "ts-essentials": "^1.0.0"
+        "@types/mkdirp": "0.5.2",
+        "@types/prettier": "1.19.1",
+        "@types/resolve": "0.0.8",
+        "chalk": "2.4.2",
+        "glob": "7.1.3",
+        "mkdirp": "0.5.5",
+        "prettier": "1.19.1",
+        "resolve": "1.17.0",
+        "ts-essentials": "1.0.4"
       }
     },
     "ts-node": {
@@ -20950,10 +20830,10 @@
       "integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
       "dev": true,
       "requires": {
-        "arg": "^4.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
+        "arg": "4.1.3",
+        "diff": "4.0.2",
+        "make-error": "1.3.6",
+        "source-map-support": "0.5.19",
         "yn": "3.1.1"
       },
       "dependencies": {
@@ -20983,7 +20863,7 @@
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "dev": true,
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.2.1"
       }
     },
     "tweetnacl": {
@@ -21016,13 +20896,13 @@
       "integrity": "sha512-O+hsAUwtBpqCfoq46Grm52OEdm0GBEu78LxrEzkkGdwUdCoCZpNb2HPzPoNB1MXiRnNhEOGMFyf05UbT2/bUEw==",
       "dev": true,
       "requires": {
-        "command-line-args": "^4.0.7",
-        "debug": "^4.1.1",
-        "fs-extra": "^7.0.0",
-        "js-sha3": "^0.8.0",
-        "lodash": "^4.17.15",
-        "ts-essentials": "^6.0.3",
-        "ts-generator": "^0.0.8"
+        "command-line-args": "4.0.7",
+        "debug": "4.1.1",
+        "fs-extra": "7.0.1",
+        "js-sha3": "0.8.0",
+        "lodash": "4.17.20",
+        "ts-essentials": "6.0.7",
+        "ts-generator": "0.0.8"
       },
       "dependencies": {
         "debug": {
@@ -21031,7 +20911,7 @@
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.1"
           }
         },
         "fs-extra": {
@@ -21040,9 +20920,9 @@
           "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "jsonfile": "^4.0.0",
-            "universalify": "^0.1.0"
+            "graceful-fs": "4.2.4",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.2"
           }
         },
         "js-sha3": {
@@ -21057,7 +20937,7 @@
           "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.6"
+            "graceful-fs": "4.2.4"
           }
         },
         "ts-essentials": {
@@ -21092,21 +20972,21 @@
       "integrity": "sha1-usxp0lWXCkeOCfdsf2iZddU1p4o=",
       "dev": true,
       "requires": {
-        "archy": "^1.0.0",
-        "bluebird": "^3.1.1",
-        "chalk": "^1.0.0",
-        "cli-truncate": "^1.0.0",
-        "columnify": "^1.5.2",
-        "elegant-spinner": "^1.0.1",
-        "has-unicode": "^2.0.1",
-        "listify": "^1.0.0",
-        "log-update": "^1.0.2",
-        "minimist": "^1.2.0",
-        "promise-finally": "^3.0.0",
-        "typings-core": "^2.3.3",
-        "update-notifier": "^2.0.0",
-        "wordwrap": "^1.0.0",
-        "xtend": "^4.0.1"
+        "archy": "1.0.0",
+        "bluebird": "3.7.2",
+        "chalk": "1.1.3",
+        "cli-truncate": "1.1.0",
+        "columnify": "1.5.4",
+        "elegant-spinner": "1.0.1",
+        "has-unicode": "2.0.1",
+        "listify": "1.0.3",
+        "log-update": "1.0.2",
+        "minimist": "1.2.5",
+        "promise-finally": "3.0.1",
+        "typings-core": "2.3.3",
+        "update-notifier": "2.5.0",
+        "wordwrap": "1.0.0",
+        "xtend": "4.0.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -21127,11 +21007,11 @@
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
           }
         },
         "strip-ansi": {
@@ -21140,7 +21020,7 @@
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "2.1.1"
           }
         },
         "supports-color": {
@@ -21157,38 +21037,38 @@
       "integrity": "sha1-CexUzVsR3V8e8vwKsx03ACyita0=",
       "dev": true,
       "requires": {
-        "array-uniq": "^1.0.2",
-        "configstore": "^3.0.0",
-        "debug": "^2.2.0",
-        "detect-indent": "^5.0.0",
-        "graceful-fs": "^4.1.2",
-        "has": "^1.0.1",
-        "invariant": "^2.2.0",
-        "is-absolute": "^0.2.3",
-        "jspm-config": "^0.3.0",
-        "listify": "^1.0.0",
-        "lockfile": "^1.0.1",
-        "make-error-cause": "^1.2.1",
-        "mkdirp": "^0.5.1",
-        "object.pick": "^1.1.1",
-        "parse-json": "^2.2.0",
-        "popsicle": "^9.0.0",
-        "popsicle-proxy-agent": "^3.0.0",
-        "popsicle-retry": "^3.2.0",
-        "popsicle-rewrite": "^1.0.0",
-        "popsicle-status": "^2.0.0",
-        "promise-finally": "^3.0.0",
-        "rc": "^1.1.5",
-        "rimraf": "^2.4.4",
-        "sort-keys": "^1.0.0",
-        "string-template": "^1.0.0",
-        "strip-bom": "^3.0.0",
-        "thenify": "^3.1.0",
-        "throat": "^3.0.0",
-        "touch": "^1.0.0",
-        "typescript": "^2.1.4",
-        "xtend": "^4.0.0",
-        "zip-object": "^0.1.0"
+        "array-uniq": "1.0.3",
+        "configstore": "3.1.2",
+        "debug": "2.6.9",
+        "detect-indent": "5.0.0",
+        "graceful-fs": "4.2.4",
+        "has": "1.0.3",
+        "invariant": "2.2.4",
+        "is-absolute": "0.2.6",
+        "jspm-config": "0.3.4",
+        "listify": "1.0.3",
+        "lockfile": "1.0.4",
+        "make-error-cause": "1.2.2",
+        "mkdirp": "0.5.5",
+        "object.pick": "1.3.0",
+        "parse-json": "2.2.0",
+        "popsicle": "9.2.0",
+        "popsicle-proxy-agent": "3.0.0",
+        "popsicle-retry": "3.2.1",
+        "popsicle-rewrite": "1.0.0",
+        "popsicle-status": "2.0.1",
+        "promise-finally": "3.0.1",
+        "rc": "1.2.8",
+        "rimraf": "2.7.1",
+        "sort-keys": "1.1.2",
+        "string-template": "1.0.0",
+        "strip-bom": "3.0.0",
+        "thenify": "3.3.1",
+        "throat": "3.2.0",
+        "touch": "1.0.0",
+        "typescript": "2.9.2",
+        "xtend": "4.0.2",
+        "zip-object": "0.1.0"
       },
       "dependencies": {
         "debug": {
@@ -21212,7 +21092,7 @@
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "1.3.2"
           }
         },
         "strip-bom": {
@@ -21235,8 +21115,8 @@
       "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
       "dev": true,
       "requires": {
-        "buffer": "^5.2.1",
-        "through": "^2.3.8"
+        "buffer": "5.6.0",
+        "through": "2.3.8"
       }
     },
     "unc-path-regex": {
@@ -21257,10 +21137,10 @@
       "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^2.0.1"
+        "arr-union": "3.1.0",
+        "get-value": "2.0.6",
+        "is-extendable": "0.1.1",
+        "set-value": "2.0.1"
       }
     },
     "unique-string": {
@@ -21269,7 +21149,7 @@
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
       "dev": true,
       "requires": {
-        "crypto-random-string": "^1.0.0"
+        "crypto-random-string": "1.0.0"
       }
     },
     "universalify": {
@@ -21290,8 +21170,8 @@
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
       "requires": {
-        "has-value": "^0.3.1",
-        "isobject": "^3.0.0"
+        "has-value": "0.3.1",
+        "isobject": "3.0.1"
       },
       "dependencies": {
         "has-value": {
@@ -21300,9 +21180,9 @@
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
           "requires": {
-            "get-value": "^2.0.3",
-            "has-values": "^0.1.4",
-            "isobject": "^2.0.0"
+            "get-value": "2.0.6",
+            "has-values": "0.1.4",
+            "isobject": "2.1.0"
           },
           "dependencies": {
             "isobject": {
@@ -21336,16 +21216,16 @@
       "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
       "dev": true,
       "requires": {
-        "boxen": "^1.2.1",
-        "chalk": "^2.0.1",
-        "configstore": "^3.0.0",
-        "import-lazy": "^2.1.0",
-        "is-ci": "^1.0.10",
-        "is-installed-globally": "^0.1.0",
-        "is-npm": "^1.0.0",
-        "latest-version": "^3.0.0",
-        "semver-diff": "^2.0.0",
-        "xdg-basedir": "^3.0.0"
+        "boxen": "1.3.0",
+        "chalk": "2.4.2",
+        "configstore": "3.1.2",
+        "import-lazy": "2.1.0",
+        "is-ci": "1.2.1",
+        "is-installed-globally": "0.1.0",
+        "is-npm": "1.0.0",
+        "latest-version": "3.1.0",
+        "semver-diff": "2.1.0",
+        "xdg-basedir": "3.0.0"
       }
     },
     "uri-js": {
@@ -21354,7 +21234,7 @@
       "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "dev": true,
       "requires": {
-        "punycode": "^2.1.0"
+        "punycode": "2.1.1"
       }
     },
     "urix": {
@@ -21387,7 +21267,7 @@
       "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
       "dev": true,
       "requires": {
-        "prepend-http": "^2.0.0"
+        "prepend-http": "2.0.0"
       }
     },
     "url-set-query": {
@@ -21426,10 +21306,10 @@
       "integrity": "sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==",
       "dev": true,
       "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.2",
-        "has-symbols": "^1.0.1",
-        "object.getownpropertydescriptors": "^2.1.0"
+        "define-properties": "1.1.3",
+        "es-abstract": "1.17.6",
+        "has-symbols": "1.0.1",
+        "object.getownpropertydescriptors": "2.1.0"
       }
     },
     "uuid": {
@@ -21444,8 +21324,8 @@
       "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
       "dev": true,
       "requires": {
-        "spdx-correct": "^3.0.0",
-        "spdx-expression-parse": "^3.0.0"
+        "spdx-correct": "3.1.1",
+        "spdx-expression-parse": "3.0.1"
       }
     },
     "verror": {
@@ -21454,9 +21334,9 @@
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "dev": true,
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "wcwidth": {
@@ -21465,7 +21345,7 @@
       "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
       "dev": true,
       "requires": {
-        "defaults": "^1.0.3"
+        "defaults": "1.0.3"
       }
     },
     "web3-utils": {
@@ -21476,10 +21356,10 @@
       "requires": {
         "bn.js": "4.11.8",
         "eth-lib": "0.2.7",
-        "ethereum-bloom-filters": "^1.0.6",
+        "ethereum-bloom-filters": "1.0.7",
         "ethjs-unit": "0.1.6",
         "number-to-bn": "1.7.0",
-        "randombytes": "^2.1.0",
+        "randombytes": "2.1.0",
         "underscore": "1.9.1",
         "utf8": "3.0.0"
       },
@@ -21498,7 +21378,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "^2.0.0"
+        "isexe": "2.0.0"
       }
     },
     "which-module": {
@@ -21513,7 +21393,7 @@
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
       "requires": {
-        "string-width": "^1.0.2 || 2"
+        "string-width": "2.1.1"
       }
     },
     "widest-line": {
@@ -21522,7 +21402,7 @@
       "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
       "dev": true,
       "requires": {
-        "string-width": "^2.1.1"
+        "string-width": "2.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -21537,8 +21417,8 @@
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "dev": true,
           "requires": {
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^4.0.0"
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
           }
         },
         "strip-ansi": {
@@ -21547,7 +21427,7 @@
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "3.0.0"
           }
         }
       }
@@ -21570,9 +21450,9 @@
       "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "dev": true,
       "requires": {
-        "ansi-styles": "^3.2.0",
-        "string-width": "^3.0.0",
-        "strip-ansi": "^5.0.0"
+        "ansi-styles": "3.2.1",
+        "string-width": "3.1.0",
+        "strip-ansi": "5.2.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -21587,9 +21467,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "7.0.3",
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "5.2.0"
           }
         },
         "strip-ansi": {
@@ -21598,7 +21478,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "4.1.0"
           }
         }
       }
@@ -21615,9 +21495,9 @@
       "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "dev": true,
       "requires": {
-        "graceful-fs": "^4.1.11",
-        "imurmurhash": "^0.1.4",
-        "signal-exit": "^3.0.2"
+        "graceful-fs": "4.2.4",
+        "imurmurhash": "0.1.4",
+        "signal-exit": "3.0.3"
       }
     },
     "ws": {
@@ -21638,10 +21518,10 @@
       "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
       "dev": true,
       "requires": {
-        "global": "~4.3.0",
-        "is-function": "^1.0.1",
-        "parse-headers": "^2.0.0",
-        "xtend": "^4.0.0"
+        "global": "4.3.2",
+        "is-function": "1.0.2",
+        "parse-headers": "2.0.3",
+        "xtend": "4.0.2"
       }
     },
     "xhr-request": {
@@ -21650,13 +21530,13 @@
       "integrity": "sha512-Y7qzEaR3FDtL3fP30k9wO/e+FBnBByZeybKOhASsGP30NIkRAAkKD/sCnLvgEfAIEC1rcmK7YG8f4oEnIrrWzA==",
       "dev": true,
       "requires": {
-        "buffer-to-arraybuffer": "^0.0.5",
-        "object-assign": "^4.1.1",
-        "query-string": "^5.0.1",
-        "simple-get": "^2.7.0",
-        "timed-out": "^4.0.1",
-        "url-set-query": "^1.0.0",
-        "xhr": "^2.0.4"
+        "buffer-to-arraybuffer": "0.0.5",
+        "object-assign": "4.1.1",
+        "query-string": "5.1.1",
+        "simple-get": "2.8.1",
+        "timed-out": "4.0.1",
+        "url-set-query": "1.0.0",
+        "xhr": "2.5.0"
       }
     },
     "xhr-request-promise": {
@@ -21665,7 +21545,7 @@
       "integrity": "sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==",
       "dev": true,
       "requires": {
-        "xhr-request": "^1.1.0"
+        "xhr-request": "1.1.0"
       }
     },
     "xtend": {
@@ -21692,16 +21572,16 @@
       "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
       "dev": true,
       "requires": {
-        "cliui": "^5.0.0",
-        "find-up": "^3.0.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^13.1.2"
+        "cliui": "5.0.0",
+        "find-up": "3.0.0",
+        "get-caller-file": "2.0.5",
+        "require-directory": "2.1.1",
+        "require-main-filename": "2.0.0",
+        "set-blocking": "2.0.0",
+        "string-width": "3.1.0",
+        "which-module": "2.0.0",
+        "y18n": "4.0.0",
+        "yargs-parser": "13.1.2"
       },
       "dependencies": {
         "ansi-regex": {
@@ -21716,7 +21596,7 @@
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
-            "locate-path": "^3.0.0"
+            "locate-path": "3.0.0"
           }
         },
         "locate-path": {
@@ -21725,8 +21605,8 @@
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
+            "p-locate": "3.0.0",
+            "path-exists": "3.0.0"
           }
         },
         "p-limit": {
@@ -21735,7 +21615,7 @@
           "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
           "dev": true,
           "requires": {
-            "p-try": "^2.0.0"
+            "p-try": "2.2.0"
           }
         },
         "p-locate": {
@@ -21744,7 +21624,7 @@
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
-            "p-limit": "^2.0.0"
+            "p-limit": "2.3.0"
           }
         },
         "p-try": {
@@ -21759,9 +21639,9 @@
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "emoji-regex": "7.0.3",
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "5.2.0"
           }
         },
         "strip-ansi": {
@@ -21770,7 +21650,7 @@
           "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "ansi-regex": "4.1.0"
           }
         }
       }
@@ -21781,8 +21661,8 @@
       "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
       "dev": true,
       "requires": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
+        "camelcase": "5.3.1",
+        "decamelize": "1.2.0"
       }
     },
     "yargs-unparser": {
@@ -21791,9 +21671,9 @@
       "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
       "dev": true,
       "requires": {
-        "flat": "^4.1.0",
-        "lodash": "^4.17.15",
-        "yargs": "^13.3.0"
+        "flat": "4.1.0",
+        "lodash": "4.17.20",
+        "yargs": "13.3.2"
       }
     },
     "yauzl": {
@@ -21802,8 +21682,8 @@
       "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "buffer-crc32": "0.2.13",
+        "fd-slicer": "1.1.0"
       }
     },
     "yn": {

--- a/test/MassMigration.test.ts
+++ b/test/MassMigration.test.ts
@@ -13,7 +13,7 @@ import { MassMigrationBatch, MassMigrationCommitment } from "../ts/commitments";
 const DOMAIN =
     "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
-describe("Mass Migrations", async function () {
+describe("Mass Migrations", async function() {
     const tokenID = 1;
     let Alice: Account;
     let Bob: Account;
@@ -21,12 +21,12 @@ describe("Mass Migrations", async function () {
     let stateTree: StateTree;
     let registry: AccountRegistry;
     let initialBatch: MassMigrationBatch;
-    before(async function () {
+    before(async function() {
         await mcl.init();
         mcl.setDomainHex(DOMAIN);
     });
 
-    beforeEach(async function () {
+    beforeEach(async function() {
         const accounts = await ethers.getSigners();
         contracts = await deployAll(accounts[0], TESTING_PARAMS);
         stateTree = new StateTree(TESTING_PARAMS.MAX_DEPTH);
@@ -57,7 +57,7 @@ describe("Mass Migrations", async function () {
         );
     });
 
-    it("submit a batch and dispute", async function () {
+    it("submit a batch and dispute", async function() {
         const tx = new TxMassMigration(
             Alice.stateID,
             0,
@@ -87,7 +87,7 @@ describe("Mass Migrations", async function () {
         );
         const {
             0: postStateRoot,
-            1: error,
+            1: error
         } = await contracts.massMigration.processMassMigrationCommit(
             stateRoot,
             commitment.toSolStruct().body,
@@ -95,8 +95,8 @@ describe("Mass Migrations", async function () {
                 {
                     pathToAccount: Alice.stateID,
                     account: proof.account,
-                    siblings: proof.witness,
-                },
+                    siblings: proof.witness
+                }
             ]
         );
         assert.equal(
@@ -128,8 +128,8 @@ describe("Mass Migrations", async function () {
             {
                 pathToAccount: Alice.stateID,
                 account: proof.account,
-                siblings: proof.witness,
-            },
+                siblings: proof.witness
+            }
         ]);
 
         assert.equal(

--- a/test/MassMigration.test.ts
+++ b/test/MassMigration.test.ts
@@ -14,18 +14,18 @@ import { assert } from "chai";
 const DOMAIN =
     "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
-describe("Mass Migrations", async function() {
+describe("Mass Migrations", async function () {
     let Alice: Account;
     let Bob: Account;
     let contracts: allContracts;
     let stateTree: StateTree;
     let registry: AccountRegistry;
-    before(async function() {
+    before(async function () {
         await mcl.init();
         mcl.setDomainHex(DOMAIN);
     });
 
-    beforeEach(async function() {
+    beforeEach(async function () {
         const accounts = await ethers.getSigners();
         contracts = await deployAll(accounts[0], TESTING_PARAMS);
         stateTree = new StateTree(TESTING_PARAMS.MAX_DEPTH);
@@ -47,7 +47,7 @@ describe("Mass Migrations", async function() {
         stateTree.createAccount(Bob);
     });
 
-    it("submit a batch and dispute", async function() {
+    it("submit a batch and dispute", async function () {
         const tx = new TxMassMigration(
             Alice.stateID,
             0,
@@ -58,7 +58,7 @@ describe("Mass Migrations", async function() {
         );
         const signature = Alice.sign(tx);
         const rollup = contracts.rollup;
-        const rollupUtils = contracts.rollupUtils;
+        const rollupUtils = contracts.clientUtils;
         const stateRoot = stateTree.root;
         const proof = stateTree.applyMassMigration(tx);
         const txs = ethers.utils.arrayify(tx.encode(true));
@@ -69,7 +69,7 @@ describe("Mass Migrations", async function() {
             withdrawRoot:
                 "0x0000000000000000000000000000000000000000000000000000000000000000",
             tokenID: 1,
-            amount: tx.amount
+            amount: tx.amount,
         };
 
         const commitment = {
@@ -78,7 +78,7 @@ describe("Mass Migrations", async function() {
             txs,
             massMigrationMetaInfo: MMInfo,
             signature: aggregatedSignature0,
-            batchType: Usage.MassMigration
+            batchType: Usage.MassMigration,
         };
         const result = await contracts.massMigration.processMassMigrationCommit(
             commitment,
@@ -86,8 +86,8 @@ describe("Mass Migrations", async function() {
                 {
                     pathToAccount: Alice.stateID,
                     account: proof.account,
-                    siblings: proof.witness
-                }
+                    siblings: proof.witness,
+                },
             ]
         );
 
@@ -137,7 +137,7 @@ describe("Mass Migrations", async function() {
                     "bytes32",
                     "uint256",
                     "uint256[2]",
-                    "uint8"
+                    "uint8",
                 ],
                 [
                     commitment.stateRoot,
@@ -148,7 +148,7 @@ describe("Mass Migrations", async function() {
                     commitment.massMigrationMetaInfo.withdrawRoot,
                     commitment.massMigrationMetaInfo.targetSpokeID,
                     commitment.signature,
-                    commitment.batchType
+                    commitment.batchType,
                 ]
             )
         );
@@ -163,15 +163,15 @@ describe("Mass Migrations", async function() {
         const commitmentMP = {
             commitment,
             pathToCommitment: 0,
-            siblings: tree.witness(0).nodes
+            siblings: tree.witness(0).nodes,
         };
 
         await rollup.disputeMMBatch(batchId, commitmentMP, [
             {
                 pathToAccount: Alice.stateID,
                 account: proof.account,
-                siblings: proof.witness
-            }
+                siblings: proof.witness,
+            },
         ]);
     });
 });

--- a/test/rollup.test.ts
+++ b/test/rollup.test.ts
@@ -14,19 +14,19 @@ import { assert } from "chai";
 const DOMAIN =
     "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
-describe("Rollup", async function () {
+describe("Rollup", async function() {
     const tokenID = 1;
     let Alice: Account;
     let Bob: Account;
     let contracts: allContracts;
     let stateTree: StateTree;
     let registry: AccountRegistry;
-    before(async function () {
+    before(async function() {
         await mcl.init();
         mcl.setDomainHex(DOMAIN);
     });
 
-    beforeEach(async function () {
+    beforeEach(async function() {
         const accounts = await ethers.getSigners();
         contracts = await deployAll(accounts[0], TESTING_PARAMS);
         stateTree = new StateTree(TESTING_PARAMS.MAX_DEPTH);
@@ -47,7 +47,7 @@ describe("Rollup", async function () {
         stateTree.createAccount(Bob);
     });
 
-    it("submit a batch and dispute", async function () {
+    it("submit a batch and dispute", async function() {
         const feeReceiver = Alice.stateID;
         const fee = 1;
         const tx = new TxTransfer(
@@ -75,7 +75,7 @@ describe("Rollup", async function () {
             signature: aggregatedSignature0,
             tokenType: tokenID,
             feeReceiver,
-            txs: serialized,
+            txs: serialized
         };
         const _txSubmit = await rollup.submitBatch(
             [submission],
@@ -100,7 +100,7 @@ describe("Rollup", async function () {
             txs: serialized,
             tokenType: tokenID,
             feeReceiver,
-            batchType: Usage.Transfer,
+            batchType: Usage.Transfer
         };
         const depth = 1; // Math.log2(commitmentLength + 1)
         const tree = Tree.new(
@@ -131,7 +131,7 @@ describe("Rollup", async function () {
                     "bytes",
                     "uint256",
                     "uint256",
-                    "uint8",
+                    "uint8"
                 ],
                 [
                     commitment.stateRoot,
@@ -140,7 +140,7 @@ describe("Rollup", async function () {
                     commitment.txs,
                     commitment.tokenType,
                     commitment.feeReceiver,
-                    commitment.batchType,
+                    commitment.batchType
                 ]
             )
         );
@@ -155,7 +155,7 @@ describe("Rollup", async function () {
         const commitmentMP = {
             commitment,
             pathToCommitment: 0,
-            witness: tree.witness(0).nodes,
+            witness: tree.witness(0).nodes
         };
 
         const pathToAccount = 0; // Dummy value
@@ -164,18 +164,18 @@ describe("Rollup", async function () {
             {
                 pathToAccount,
                 account: proof[0].senderAccount,
-                siblings: proof[0].senderWitness,
+                siblings: proof[0].senderWitness
             },
             {
                 pathToAccount,
                 account: proof[0].receiverAccount,
-                siblings: proof[0].receiverWitness,
+                siblings: proof[0].receiverWitness
             },
             {
                 pathToAccount,
                 account: feeProof.feeReceiverAccount,
-                siblings: feeProof.feeReceiverWitness,
-            },
+                siblings: feeProof.feeReceiverWitness
+            }
         ]);
         const receipt = await _tx.wait();
         console.log("disputeBatch execution cost", receipt.gasUsed.toNumber());

--- a/test/rollup.test.ts
+++ b/test/rollup.test.ts
@@ -14,19 +14,19 @@ import { assert } from "chai";
 const DOMAIN =
     "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
-describe("Rollup", async function() {
+describe("Rollup", async function () {
     const tokenID = 1;
     let Alice: Account;
     let Bob: Account;
     let contracts: allContracts;
     let stateTree: StateTree;
     let registry: AccountRegistry;
-    before(async function() {
+    before(async function () {
         await mcl.init();
         mcl.setDomainHex(DOMAIN);
     });
 
-    beforeEach(async function() {
+    beforeEach(async function () {
         const accounts = await ethers.getSigners();
         contracts = await deployAll(accounts[0], TESTING_PARAMS);
         stateTree = new StateTree(TESTING_PARAMS.MAX_DEPTH);
@@ -47,7 +47,7 @@ describe("Rollup", async function() {
         stateTree.createAccount(Bob);
     });
 
-    it("submit a batch and dispute", async function() {
+    it("submit a batch and dispute", async function () {
         const feeReceiver = Alice.stateID;
         const fee = 1;
         const tx = new TxTransfer(
@@ -61,7 +61,7 @@ describe("Rollup", async function() {
         const signature = Alice.sign(tx);
 
         const rollup = contracts.rollup;
-        const rollupUtils = contracts.rollupUtils;
+        const rollupUtils = contracts.clientUtils;
         const stateRoot = stateTree.root;
         const { proof, feeProof, safe } = stateTree.applyTransferBatch(
             [tx],
@@ -75,7 +75,7 @@ describe("Rollup", async function() {
             signature: aggregatedSignature0,
             tokenType: tokenID,
             feeReceiver,
-            txs: serialized
+            txs: serialized,
         };
         const _txSubmit = await rollup.submitBatch(
             [submission],
@@ -100,7 +100,7 @@ describe("Rollup", async function() {
             txs: serialized,
             tokenType: tokenID,
             feeReceiver,
-            batchType: Usage.Transfer
+            batchType: Usage.Transfer,
         };
         const depth = 1; // Math.log2(commitmentLength + 1)
         const tree = Tree.new(
@@ -131,7 +131,7 @@ describe("Rollup", async function() {
                     "bytes",
                     "uint256",
                     "uint256",
-                    "uint8"
+                    "uint8",
                 ],
                 [
                     commitment.stateRoot,
@@ -140,7 +140,7 @@ describe("Rollup", async function() {
                     commitment.txs,
                     commitment.tokenType,
                     commitment.feeReceiver,
-                    commitment.batchType
+                    commitment.batchType,
                 ]
             )
         );
@@ -155,7 +155,7 @@ describe("Rollup", async function() {
         const commitmentMP = {
             commitment,
             pathToCommitment: 0,
-            witness: tree.witness(0).nodes
+            witness: tree.witness(0).nodes,
         };
 
         const pathToAccount = 0; // Dummy value
@@ -164,18 +164,18 @@ describe("Rollup", async function() {
             {
                 pathToAccount,
                 account: proof[0].senderAccount,
-                siblings: proof[0].senderWitness
+                siblings: proof[0].senderWitness,
             },
             {
                 pathToAccount,
                 account: proof[0].receiverAccount,
-                siblings: proof[0].receiverWitness
+                siblings: proof[0].receiverWitness,
             },
             {
                 pathToAccount,
                 account: feeProof.feeReceiverAccount,
-                siblings: feeProof.feeReceiverWitness
-            }
+                siblings: feeProof.feeReceiverWitness,
+            },
         ]);
         const receipt = await _tx.wait();
         console.log("disputeBatch execution cost", receipt.gasUsed.toNumber());

--- a/test/rollupTransfer.test.ts
+++ b/test/rollupTransfer.test.ts
@@ -29,7 +29,7 @@ describe("Rollup Transfer Commitment", () => {
     const initialBalance = 1000;
     const initialNonce = 9;
 
-    before(async function () {
+    before(async function() {
         await mcl.init();
         mcl.setDomainHex(DOMAIN_HEX);
         const [signer, ...rest] = await ethers.getSigners();
@@ -55,7 +55,7 @@ describe("Rollup Transfer Commitment", () => {
         }
     });
 
-    beforeEach(async function () {
+    beforeEach(async function() {
         const [signer, ...rest] = await ethers.getSigners();
         rollup = await new TestTransferFactory(signer).deploy();
         stateTree = StateTree.new(STATE_TREE_DEPTH);
@@ -64,7 +64,7 @@ describe("Rollup Transfer Commitment", () => {
         }
     });
 
-    it("transfer commitment: signature check", async function () {
+    it("transfer commitment: signature check", async function() {
         const txs: TxTransfer[] = [];
         const amount = 20;
         const fee = 1;
@@ -110,11 +110,11 @@ describe("Rollup Transfer Commitment", () => {
             stateAccounts,
             stateWitnesses,
             pubkeys,
-            pubkeyWitnesses,
+            pubkeyWitnesses
         };
         const {
             0: gasCost,
-            1: noError,
+            1: noError
         } = await rollup.callStatic._checkSignature(
             signature,
             proof,
@@ -146,7 +146,7 @@ describe("Rollup Transfer Commitment", () => {
         console.log("transaction gas cost:", receipt.gasUsed?.toNumber());
     }).timeout(400000);
 
-    it("transfer commitment: processTx", async function () {
+    it("transfer commitment: processTx", async function() {
         const amount = 20;
         const fee = 1;
         for (let i = 0; i < COMMIT_SIZE; i++) {
@@ -172,18 +172,18 @@ describe("Rollup Transfer Commitment", () => {
                 {
                     pathToAccount: sender.stateID,
                     account: proof.senderAccount,
-                    siblings: proof.senderWitness,
+                    siblings: proof.senderWitness
                 },
                 {
                     pathToAccount: receiver.stateID,
                     account: proof.receiverAccount,
-                    siblings: proof.receiverWitness,
+                    siblings: proof.receiverWitness
                 }
             );
             assert.equal(result[0], postRoot, "mismatch processed stateroot");
         }
     });
-    it("transfer commitment: processTransferCommit", async function () {
+    it("transfer commitment: processTransferCommit", async function() {
         const txs: TxTransfer[] = [];
         const amount = 20;
         const fee = 1;
@@ -222,24 +222,24 @@ describe("Rollup Transfer Commitment", () => {
             stateMerkleProof.push({
                 account: proof[i].senderAccount,
                 pathToAccount,
-                siblings: proof[i].senderWitness,
+                siblings: proof[i].senderWitness
             });
             stateMerkleProof.push({
                 account: proof[i].receiverAccount,
                 pathToAccount,
-                siblings: proof[i].receiverWitness,
+                siblings: proof[i].receiverWitness
             });
         }
         stateMerkleProof.push({
             account: feeProof.feeReceiverAccount,
             pathToAccount,
-            siblings: feeProof.feeReceiverWitness,
+            siblings: feeProof.feeReceiverWitness
         });
         const postStateRoot = stateTree.root;
 
         const {
             0: postRoot,
-            1: gasCost,
+            1: gasCost
         } = await rollup.callStatic.testProcessTransferCommit(
             s0,
             serialized,

--- a/test/rollupTransfer.test.ts
+++ b/test/rollupTransfer.test.ts
@@ -1,5 +1,4 @@
 import { LoggerFactory } from "../types/ethers-contracts/LoggerFactory";
-import { RollupUtilsFactory } from "../types/ethers-contracts/RollupUtilsFactory";
 import { TestTransferFactory } from "../types/ethers-contracts/TestTransferFactory";
 import { TestTransfer } from "../types/ethers-contracts/TestTransfer";
 import { BlsAccountRegistryFactory } from "../types/ethers-contracts/BlsAccountRegistryFactory";
@@ -30,7 +29,7 @@ describe("Rollup Transfer Commitment", () => {
     const initialBalance = 1000;
     const initialNonce = 9;
 
-    before(async function() {
+    before(async function () {
         await mcl.init();
         mcl.setDomainHex(DOMAIN_HEX);
         const [signer, ...rest] = await ethers.getSigners();
@@ -56,22 +55,16 @@ describe("Rollup Transfer Commitment", () => {
         }
     });
 
-    beforeEach(async function() {
+    beforeEach(async function () {
         const [signer, ...rest] = await ethers.getSigners();
-        let rollupUtilsLib = await new RollupUtilsFactory(signer).deploy();
-        rollup = await new TestTransferFactory(
-            {
-                __$a6b8846b3184b62d6aec39d1f36e30dab3$__: rollupUtilsLib.address
-            },
-            signer
-        ).deploy();
+        rollup = await new TestTransferFactory(signer).deploy();
         stateTree = StateTree.new(STATE_TREE_DEPTH);
         for (let i = 0; i < ACCOUNT_SIZE; i++) {
             stateTree.createAccount(accounts[i]);
         }
     });
 
-    it("transfer commitment: signature check", async function() {
+    it("transfer commitment: signature check", async function () {
         const txs: TxTransfer[] = [];
         const amount = 20;
         const fee = 1;
@@ -117,11 +110,11 @@ describe("Rollup Transfer Commitment", () => {
             stateAccounts,
             stateWitnesses,
             pubkeys,
-            pubkeyWitnesses
+            pubkeyWitnesses,
         };
         const {
             0: gasCost,
-            1: noError
+            1: noError,
         } = await rollup.callStatic._checkSignature(
             signature,
             proof,
@@ -153,7 +146,7 @@ describe("Rollup Transfer Commitment", () => {
         console.log("transaction gas cost:", receipt.gasUsed?.toNumber());
     }).timeout(400000);
 
-    it("transfer commitment: processTx", async function() {
+    it("transfer commitment: processTx", async function () {
         const amount = 20;
         const fee = 1;
         for (let i = 0; i < COMMIT_SIZE; i++) {
@@ -179,18 +172,18 @@ describe("Rollup Transfer Commitment", () => {
                 {
                     pathToAccount: sender.stateID,
                     account: proof.senderAccount,
-                    siblings: proof.senderWitness
+                    siblings: proof.senderWitness,
                 },
                 {
                     pathToAccount: receiver.stateID,
                     account: proof.receiverAccount,
-                    siblings: proof.receiverWitness
+                    siblings: proof.receiverWitness,
                 }
             );
             assert.equal(result[0], postRoot, "mismatch processed stateroot");
         }
     });
-    it("transfer commitment: processTransferCommit", async function() {
+    it("transfer commitment: processTransferCommit", async function () {
         const txs: TxTransfer[] = [];
         const amount = 20;
         const fee = 1;
@@ -229,24 +222,24 @@ describe("Rollup Transfer Commitment", () => {
             stateMerkleProof.push({
                 account: proof[i].senderAccount,
                 pathToAccount,
-                siblings: proof[i].senderWitness
+                siblings: proof[i].senderWitness,
             });
             stateMerkleProof.push({
                 account: proof[i].receiverAccount,
                 pathToAccount,
-                siblings: proof[i].receiverWitness
+                siblings: proof[i].receiverWitness,
             });
         }
         stateMerkleProof.push({
             account: feeProof.feeReceiverAccount,
             pathToAccount,
-            siblings: feeProof.feeReceiverWitness
+            siblings: feeProof.feeReceiverWitness,
         });
         const postStateRoot = stateTree.root;
 
         const {
             0: postRoot,
-            1: gasCost
+            1: gasCost,
         } = await rollup.callStatic.testProcessTransferCommit(
             s0,
             serialized,

--- a/ts/allContractsInterfaces.ts
+++ b/ts/allContractsInterfaces.ts
@@ -12,6 +12,7 @@ import { DepositManager } from "../types/ethers-contracts/DepositManager";
 import { Rollup } from "../types/ethers-contracts/Rollup";
 import { BlsAccountRegistry } from "../types/ethers-contracts/BlsAccountRegistry";
 import { MassMigration } from "../types/ethers-contracts/MassMigration";
+import { ClientUtils } from "../types/ethers-contracts/ClientUtils";
 
 export interface allContracts {
     paramManager: ParamManager;
@@ -28,4 +29,5 @@ export interface allContracts {
     testToken: TestToken;
     depositManager: DepositManager;
     rollup: Rollup;
+    clientUtils: ClientUtils;
 }

--- a/ts/deploy.ts
+++ b/ts/deploy.ts
@@ -81,7 +81,7 @@ export async function deployAll(
     );
 
     const allLinkRefs = {
-        __$b941c30c0f5422d8b714f571f17d94a5fd$__: paramManager.address,
+        __$b941c30c0f5422d8b714f571f17d94a5fd$__: paramManager.address
     };
 
     // deploy MTUtils
@@ -218,7 +218,7 @@ export async function deployAll(
         testToken,
         depositManager,
         rollup,
-        clientUtils,
+        clientUtils
     };
 }
 

--- a/ts/deploy.ts
+++ b/ts/deploy.ts
@@ -1,6 +1,7 @@
 import { ParamManagerFactory } from "../types/ethers-contracts/ParamManagerFactory";
 import { RollupUtilsFactory } from "../types/ethers-contracts/RollupUtilsFactory";
 import { RollupUtils } from "../types/ethers-contracts/RollupUtils";
+import { ClientUtilsFactory } from "../types/ethers-contracts/ClientUtilsFactory";
 import { NameRegistryFactory } from "../types/ethers-contracts/NameRegistryFactory";
 import { NameRegistry } from "../types/ethers-contracts/NameRegistry";
 import { GovernanceFactory } from "../types/ethers-contracts/GovernanceFactory";
@@ -177,6 +178,18 @@ export async function deployAll(
         await paramManager.DEPOSIT_MANAGER()
     );
 
+    const clientUtils = await new ClientUtilsFactory(
+        allLinkRefs,
+        signer
+    ).deploy();
+    await waitAndRegister(
+        clientUtils,
+        "clientUtils",
+        verbose,
+        nameRegistry,
+        await paramManager.CLIENT_UTILS()
+    );
+
     const root =
         parameters.GENESIS_STATE_ROOT ||
         (await getMerkleRootWithCoordinatorAccount(
@@ -212,7 +225,8 @@ export async function deployAll(
         pob,
         testToken,
         depositManager,
-        rollup
+        rollup,
+        clientUtils
     };
 }
 

--- a/ts/deploy.ts
+++ b/ts/deploy.ts
@@ -1,6 +1,5 @@
 import { ParamManagerFactory } from "../types/ethers-contracts/ParamManagerFactory";
 import { RollupUtilsFactory } from "../types/ethers-contracts/RollupUtilsFactory";
-import { RollupUtils } from "../types/ethers-contracts/RollupUtils";
 import { ClientUtilsFactory } from "../types/ethers-contracts/ClientUtilsFactory";
 import { NameRegistryFactory } from "../types/ethers-contracts/NameRegistryFactory";
 import { NameRegistry } from "../types/ethers-contracts/NameRegistry";
@@ -20,6 +19,7 @@ import { BlsAccountRegistryFactory } from "../types/ethers-contracts/BlsAccountR
 import { Signer, Contract } from "ethers";
 import { DeploymentParameters } from "./interfaces";
 import { allContracts } from "./allContractsInterfaces";
+import { ClientUtils } from "../types/ethers-contracts/ClientUtils";
 
 async function waitAndRegister(
     contract: Contract,
@@ -82,7 +82,6 @@ export async function deployAll(
 
     const allLinkRefs = {
         __$b941c30c0f5422d8b714f571f17d94a5fd$__: paramManager.address,
-        __$a6b8846b3184b62d6aec39d1f36e30dab3$__: rollupUtils.address
     };
 
     // deploy MTUtils
@@ -122,7 +121,6 @@ export async function deployAll(
     );
 
     const massMigration = await new MassMigrationProductionFactory(
-        allLinkRefs,
         signer
     ).deploy();
     await waitAndRegister(
@@ -133,10 +131,7 @@ export async function deployAll(
         await paramManager.MASS_MIGS()
     );
 
-    const transfer = await new TransferProductionFactory(
-        allLinkRefs,
-        signer
-    ).deploy();
+    const transfer = await new TransferProductionFactory(signer).deploy();
     await waitAndRegister(
         transfer,
         "transfer",
@@ -178,10 +173,7 @@ export async function deployAll(
         await paramManager.DEPOSIT_MANAGER()
     );
 
-    const clientUtils = await new ClientUtilsFactory(
-        allLinkRefs,
-        signer
-    ).deploy();
+    const clientUtils = await new ClientUtilsFactory(signer).deploy();
     await waitAndRegister(
         clientUtils,
         "clientUtils",
@@ -193,7 +185,7 @@ export async function deployAll(
     const root =
         parameters.GENESIS_STATE_ROOT ||
         (await getMerkleRootWithCoordinatorAccount(
-            rollupUtils,
+            clientUtils,
             merkleTreeUtils,
             parameters
         ));
@@ -226,12 +218,12 @@ export async function deployAll(
         testToken,
         depositManager,
         rollup,
-        clientUtils
+        clientUtils,
     };
 }
 
 async function getMerkleRootWithCoordinatorAccount(
-    rollupUtils: RollupUtils,
+    rollupUtils: ClientUtils,
     merkleTreeUtils: MerkleTreeUtils,
     parameters: DeploymentParameters
 ) {


### PR DESCRIPTION
Typechain didnt support `structs` as args before so we had to write extra utils for off-chain testing. This PR removes those and creates `ClientUtils.sol` that acts as a frontend for utils. Also converts all functions in `RollupUtils.sol` to internal, which means lower gas costs. 