### PR TITLE
abstract out RollupUtilsLib

### DIFF
--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.15;
 pragma experimental ABIEncoderV2;
 import { Types } from "./libs/Types.sol";
 import { Logger } from "./Logger.sol";
-import { RollupUtils } from "./libs/RollupUtils.sol";
+import { RollupUtilsLib } from "./libs/RollupUtils.sol";
 import { MerkleTreeUtils as MTUtils } from "./MerkleTreeUtils.sol";
 import { NameRegistry as Registry } from "./NameRegistry.sol";
 import { ITokenRegistry } from "./interfaces/ITokenRegistry.sol";
@@ -109,7 +109,7 @@ contract DepositManager {
             0
         );
         // get new account hash
-        bytes memory accountBytes = RollupUtils.BytesFromAccount(newAccount);
+        bytes memory accountBytes = RollupUtilsLib.BytesFromAccount(newAccount);
         // queue the deposit
         pendingDeposits.push(keccak256(accountBytes));
         // emit the event

--- a/contracts/FraudProof.sol
+++ b/contracts/FraudProof.sol
@@ -6,7 +6,7 @@ import { Tx } from "./libs/Tx.sol";
 import { IERC20 } from "./interfaces/IERC20.sol";
 
 import { Types } from "./libs/Types.sol";
-import { RollupUtils } from "./libs/RollupUtils.sol";
+import { RollupUtilsLib } from "./libs/RollupUtils.sol";
 import { ParamManager } from "./libs/ParamManager.sol";
 
 import { MerkleTreeUtilsLib } from "./MerkleTreeUtils.sol";
@@ -94,7 +94,7 @@ contract FraudProofHelpers is FraudProofSetup {
         Types.AccountMerkleProof memory _merkle_proof
     ) public pure returns (bytes32) {
         bytes32 newRoot = MerkleTreeUtilsLib.rootFromWitnesses(
-            keccak256(RollupUtils.BytesFromAccount(new_account)),
+            keccak256(RollupUtilsLib.BytesFromAccount(new_account)),
             _merkle_proof.pathToAccount,
             _merkle_proof.siblings
         );

--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -3,7 +3,7 @@ pragma experimental ABIEncoderV2;
 
 import { FraudProofHelpers } from "./FraudProof.sol";
 import { Types } from "./libs/Types.sol";
-import { RollupUtils } from "./libs/RollupUtils.sol";
+import { RollupUtilsLib } from "./libs/RollupUtils.sol";
 import { Tx } from "./libs/Tx.sol";
 import { MerkleTreeUtilsLib } from "./MerkleTreeUtils.sol";
 
@@ -101,7 +101,7 @@ contract MassMigration is FraudProofHelpers {
         require(
             MerkleTreeUtilsLib.verifyLeaf(
                 stateRoot,
-                RollupUtils.HashFromAccount(fromAccountProof.account),
+                RollupUtilsLib.HashFromAccount(fromAccountProof.account),
                 _tx.fromIndex,
                 fromAccountProof.siblings
             ),
@@ -140,7 +140,7 @@ contract MassMigration is FraudProofHelpers {
         Types.UserAccount memory account = _merkle_proof.account;
         account = RemoveTokensFromAccount(account, _tx.amount);
         account.nonce++;
-        bytes memory accountInBytes = RollupUtils.BytesFromAccount(account);
+        bytes memory accountInBytes = RollupUtilsLib.BytesFromAccount(account);
         newRoot = MerkleTreeUtilsLib.rootFromWitnesses(
             keccak256(accountInBytes),
             _tx.fromIndex,

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.15;
 pragma experimental ABIEncoderV2;
 import { FraudProofHelpers } from "./FraudProof.sol";
 import { Types } from "./libs/Types.sol";
-import { RollupUtils } from "./libs/RollupUtils.sol";
+import { RollupUtilsLib } from "./libs/RollupUtils.sol";
 import { MerkleTreeUtilsLib } from "./MerkleTreeUtils.sol";
 
 import { BLS } from "./libs/BLS.sol";
@@ -45,7 +45,7 @@ contract Transfer is FraudProofHelpers {
             require(
                 MerkleTreeUtilsLib.verifyLeaf(
                     stateRoot,
-                    RollupUtils.HashFromAccount(proof.stateAccounts[i]),
+                    RollupUtilsLib.HashFromAccount(proof.stateAccounts[i]),
                     signerStateID,
                     proof.stateWitnesses[i]
                 ),
@@ -161,7 +161,7 @@ contract Transfer is FraudProofHelpers {
         require(
             MerkleTreeUtilsLib.verifyLeaf(
                 stateRoot,
-                RollupUtils.HashFromAccount(fromAccountProof.account),
+                RollupUtilsLib.HashFromAccount(fromAccountProof.account),
                 _tx.fromIndex,
                 fromAccountProof.siblings
             ),
@@ -207,7 +207,7 @@ contract Transfer is FraudProofHelpers {
         require(
             MerkleTreeUtilsLib.verifyLeaf(
                 newRoot,
-                RollupUtils.HashFromAccount(toAccountProof.account),
+                RollupUtilsLib.HashFromAccount(toAccountProof.account),
                 _tx.toIndex,
                 toAccountProof.siblings
             ),
@@ -235,7 +235,7 @@ contract Transfer is FraudProofHelpers {
         Types.UserAccount memory account = _merkle_proof.account;
         account.balance = account.balance.sub(_tx.amount).sub(_tx.fee);
         account.nonce++;
-        bytes memory accountInBytes = RollupUtils.BytesFromAccount(account);
+        bytes memory accountInBytes = RollupUtilsLib.BytesFromAccount(account);
         newRoot = MerkleTreeUtilsLib.rootFromWitnesses(
             keccak256(accountInBytes),
             _tx.fromIndex,
@@ -250,7 +250,7 @@ contract Transfer is FraudProofHelpers {
     ) public pure returns (bytes memory updatedAccount, bytes32 newRoot) {
         Types.UserAccount memory account = _merkle_proof.account;
         account.balance = account.balance.add(_tx.amount);
-        bytes memory accountInBytes = RollupUtils.BytesFromAccount(account);
+        bytes memory accountInBytes = RollupUtilsLib.BytesFromAccount(account);
         newRoot = MerkleTreeUtilsLib.rootFromWitnesses(
             keccak256(accountInBytes),
             _tx.toIndex,
@@ -281,7 +281,7 @@ contract Transfer is FraudProofHelpers {
         require(
             MerkleTreeUtilsLib.verifyLeaf(
                 stateRoot,
-                RollupUtils.HashFromAccount(account),
+                RollupUtilsLib.HashFromAccount(account),
                 feeReceiver,
                 stateLeafProof.siblings
             ),

--- a/test/rollupTransfer.test.ts
+++ b/test/rollupTransfer.test.ts
@@ -1,5 +1,4 @@
 import { LoggerFactory } from "../types/ethers-contracts/LoggerFactory";
-import { RollupUtilsFactory } from "../types/ethers-contracts/RollupUtilsFactory";
 import { TestTransferFactory } from "../types/ethers-contracts/TestTransferFactory";
 import { TestTransfer } from "../types/ethers-contracts/TestTransfer";
 import { BlsAccountRegistryFactory } from "../types/ethers-contracts/BlsAccountRegistryFactory";
@@ -58,13 +57,7 @@ describe("Rollup Transfer Commitment", () => {
 
     beforeEach(async function() {
         const [signer, ...rest] = await ethers.getSigners();
-        let rollupUtilsLib = await new RollupUtilsFactory(signer).deploy();
-        rollup = await new TestTransferFactory(
-            {
-                __$a6b8846b3184b62d6aec39d1f36e30dab3$__: rollupUtilsLib.address
-            },
-            signer
-        ).deploy();
+        rollup = await new TestTransferFactory(signer).deploy();
         stateTree = StateTree.new(STATE_TREE_DEPTH);
         for (let i = 0; i < ACCOUNT_SIZE; i++) {
             stateTree.createAccount(accounts[i]);

--- a/test/rollupUtils.test.ts
+++ b/test/rollupUtils.test.ts
@@ -15,13 +15,8 @@ describe("RollupUtils", async function() {
     it("test account encoding and decoding", async function() {
         const account = EMPTY_ACCOUNT;
 
-        const accountBytes = await RollupUtilsInstance.BytesFromAccountDeconstructed(
-            account.ID,
-            account.balance,
-            account.nonce,
-            account.tokenType,
-            account.burn,
-            account.lastBurn
+        const accountBytes = await RollupUtilsInstance.BytesFromAccount(
+            account
         );
         const regeneratedAccount = await RollupUtilsInstance.AccountFromBytes(
             accountBytes
@@ -32,26 +27,6 @@ describe("RollupUtils", async function() {
         assert.equal(regeneratedAccount["3"].toNumber(), account.tokenType);
         assert.equal(regeneratedAccount["4"].toNumber(), account.burn);
         assert.equal(regeneratedAccount["5"].toNumber(), account.lastBurn);
-
-        const tx = TxTransfer.rand().extended();
-
-        const txBytes = await RollupUtilsInstance.BytesFromTxDeconstructed(
-            tx.txType,
-            tx.fromIndex,
-            tx.toIndex,
-            tx.tokenType,
-            tx.nonce,
-            tx.amount,
-            tx.fee
-        );
-
-        const txData = await RollupUtilsInstance.TxFromBytes(txBytes);
-        assert.equal(txData.fromIndex.toString(), tx.fromIndex.toString());
-        assert.equal(txData.toIndex.toString(), tx.toIndex.toString());
-        assert.equal(txData.tokenType.toString(), tx.tokenType.toString());
-        assert.equal(txData.nonce.toString(), tx.nonce.toString());
-        assert.equal(txData.txType.toString(), tx.txType.toString());
-        assert.equal(txData.amount.toString(), tx.amount.toString());
     });
     it("test transfer utils", async function() {
         const tx = TxTransfer.rand().extended();
@@ -63,15 +38,15 @@ describe("RollupUtils", async function() {
             tx.amount,
             tx.fee
         );
-        const txBytes = await RollupUtilsInstance.BytesFromTxDeconstructed(
-            tx.txType,
-            tx.fromIndex,
-            tx.toIndex,
-            tx.tokenType,
-            tx.nonce,
-            tx.amount,
-            tx.fee
-        );
+        const txBytes = await RollupUtilsInstance.BytesFromTx(tx);
+
+        const txData = await RollupUtilsInstance.TxFromBytes(txBytes);
+        assert.equal(txData.fromIndex.toNumber(), tx.fromIndex);
+        assert.equal(txData.toIndex.toNumber(), tx.toIndex);
+        assert.equal(txData.tokenType.toNumber(), tx.tokenType);
+        assert.equal(txData.nonce.toNumber(), tx.nonce);
+        assert.equal(txData.txType.toNumber(), tx.txType);
+        assert.equal(txData.amount.toNumber(), tx.amount);
         await RollupUtilsInstance.CompressTransferFromEncoded(txBytes, "0x00");
         const txs = await RollupUtilsInstance.CompressManyTransferFromEncoded(
             [txBytes, txBytes],

--- a/ts/deploy.ts
+++ b/ts/deploy.ts
@@ -80,8 +80,7 @@ export async function deployAll(
     );
 
     const allLinkRefs = {
-        __$b941c30c0f5422d8b714f571f17d94a5fd$__: paramManager.address,
-        __$a6b8846b3184b62d6aec39d1f36e30dab3$__: rollupUtils.address
+        __$b941c30c0f5422d8b714f571f17d94a5fd$__: paramManager.address
     };
 
     // deploy MTUtils
@@ -121,7 +120,6 @@ export async function deployAll(
     );
 
     const massMigration = await new MassMigrationProductionFactory(
-        allLinkRefs,
         signer
     ).deploy();
     await waitAndRegister(
@@ -132,10 +130,7 @@ export async function deployAll(
         await paramManager.MASS_MIGS()
     );
 
-    const transfer = await new TransferProductionFactory(
-        allLinkRefs,
-        signer
-    ).deploy();
+    const transfer = await new TransferProductionFactory(signer).deploy();
     await waitAndRegister(
         transfer,
         "transfer",


### PR DESCRIPTION
This is an alternative to #226

In this PR
- We still keep RollupUtils as the client proxy contract. 
- RollupUtils is now a contract, and 
- We have RollupUtilsLib that defines internal functions for other contracts to consume. This has the benefit that we have lower gas cost and we don't have to link the library for rollupUtils.