### PR TITLE
Rename Accounts to States

### DIFF
--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -12,6 +12,7 @@ import { Governance } from "./Governance.sol";
 import { Rollup } from "./Rollup.sol";
 
 contract DepositManager {
+    using Types for Types.UserState;
     MTUtils public merkleUtils;
     Registry public nameRegistry;
     bytes32[] public pendingDeposits;
@@ -98,19 +99,19 @@ contract DepositManager {
             tokenContract.transferFrom(msg.sender, vault, _amount),
             "token transfer not approved"
         );
-        // create a new account
-        Types.UserState memory newAccount = Types.UserState(
+        // create a new state
+        Types.UserState memory newState = Types.UserState(
             accountID,
             _tokenType,
             _amount,
             0
         );
-        // get new account hash
-        bytes memory accountBytes = Types.encode(newAccount);
+        // get new state hash
+        bytes memory encodedState = newState.encode();
         // queue the deposit
-        pendingDeposits.push(keccak256(accountBytes));
+        pendingDeposits.push(keccak256(encodedState));
         // emit the event
-        logger.logDepositQueued(accountID, accountBytes);
+        logger.logDepositQueued(accountID, encodedState);
         queueNumber++;
         uint256 tmpDepositSubtreeHeight = 0;
         uint256 tmp = queueNumber;

--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -100,7 +100,7 @@ contract DepositManager {
             "token transfer not approved"
         );
         // create a new account
-        Types.UserAccount memory newAccount = Types.UserAccount(
+        Types.UserState memory newAccount = Types.UserState(
             accountID,
             _tokenType,
             _amount,

--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -2,7 +2,6 @@ pragma solidity ^0.5.15;
 pragma experimental ABIEncoderV2;
 import { Types } from "./libs/Types.sol";
 import { Logger } from "./Logger.sol";
-import { RollupUtilsLib } from "./libs/RollupUtils.sol";
 import { MerkleTreeUtils as MTUtils } from "./MerkleTreeUtils.sol";
 import { NameRegistry as Registry } from "./NameRegistry.sol";
 import { ITokenRegistry } from "./interfaces/ITokenRegistry.sol";
@@ -107,7 +106,7 @@ contract DepositManager {
             0
         );
         // get new account hash
-        bytes memory accountBytes = RollupUtilsLib.BytesFromAccount(newAccount);
+        bytes memory accountBytes = Types.encode(newAccount);
         // queue the deposit
         pendingDeposits.push(keccak256(accountBytes));
         // emit the event

--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -166,12 +166,12 @@ contract DepositManager {
      * @notice Merges the deposit tree with the balance tree by
      *        superimposing the deposit subtree on the balance tree
      * @param _subTreeDepth Deposit tree depth or depth of subtree that is being deposited
-     * @param _zero_account_mp Merkle proof proving the node at which we are inserting the deposit subtree consists of all empty leaves
+     * @param zero Merkle proof proving the node at which we are inserting the deposit subtree consists of all empty leaves
      * @return Updates in-state merkle tree root
      */
     function finaliseDeposits(
         uint256 _subTreeDepth,
-        Types.StateMerkleProof memory _zero_account_mp,
+        Types.StateMerkleProofWithPath memory zero,
         bytes32 latestBalanceTree
     ) public onlyRollup returns (bytes32) {
         bytes32 emptySubtreeRoot = merkleUtils.getRoot(_subTreeDepth);
@@ -181,8 +181,8 @@ contract DepositManager {
         bool isValid = merkleUtils.verifyLeaf(
             latestBalanceTree,
             emptySubtreeRoot,
-            _zero_account_mp.pathToAccount,
-            _zero_account_mp.siblings
+            zero.path,
+            zero.witness
         );
 
         require(isValid, "proof invalid");
@@ -193,7 +193,7 @@ contract DepositManager {
         // emit the event
         logger.logDepositFinalised(
             depositsSubTreeRoot,
-            _zero_account_mp.pathToAccount
+            zero.path
         );
 
         // return the updated merkle tree root

--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -171,7 +171,7 @@ contract DepositManager {
      */
     function finaliseDeposits(
         uint256 _subTreeDepth,
-        Types.AccountMerkleProof memory _zero_account_mp,
+        Types.StateMerkleProof memory _zero_account_mp,
         bytes32 latestBalanceTree
     ) public onlyRollup returns (bytes32) {
         bytes32 emptySubtreeRoot = merkleUtils.getRoot(_subTreeDepth);

--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -190,10 +190,7 @@ contract DepositManager {
         bytes32 depositsSubTreeRoot = dequeue();
 
         // emit the event
-        logger.logDepositFinalised(
-            depositsSubTreeRoot,
-            zero.path
-        );
+        logger.logDepositFinalised(depositsSubTreeRoot, zero.path);
 
         // return the updated merkle tree root
         return (depositsSubTreeRoot);

--- a/contracts/FraudProof.sol
+++ b/contracts/FraudProof.sol
@@ -24,7 +24,7 @@ contract FraudProofHelpers is FraudProofSetup {
     function validateTxBasic(
         uint256 amount,
         uint256 fee,
-        Types.UserState memory _from_account
+        Types.UserState memory fromState
     ) public pure returns (Types.ErrorCode) {
         if (amount == 0) {
             // invalid state transition
@@ -34,7 +34,7 @@ contract FraudProofHelpers is FraudProofSetup {
         }
 
         // check from leaf has enough balance
-        if (_from_account.balance < amount.add(fee)) {
+        if (fromState.balance < amount.add(fee)) {
             // invalid state transition
             // needs to be slashed because the account doesnt have enough balance
             // for the transfer
@@ -42,46 +42,5 @@ contract FraudProofHelpers is FraudProofSetup {
         }
 
         return Types.ErrorCode.NoError;
-    }
-
-    function RemoveTokensFromAccount(
-        Types.UserState memory account,
-        uint256 numOfTokens
-    ) public pure returns (Types.UserState memory updatedAccount) {
-        return (
-            UpdateBalanceInAccount(
-                account,
-                BalanceFromAccount(account).sub(numOfTokens)
-            )
-        );
-    }
-
-    // returns a new User Account with updated balance
-    function UpdateBalanceInAccount(
-        Types.UserState memory original_account,
-        uint256 new_balance
-    ) public pure returns (Types.UserState memory updated_account) {
-        original_account.balance = new_balance;
-        return original_account;
-    }
-
-    function AddTokensToAccount(
-        Types.UserState memory account,
-        uint256 numOfTokens
-    ) public pure returns (Types.UserState memory updatedAccount) {
-        return (
-            UpdateBalanceInAccount(
-                account,
-                BalanceFromAccount(account).add(numOfTokens)
-            )
-        );
-    }
-
-    function BalanceFromAccount(Types.UserState memory account)
-        public
-        pure
-        returns (uint256)
-    {
-        return account.balance;
     }
 }

--- a/contracts/FraudProof.sol
+++ b/contracts/FraudProof.sol
@@ -25,7 +25,7 @@ contract FraudProofHelpers is FraudProofSetup {
     function validateTxBasic(
         uint256 amount,
         uint256 fee,
-        Types.UserAccount memory _from_account
+        Types.UserState memory _from_account
     ) public pure returns (Types.ErrorCode) {
         if (amount == 0) {
             // invalid state transition
@@ -46,9 +46,9 @@ contract FraudProofHelpers is FraudProofSetup {
     }
 
     function RemoveTokensFromAccount(
-        Types.UserAccount memory account,
+        Types.UserState memory account,
         uint256 numOfTokens
-    ) public pure returns (Types.UserAccount memory updatedAccount) {
+    ) public pure returns (Types.UserState memory updatedAccount) {
         return (
             UpdateBalanceInAccount(
                 account,
@@ -59,17 +59,17 @@ contract FraudProofHelpers is FraudProofSetup {
 
     // returns a new User Account with updated balance
     function UpdateBalanceInAccount(
-        Types.UserAccount memory original_account,
+        Types.UserState memory original_account,
         uint256 new_balance
-    ) public pure returns (Types.UserAccount memory updated_account) {
+    ) public pure returns (Types.UserState memory updated_account) {
         original_account.balance = new_balance;
         return original_account;
     }
 
     function AddTokensToAccount(
-        Types.UserAccount memory account,
+        Types.UserState memory account,
         uint256 numOfTokens
-    ) public pure returns (Types.UserAccount memory updatedAccount) {
+    ) public pure returns (Types.UserState memory updatedAccount) {
         return (
             UpdateBalanceInAccount(
                 account,
@@ -78,7 +78,7 @@ contract FraudProofHelpers is FraudProofSetup {
         );
     }
 
-    function BalanceFromAccount(Types.UserAccount memory account)
+    function BalanceFromAccount(Types.UserState memory account)
         public
         pure
         returns (uint256)
@@ -90,7 +90,7 @@ contract FraudProofHelpers is FraudProofSetup {
      * @notice Returns the updated root and balance
      */
     function UpdateAccountWithSiblings(
-        Types.UserAccount memory new_account,
+        Types.UserState memory new_account,
         Types.AccountMerkleProof memory _merkle_proof
     ) public pure returns (bytes32) {
         bytes32 newRoot = MerkleTreeUtilsLib.rootFromWitnesses(

--- a/contracts/FraudProof.sol
+++ b/contracts/FraudProof.sol
@@ -85,19 +85,4 @@ contract FraudProofHelpers is FraudProofSetup {
     {
         return account.balance;
     }
-
-    /**
-     * @notice Returns the updated root and balance
-     */
-    function UpdateAccountWithSiblings(
-        Types.UserState memory new_account,
-        Types.StateMerkleProof memory _merkle_proof
-    ) public pure returns (bytes32) {
-        bytes32 newRoot = MerkleTreeUtilsLib.rootFromWitnesses(
-            keccak256(RollupUtilsLib.BytesFromAccount(new_account)),
-            _merkle_proof.pathToAccount,
-            _merkle_proof.siblings
-        );
-        return newRoot;
-    }
 }

--- a/contracts/FraudProof.sol
+++ b/contracts/FraudProof.sol
@@ -36,7 +36,7 @@ contract FraudProofHelpers is FraudProofSetup {
         // check from leaf has enough balance
         if (fromState.balance < amount.add(fee)) {
             // invalid state transition
-            // needs to be slashed because the account doesnt have enough balance
+            // needs to be slashed because the state doesnt have enough balance
             // for the transfer
             return Types.ErrorCode.NotEnoughTokenBalance;
         }

--- a/contracts/FraudProof.sol
+++ b/contracts/FraudProof.sol
@@ -6,7 +6,6 @@ import { Tx } from "./libs/Tx.sol";
 import { IERC20 } from "./interfaces/IERC20.sol";
 
 import { Types } from "./libs/Types.sol";
-import { RollupUtilsLib } from "./libs/RollupUtils.sol";
 import { ParamManager } from "./libs/ParamManager.sol";
 
 import { MerkleTreeUtilsLib } from "./MerkleTreeUtils.sol";

--- a/contracts/FraudProof.sol
+++ b/contracts/FraudProof.sol
@@ -91,7 +91,7 @@ contract FraudProofHelpers is FraudProofSetup {
      */
     function UpdateAccountWithSiblings(
         Types.UserState memory new_account,
-        Types.AccountMerkleProof memory _merkle_proof
+        Types.StateMerkleProof memory _merkle_proof
     ) public pure returns (bytes32) {
         bytes32 newRoot = MerkleTreeUtilsLib.rootFromWitnesses(
             keccak256(RollupUtilsLib.BytesFromAccount(new_account)),

--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -117,10 +117,7 @@ contract MassMigration is FraudProofHelpers {
 
         bytes32 newRoot;
         bytes memory newFromState;
-        (newFromState, newRoot) = ApplyMassMigrationTxSender(
-            from,
-            _tx
-        );
+        (newFromState, newRoot) = ApplyMassMigrationTxSender(from, _tx);
 
         return (
             newRoot,

--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -19,7 +19,7 @@ contract MassMigration is FraudProofHelpers {
     function processMassMigrationCommit(
         bytes32 stateRoot,
         Types.MassMigrationBody memory commitmentBody,
-        Types.AccountMerkleProof[] memory accountProofs
+        Types.StateMerkleProof[] memory accountProofs
     ) public view returns (bytes32, bool) {
         uint256 length = commitmentBody.txs.massMigration_size();
 
@@ -85,7 +85,7 @@ contract MassMigration is FraudProofHelpers {
     function processMassMigrationTx(
         bytes32 stateRoot,
         Tx.MassMigration memory _tx,
-        Types.AccountMerkleProof memory fromAccountProof
+        Types.StateMerkleProof memory fromAccountProof
     )
         public
         pure
@@ -134,7 +134,7 @@ contract MassMigration is FraudProofHelpers {
     }
 
     function ApplyMassMigrationTxSender(
-        Types.AccountMerkleProof memory _merkle_proof,
+        Types.StateMerkleProof memory _merkle_proof,
         Tx.MassMigration memory _tx
     ) public pure returns (bytes memory updatedAccount, bytes32 newRoot) {
         Types.UserState memory account = _merkle_proof.account;

--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -137,7 +137,7 @@ contract MassMigration is FraudProofHelpers {
         Tx.MassMigration memory _tx
     ) public pure returns (bytes memory newState, bytes32 newRoot) {
         Types.UserState memory state = _merkle_proof.state;
-        state = RemoveTokensFromAccount(state, _tx.amount);
+        state.balance = state.balance.sub(_tx.amount);
         state.nonce++;
         bytes memory encodedState = state.encode();
         newRoot = MerkleTreeUtilsLib.rootFromWitnesses(

--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -3,12 +3,12 @@ pragma experimental ABIEncoderV2;
 
 import { FraudProofHelpers } from "./FraudProof.sol";
 import { Types } from "./libs/Types.sol";
-import { RollupUtilsLib } from "./libs/RollupUtils.sol";
 import { Tx } from "./libs/Tx.sol";
 import { MerkleTreeUtilsLib } from "./MerkleTreeUtils.sol";
 
 contract MassMigration is FraudProofHelpers {
     using Tx for bytes;
+    using Types for Types.UserState;
     uint256 constant BURN_STATE_INDEX = 0;
 
     /**
@@ -101,7 +101,7 @@ contract MassMigration is FraudProofHelpers {
         require(
             MerkleTreeUtilsLib.verifyLeaf(
                 stateRoot,
-                RollupUtilsLib.HashFromAccount(from.state),
+                keccak256(from.state.encode()),
                 _tx.fromIndex,
                 from.witness
             ),
@@ -140,7 +140,7 @@ contract MassMigration is FraudProofHelpers {
         Types.UserState memory account = _merkle_proof.state;
         account = RemoveTokensFromAccount(account, _tx.amount);
         account.nonce++;
-        bytes memory accountInBytes = RollupUtilsLib.BytesFromAccount(account);
+        bytes memory accountInBytes = Types.encode(account);
         newRoot = MerkleTreeUtilsLib.rootFromWitnesses(
             keccak256(accountInBytes),
             _tx.fromIndex,

--- a/contracts/MassMigrations.sol
+++ b/contracts/MassMigrations.sol
@@ -137,7 +137,7 @@ contract MassMigration is FraudProofHelpers {
         Types.AccountMerkleProof memory _merkle_proof,
         Tx.MassMigration memory _tx
     ) public pure returns (bytes memory updatedAccount, bytes32 newRoot) {
-        Types.UserAccount memory account = _merkle_proof.account;
+        Types.UserState memory account = _merkle_proof.account;
         account = RemoveTokensFromAccount(account, _tx.amount);
         account.nonce++;
         bytes memory accountInBytes = RollupUtilsLib.BytesFromAccount(account);

--- a/contracts/Rollup.sol
+++ b/contracts/Rollup.sol
@@ -380,18 +380,18 @@ contract Rollup is RollupHelpers {
      */
     function finaliseDepositsAndSubmitBatch(
         uint256 _subTreeDepth,
-        Types.StateMerkleProof calldata _zero_account_mp
+        Types.StateMerkleProofWithPath calldata zero
     ) external payable onlyCoordinator isNotRollingBack {
         bytes32 depositSubTreeRoot = depositManager.finaliseDeposits(
             _subTreeDepth,
-            _zero_account_mp,
+            zero,
             getLatestBalanceTreeRoot()
         );
 
         bytes32 newRoot = merkleUtils.updateLeafWithSiblings(
             depositSubTreeRoot,
-            _zero_account_mp.pathToAccount,
-            _zero_account_mp.siblings
+            zero.path,
+            zero.witness
         );
 
         bytes32[] memory depositCommitments = new bytes32[](1);

--- a/contracts/Rollup.sol
+++ b/contracts/Rollup.sol
@@ -429,7 +429,7 @@ contract Rollup is RollupHelpers {
         uint256 _batch_id,
         Types.CommitmentInclusionProof memory previous,
         Types.TransferCommitmentInclusionProof memory target,
-        Types.StateMerkleProof[] memory accountProofs
+        Types.StateMerkleProof[] memory proofs
     )
         public
         isDisputable(_batch_id)
@@ -444,7 +444,7 @@ contract Rollup is RollupHelpers {
             .processTransferCommit(
             previous.commitment.stateRoot,
             target.commitment.body.txs,
-            accountProofs,
+            proofs,
             target.commitment.body.tokenType,
             target.commitment.body.feeReceiver
         );
@@ -465,7 +465,7 @@ contract Rollup is RollupHelpers {
         uint256 _batch_id,
         Types.CommitmentInclusionProof memory previous,
         Types.MMCommitmentInclusionProof memory target,
-        Types.StateMerkleProof[] memory accountProofs
+        Types.StateMerkleProof[] memory proofs
     )
         public
         isDisputable(_batch_id)
@@ -480,7 +480,7 @@ contract Rollup is RollupHelpers {
             .processMassMigrationCommit(
             previous.commitment.stateRoot,
             target.commitment.body,
-            accountProofs
+            proofs
         );
 
         if (

--- a/contracts/Rollup.sol
+++ b/contracts/Rollup.sol
@@ -380,7 +380,7 @@ contract Rollup is RollupHelpers {
      */
     function finaliseDepositsAndSubmitBatch(
         uint256 _subTreeDepth,
-        Types.AccountMerkleProof calldata _zero_account_mp
+        Types.StateMerkleProof calldata _zero_account_mp
     ) external payable onlyCoordinator isNotRollingBack {
         bytes32 depositSubTreeRoot = depositManager.finaliseDeposits(
             _subTreeDepth,
@@ -429,7 +429,7 @@ contract Rollup is RollupHelpers {
         uint256 _batch_id,
         Types.CommitmentInclusionProof memory previous,
         Types.TransferCommitmentInclusionProof memory target,
-        Types.AccountMerkleProof[] memory accountProofs
+        Types.StateMerkleProof[] memory accountProofs
     )
         public
         isDisputable(_batch_id)
@@ -465,7 +465,7 @@ contract Rollup is RollupHelpers {
         uint256 _batch_id,
         Types.CommitmentInclusionProof memory previous,
         Types.MMCommitmentInclusionProof memory target,
-        Types.AccountMerkleProof[] memory accountProofs
+        Types.StateMerkleProof[] memory accountProofs
     )
         public
         isDisputable(_batch_id)

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -40,7 +40,7 @@ contract Transfer is FraudProofHelpers {
                 MerkleTreeUtilsLib.verifyLeaf(
                     accountRoot,
                     keccak256(abi.encodePacked(proof.pubkeys[i])),
-                    proof.stateAccounts[i].ID,
+                    proof.states[i].pubkeyIndex,
                     proof.pubkeyWitnesses[i]
                 ),
                 "Rollup: account does not exists"

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -28,7 +28,7 @@ contract Transfer is FraudProofHelpers {
             require(
                 MerkleTreeUtilsLib.verifyLeaf(
                     stateRoot,
-                    keccak256(proof.stateAccounts[i].encode()),
+                    keccak256(proof.states[i].encode()),
                     _tx.fromIndex,
                     proof.stateWitnesses[i]
                 ),
@@ -47,10 +47,10 @@ contract Transfer is FraudProofHelpers {
             );
 
             // construct the message
-            require(proof.stateAccounts[i].nonce > 0, "Rollup: zero nonce");
+            require(proof.states[i].nonce > 0, "Rollup: zero nonce");
             bytes memory txMsg = txs.transfer_messageOf(
                 i,
-                proof.stateAccounts[i].nonce - 1
+                proof.states[i].nonce - 1
             );
             // make the message
             messages[i] = BLS.hashToPoint(domain, txMsg);

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -172,10 +172,7 @@ contract Transfer is FraudProofHelpers {
         bytes memory newFromState;
         bytes memory newToState;
 
-        (newFromState, newRoot) = ApplyTransferTxSender(
-            from,
-            _tx
-        );
+        (newFromState, newRoot) = ApplyTransferTxSender(from, _tx);
 
         require(
             MerkleTreeUtilsLib.verifyLeaf(
@@ -187,10 +184,7 @@ contract Transfer is FraudProofHelpers {
             "Transfer: receiver does not exist"
         );
 
-        (newToState, newRoot) = ApplyTransferTxReceiver(
-            to,
-            _tx
-        );
+        (newToState, newRoot) = ApplyTransferTxReceiver(to, _tx);
 
         return (
             newRoot,

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -205,7 +205,7 @@ contract Transfer is FraudProofHelpers {
         Types.AccountMerkleProof memory _merkle_proof,
         Tx.Transfer memory _tx
     ) public pure returns (bytes memory updatedAccount, bytes32 newRoot) {
-        Types.UserAccount memory account = _merkle_proof.account;
+        Types.UserState memory account = _merkle_proof.account;
         account.balance = account.balance.sub(_tx.amount).sub(_tx.fee);
         account.nonce++;
         bytes memory accountInBytes = RollupUtilsLib.BytesFromAccount(account);
@@ -221,7 +221,7 @@ contract Transfer is FraudProofHelpers {
         Types.AccountMerkleProof memory _merkle_proof,
         Tx.Transfer memory _tx
     ) public pure returns (bytes memory updatedAccount, bytes32 newRoot) {
-        Types.UserAccount memory account = _merkle_proof.account;
+        Types.UserState memory account = _merkle_proof.account;
         account.balance = account.balance.add(_tx.amount);
         bytes memory accountInBytes = RollupUtilsLib.BytesFromAccount(account);
         newRoot = MerkleTreeUtilsLib.rootFromWitnesses(
@@ -247,7 +247,7 @@ contract Transfer is FraudProofHelpers {
             bool isValid
         )
     {
-        Types.UserAccount memory account = stateLeafProof.account;
+        Types.UserState memory account = stateLeafProof.account;
         if (account.tokenType != tokenType) {
             return (ZERO_BYTES32, Types.ErrorCode.BadToTokenType, false);
         }

--- a/contracts/Transfer.sol
+++ b/contracts/Transfer.sol
@@ -68,7 +68,7 @@ contract Transfer is FraudProofHelpers {
     function processTransferCommit(
         bytes32 stateRoot,
         bytes memory txs,
-        Types.AccountMerkleProof[] memory accountProofs,
+        Types.StateMerkleProof[] memory accountProofs,
         uint256 tokenType,
         uint256 feeReceiver
     ) public pure returns (bytes32, bool) {
@@ -118,8 +118,8 @@ contract Transfer is FraudProofHelpers {
         bytes32 stateRoot,
         Tx.Transfer memory _tx,
         uint256 tokenType,
-        Types.AccountMerkleProof memory fromAccountProof,
-        Types.AccountMerkleProof memory toAccountProof
+        Types.StateMerkleProof memory fromAccountProof,
+        Types.StateMerkleProof memory toAccountProof
     )
         public
         pure
@@ -202,7 +202,7 @@ contract Transfer is FraudProofHelpers {
     }
 
     function ApplyTransferTxSender(
-        Types.AccountMerkleProof memory _merkle_proof,
+        Types.StateMerkleProof memory _merkle_proof,
         Tx.Transfer memory _tx
     ) public pure returns (bytes memory updatedAccount, bytes32 newRoot) {
         Types.UserState memory account = _merkle_proof.account;
@@ -218,7 +218,7 @@ contract Transfer is FraudProofHelpers {
     }
 
     function ApplyTransferTxReceiver(
-        Types.AccountMerkleProof memory _merkle_proof,
+        Types.StateMerkleProof memory _merkle_proof,
         Tx.Transfer memory _tx
     ) public pure returns (bytes memory updatedAccount, bytes32 newRoot) {
         Types.UserState memory account = _merkle_proof.account;
@@ -237,7 +237,7 @@ contract Transfer is FraudProofHelpers {
         uint256 fees,
         uint256 tokenType,
         uint256 feeReceiver,
-        Types.AccountMerkleProof memory stateLeafProof
+        Types.StateMerkleProof memory stateLeafProof
     )
         public
         pure

--- a/contracts/libs/RollupUtils.sol
+++ b/contracts/libs/RollupUtils.sol
@@ -25,14 +25,10 @@ contract RollupUtils {
     function StateFromBytes(bytes memory stateBytes)
         public
         pure
-        returns (
-            uint256 ID,
-            uint256 balance,
-            uint256 nonce,
-            uint256 tokenType
-        )
+        returns (Types.UserState memory state)
     {
-        return abi.decode(stateBytes, (uint256, uint256, uint256, uint256));
+        (state.pubkeyIndex, state.tokenType, state.balance, state.nonce) = abi
+            .decode(stateBytes, (uint256, uint256, uint256, uint256));
     }
 
     function BytesFromState(Types.UserState memory state)

--- a/contracts/libs/RollupUtils.sol
+++ b/contracts/libs/RollupUtils.sol
@@ -4,33 +4,9 @@ pragma experimental ABIEncoderV2;
 import { Tx } from "./Tx.sol";
 import { Types } from "./Types.sol";
 
-library RollupUtilsLib {
-    function BytesFromAccount(Types.UserState memory account)
-        internal
-        pure
-        returns (bytes memory)
-    {
-        bytes memory data = abi.encodePacked(
-            account.pubkeyIndex,
-            account.balance,
-            account.nonce,
-            account.tokenType
-        );
-
-        return data;
-    }
-
-    function HashFromAccount(Types.UserState memory account)
-        internal
-        pure
-        returns (bytes32)
-    {
-        return keccak256(BytesFromAccount(account));
-    }
-}
-
 contract RollupUtils {
     using Tx for bytes;
+    using Types for Types.UserState;
 
     function TransferCommitmentToHash(
         Types.TransferCommitment memory commitment
@@ -62,20 +38,20 @@ contract RollupUtils {
         return abi.decode(accountBytes, (uint256, uint256, uint256, uint256));
     }
 
-    function BytesFromAccount(Types.UserState memory account)
+    function BytesFromState(Types.UserState memory state)
         public
         pure
         returns (bytes memory)
     {
-        return RollupUtilsLib.BytesFromAccount(account);
+        return state.encode();
     }
 
-    function HashFromAccount(Types.UserState memory account)
+    function HashFromState(Types.UserState memory state)
         public
         pure
         returns (bytes32)
     {
-        return RollupUtilsLib.HashFromAccount(account);
+        return keccak256(state.encode());
     }
 
     /**
@@ -96,12 +72,12 @@ contract RollupUtils {
     }
 
     function GetGenesisLeaves() public pure returns (bytes32[2] memory leaves) {
-        Types.UserState memory account1;
-        account1.pubkeyIndex = 0;
-        Types.UserState memory account2;
-        account2.pubkeyIndex = 1;
-        leaves[0] = HashFromAccount(account1);
-        leaves[1] = HashFromAccount(account2);
+        Types.UserState memory state1;
+        state1.pubkeyIndex = 0;
+        Types.UserState memory state2;
+        state2.pubkeyIndex = 1;
+        leaves[0] = keccak256(state1.encode());
+        leaves[1] = keccak256(state2.encode());
     }
 
     // ---------- Tx Related Utils -------------------

--- a/contracts/libs/RollupUtils.sol
+++ b/contracts/libs/RollupUtils.sol
@@ -21,11 +21,7 @@ contract RollupUtils {
     {
         return Types.toHash(commitment);
     }
-
-    // ---------- Account Related Utils -------------------
-
-    // AccountFromBytes decodes the bytes to account
-    function AccountFromBytes(bytes memory accountBytes)
+    function StateFromBytes(bytes memory stateBytes)
         public
         pure
         returns (
@@ -35,7 +31,7 @@ contract RollupUtils {
             uint256 tokenType
         )
     {
-        return abi.decode(accountBytes, (uint256, uint256, uint256, uint256));
+        return abi.decode(stateBytes, (uint256, uint256, uint256, uint256));
     }
 
     function BytesFromState(Types.UserState memory state)

--- a/contracts/libs/RollupUtils.sol
+++ b/contracts/libs/RollupUtils.sol
@@ -11,7 +11,7 @@ library RollupUtilsLib {
         returns (bytes memory)
     {
         bytes memory data = abi.encodePacked(
-            account.ID,
+            account.pubkeyIndex,
             account.balance,
             account.nonce,
             account.tokenType
@@ -97,9 +97,9 @@ contract RollupUtils {
 
     function GetGenesisLeaves() public pure returns (bytes32[2] memory leaves) {
         Types.UserState memory account1;
-        account1.ID = 0;
+        account1.pubkeyIndex = 0;
         Types.UserState memory account2;
-        account2.ID = 1;
+        account2.pubkeyIndex = 1;
         leaves[0] = HashFromAccount(account1);
         leaves[1] = HashFromAccount(account2);
     }

--- a/contracts/libs/RollupUtils.sol
+++ b/contracts/libs/RollupUtils.sol
@@ -21,6 +21,7 @@ contract RollupUtils {
     {
         return Types.toHash(commitment);
     }
+
     function StateFromBytes(bytes memory stateBytes)
         public
         pure

--- a/contracts/libs/RollupUtils.sol
+++ b/contracts/libs/RollupUtils.sol
@@ -5,7 +5,7 @@ import { Tx } from "./Tx.sol";
 import { Types } from "./Types.sol";
 
 library RollupUtilsLib {
-    function BytesFromAccount(Types.UserAccount memory account)
+    function BytesFromAccount(Types.UserState memory account)
         internal
         pure
         returns (bytes memory)
@@ -20,7 +20,7 @@ library RollupUtilsLib {
         return data;
     }
 
-    function HashFromAccount(Types.UserAccount memory account)
+    function HashFromAccount(Types.UserState memory account)
         internal
         pure
         returns (bytes32)
@@ -62,7 +62,7 @@ contract RollupUtils {
         return abi.decode(accountBytes, (uint256, uint256, uint256, uint256));
     }
 
-    function BytesFromAccount(Types.UserAccount memory account)
+    function BytesFromAccount(Types.UserState memory account)
         public
         pure
         returns (bytes memory)
@@ -70,7 +70,7 @@ contract RollupUtils {
         return RollupUtilsLib.BytesFromAccount(account);
     }
 
-    function HashFromAccount(Types.UserAccount memory account)
+    function HashFromAccount(Types.UserState memory account)
         public
         pure
         returns (bytes32)
@@ -96,9 +96,9 @@ contract RollupUtils {
     }
 
     function GetGenesisLeaves() public pure returns (bytes32[2] memory leaves) {
-        Types.UserAccount memory account1;
+        Types.UserState memory account1;
         account1.ID = 0;
-        Types.UserAccount memory account2;
+        Types.UserState memory account2;
         account2.ID = 1;
         leaves[0] = HashFromAccount(account1);
         leaves[1] = HashFromAccount(account2);

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -167,7 +167,7 @@ library Types {
         uint256 nonce;
     }
 
-    struct AccountMerkleProof {
+    struct StateMerkleProof {
         UserState account;
         uint256 pathToAccount; // This field is kept for backward competibility, don't use it.
         bytes32[] siblings;

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -167,7 +167,11 @@ library Types {
         uint256 nonce;
     }
 
-    function encode(UserState memory state) internal pure returns (bytes memory) {
+    function encode(UserState memory state)
+        internal
+        pure
+        returns (bytes memory)
+    {
         return
             abi.encodePacked(
                 state.pubkeyIndex,

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.5.15;
  */
 library Types {
     struct SignatureProof {
-        Types.UserAccount[] stateAccounts;
+        Types.UserState[] stateAccounts;
         bytes32[][] stateWitnesses;
         uint256[4][] pubkeys;
         bytes32[][] pubkeyWitnesses;
@@ -157,8 +157,8 @@ library Types {
         uint256 fee;
     }
 
-    // UserAccount contains the actual data stored in the leaf of balance tree
-    struct UserAccount {
+    // UserState contains the actual data stored in the leaf of balance tree
+    struct UserState {
         // ID is the path to the pubkey in the PDA tree
         uint256 ID;
         uint256 tokenType;
@@ -167,7 +167,7 @@ library Types {
     }
 
     struct AccountMerkleProof {
-        UserAccount account;
+        UserState account;
         uint256 pathToAccount; // This field is kept for backward competibility, don't use it.
         bytes32[] siblings;
     }

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.5.15;
  */
 library Types {
     struct SignatureProof {
-        Types.UserState[] stateAccounts;
+        Types.UserState[] states;
         bytes32[][] stateWitnesses;
         uint256[4][] pubkeys;
         bytes32[][] pubkeyWitnesses;

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -167,6 +167,16 @@ library Types {
         uint256 nonce;
     }
 
+    function encode(UserState memory state) internal pure returns (bytes memory) {
+        return
+            abi.encodePacked(
+                state.pubkeyIndex,
+                state.tokenType,
+                state.balance,
+                state.nonce
+            );
+    }
+
     struct StateMerkleProof {
         UserState state;
         bytes32[] witness;

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -157,10 +157,11 @@ library Types {
         uint256 fee;
     }
 
-    // UserState contains the actual data stored in the leaf of balance tree
+    /**
+    @param pubkeyIndex path to the pubkey in the PDA tree
+     */
     struct UserState {
-        // ID is the path to the pubkey in the PDA tree
-        uint256 ID;
+        uint256 pubkeyIndex;
         uint256 tokenType;
         uint256 balance;
         uint256 nonce;

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -168,9 +168,14 @@ library Types {
     }
 
     struct StateMerkleProof {
-        UserState account;
-        uint256 pathToAccount; // This field is kept for backward competibility, don't use it.
-        bytes32[] siblings;
+        UserState state;
+        bytes32[] witness;
+    }
+
+    struct StateMerkleProofWithPath {
+        UserState state;
+        uint256 path;
+        bytes32[] witness;
     }
 
     struct TransactionMerkleProof {

--- a/contracts/test/TestTransfer.sol
+++ b/contracts/test/TestTransfer.sol
@@ -30,8 +30,8 @@ contract TestTransfer is Transfer {
         bytes32 _balanceRoot,
         Tx.Transfer memory _tx,
         uint256 tokenType,
-        Types.AccountMerkleProof memory fromAccountProof,
-        Types.AccountMerkleProof memory toAccountProof
+        Types.StateMerkleProof memory fromAccountProof,
+        Types.StateMerkleProof memory toAccountProof
     )
         public
         pure
@@ -56,7 +56,7 @@ contract TestTransfer is Transfer {
     function testProcessTransferCommit(
         bytes32 stateRoot,
         bytes memory txs,
-        Types.AccountMerkleProof[] memory accountProofs,
+        Types.StateMerkleProof[] memory accountProofs,
         uint256 tokenType,
         uint256 feeReceiver
     ) public returns (bytes32, uint256) {

--- a/contracts/test/TestTransfer.sol
+++ b/contracts/test/TestTransfer.sol
@@ -30,8 +30,8 @@ contract TestTransfer is Transfer {
         bytes32 _balanceRoot,
         Tx.Transfer memory _tx,
         uint256 tokenType,
-        Types.StateMerkleProof memory fromAccountProof,
-        Types.StateMerkleProof memory toAccountProof
+        Types.StateMerkleProof memory from,
+        Types.StateMerkleProof memory to
     )
         public
         pure
@@ -43,20 +43,13 @@ contract TestTransfer is Transfer {
             bool
         )
     {
-        return
-            processTx(
-                _balanceRoot,
-                _tx,
-                tokenType,
-                fromAccountProof,
-                toAccountProof
-            );
+        return processTx(_balanceRoot, _tx, tokenType, from, to);
     }
 
     function testProcessTransferCommit(
         bytes32 stateRoot,
         bytes memory txs,
-        Types.StateMerkleProof[] memory accountProofs,
+        Types.StateMerkleProof[] memory proofs,
         uint256 tokenType,
         uint256 feeReceiver
     ) public returns (bytes32, uint256) {
@@ -65,7 +58,7 @@ contract TestTransfer is Transfer {
         (newRoot, ) = processTransferCommit(
             stateRoot,
             txs,
-            accountProofs,
+            proofs,
             tokenType,
             feeReceiver
         );

--- a/test/MassMigration.test.ts
+++ b/test/MassMigration.test.ts
@@ -96,9 +96,8 @@ describe("Mass Migrations", async function() {
             commitment.toSolStruct().body,
             [
                 {
-                    pathToAccount: Alice.stateID,
-                    account: proof.state,
-                    siblings: proof.witness
+                    state: proof.state,
+                    witness: proof.witness
                 }
             ]
         );
@@ -129,9 +128,8 @@ describe("Mass Migrations", async function() {
 
         await rollup.disputeMMBatch(batchId, previousMP, commitmentMP, [
             {
-                pathToAccount: Alice.stateID,
-                account: proof.state,
-                siblings: proof.witness
+                state: proof.state,
+                witness: proof.witness
             }
         ]);
 

--- a/test/MassMigration.test.ts
+++ b/test/MassMigration.test.ts
@@ -44,8 +44,8 @@ describe("Mass Migrations", async function() {
         Bob.newKeyPair();
         Bob.pubkeyIndex = await registry.register(Bob.encodePubkey());
 
-        stateTree.createAccount(Alice);
-        stateTree.createAccount(Bob);
+        stateTree.createState(Alice);
+        stateTree.createState(Bob);
         const accountRoot = await registry.root();
         const initialCommitment = MassMigrationCommitment.new(
             stateTree.root,
@@ -97,7 +97,7 @@ describe("Mass Migrations", async function() {
             [
                 {
                     pathToAccount: Alice.stateID,
-                    account: proof.account,
+                    account: proof.state,
                     siblings: proof.witness
                 }
             ]
@@ -130,7 +130,7 @@ describe("Mass Migrations", async function() {
         await rollup.disputeMMBatch(batchId, previousMP, commitmentMP, [
             {
                 pathToAccount: Alice.stateID,
-                account: proof.account,
+                account: proof.state,
                 siblings: proof.witness
             }
         ]);

--- a/test/MassMigration.test.ts
+++ b/test/MassMigration.test.ts
@@ -3,7 +3,7 @@ import { TESTING_PARAMS } from "../ts/constants";
 import { ethers } from "@nomiclabs/buidler";
 import { StateTree } from "../ts/stateTree";
 import { AccountRegistry } from "../ts/accountTree";
-import { Account } from "../ts/stateAccount";
+import { State } from "../ts/state";
 import { TxMassMigration } from "../ts/tx";
 import * as mcl from "../ts/mcl";
 import { allContracts } from "../ts/allContractsInterfaces";
@@ -16,8 +16,8 @@ const DOMAIN =
 
 describe("Mass Migrations", async function() {
     const tokenID = 1;
-    let Alice: Account;
-    let Bob: Account;
+    let Alice: State;
+    let Bob: State;
     let contracts: allContracts;
     let stateTree: StateTree;
     let registry: AccountRegistry;
@@ -28,21 +28,21 @@ describe("Mass Migrations", async function() {
     });
 
     beforeEach(async function() {
-        const accounts = await ethers.getSigners();
-        contracts = await deployAll(accounts[0], TESTING_PARAMS);
+        const [signer, ...rest] = await ethers.getSigners();
+        contracts = await deployAll(signer, TESTING_PARAMS);
         stateTree = new StateTree(TESTING_PARAMS.MAX_DEPTH);
         const registryContract = contracts.blsAccountRegistry;
         registry = await AccountRegistry.new(registryContract);
         const initialBalance = USDT.castInt(1000.0);
-        Alice = Account.new(-1, tokenID, initialBalance, 0);
+        Alice = State.new(-1, tokenID, initialBalance, 0);
         Alice.setStateID(2);
         Alice.newKeyPair();
-        Alice.accountID = await registry.register(Alice.encodePubkey());
+        Alice.pubkeyIndex = await registry.register(Alice.encodePubkey());
 
-        Bob = Account.new(-1, tokenID, initialBalance, 0);
+        Bob = State.new(-1, tokenID, initialBalance, 0);
         Bob.setStateID(3);
         Bob.newKeyPair();
-        Bob.accountID = await registry.register(Bob.encodePubkey());
+        Bob.pubkeyIndex = await registry.register(Bob.encodePubkey());
 
         stateTree.createAccount(Alice);
         stateTree.createAccount(Bob);

--- a/test/rollup.test.ts
+++ b/test/rollup.test.ts
@@ -3,7 +3,7 @@ import { TESTING_PARAMS } from "../ts/constants";
 import { ethers } from "@nomiclabs/buidler";
 import { StateTree } from "../ts/stateTree";
 import { AccountRegistry } from "../ts/accountTree";
-import { Account } from "../ts/stateAccount";
+import { State } from "../ts/state";
 import { serialize, TxTransfer } from "../ts/tx";
 import * as mcl from "../ts/mcl";
 import { allContracts } from "../ts/allContractsInterfaces";
@@ -16,8 +16,8 @@ const DOMAIN =
 
 describe("Rollup", async function() {
     const tokenID = 1;
-    let Alice: Account;
-    let Bob: Account;
+    let Alice: State;
+    let Bob: State;
     let contracts: allContracts;
     let stateTree: StateTree;
     let registry: AccountRegistry;
@@ -35,15 +35,15 @@ describe("Rollup", async function() {
         registry = await AccountRegistry.new(registryContract);
         const initialBalance = USDT.castInt(55.6);
 
-        Alice = Account.new(-1, tokenID, initialBalance, 0);
+        Alice = State.new(-1, tokenID, initialBalance, 0);
         Alice.setStateID(0);
         Alice.newKeyPair();
-        Alice.accountID = await registry.register(Alice.encodePubkey());
+        Alice.pubkeyIndex = await registry.register(Alice.encodePubkey());
 
-        Bob = Account.new(-1, tokenID, initialBalance, 0);
+        Bob = State.new(-1, tokenID, initialBalance, 0);
         Bob.setStateID(1);
         Bob.newKeyPair();
-        Bob.accountID = await registry.register(Bob.encodePubkey());
+        Bob.pubkeyIndex = await registry.register(Bob.encodePubkey());
 
         stateTree.createAccount(Alice);
         stateTree.createAccount(Bob);

--- a/test/rollup.test.ts
+++ b/test/rollup.test.ts
@@ -45,8 +45,8 @@ describe("Rollup", async function() {
         Bob.newKeyPair();
         Bob.pubkeyIndex = await registry.register(Bob.encodePubkey());
 
-        stateTree.createAccount(Alice);
-        stateTree.createAccount(Bob);
+        stateTree.createState(Alice);
+        stateTree.createState(Bob);
 
         const accountRoot = await registry.root();
 
@@ -127,17 +127,17 @@ describe("Rollup", async function() {
             [
                 {
                     pathToAccount,
-                    account: proof[0].senderAccount,
+                    account: proof[0].sender,
                     siblings: proof[0].senderWitness
                 },
                 {
                     pathToAccount,
-                    account: proof[0].receiverAccount,
+                    account: proof[0].receiver,
                     siblings: proof[0].receiverWitness
                 },
                 {
                     pathToAccount,
-                    account: feeProof.feeReceiverAccount,
+                    account: feeProof.feeReceiver,
                     siblings: feeProof.feeReceiverWitness
                 }
             ]

--- a/test/rollup.test.ts
+++ b/test/rollup.test.ts
@@ -118,27 +118,22 @@ describe("Rollup", async function() {
         const previousMP = initialBatch.proofCompressed(0);
         const commitmentMP = targetBatch.proof(0);
 
-        const pathToAccount = 0; // Dummy value
-
         const _tx = await rollup.disputeBatch(
             batchId,
             previousMP,
             commitmentMP,
             [
                 {
-                    pathToAccount,
-                    account: proof[0].sender,
-                    siblings: proof[0].senderWitness
+                    state: proof[0].sender,
+                    witness: proof[0].senderWitness
                 },
                 {
-                    pathToAccount,
-                    account: proof[0].receiver,
-                    siblings: proof[0].receiverWitness
+                    state: proof[0].receiver,
+                    witness: proof[0].receiverWitness
                 },
                 {
-                    pathToAccount,
-                    account: feeProof.feeReceiver,
-                    siblings: feeProof.feeReceiverWitness
+                    state: feeProof.feeReceiver,
+                    witness: feeProof.feeReceiverWitness
                 }
             ]
         );

--- a/test/rollupTransfer.test.ts
+++ b/test/rollupTransfer.test.ts
@@ -99,17 +99,15 @@ describe("Rollup Transfer Commitment", () => {
         assert.isTrue(stateTransitionProof.safe);
         const { serialized, commit } = serialize(txs);
         const stateWitnesses = [];
-        const states = [];
+        const statesReordered = [];
         for (let i = 0; i < COMMIT_SIZE; i++) {
-            stateWitnesses.push(
-                stateTree.getStateWitness(signers[i].stateID)
-            );
-            states.push(signers[i].toSolStruct());
+            stateWitnesses.push(stateTree.getStateWitness(signers[i].stateID));
+            statesReordered.push(signers[i].toSolStruct());
         }
         const postStateRoot = stateTree.root;
         const accountRoot = registry.root();
         const proof = {
-            states,
+            states: statesReordered,
             stateWitnesses,
             pubkeys,
             pubkeyWitnesses
@@ -173,14 +171,12 @@ describe("Rollup Transfer Commitment", () => {
                 tx.extended(tokenID),
                 tokenID,
                 {
-                    pathToAccount: sender.stateID,
-                    account: proof.sender,
-                    siblings: proof.senderWitness
+                    state: proof.sender,
+                    witness: proof.senderWitness
                 },
                 {
-                    pathToAccount: receiver.stateID,
-                    account: proof.receiver,
-                    siblings: proof.receiverWitness
+                    state: proof.receiver,
+                    witness: proof.receiverWitness
                 }
             );
             assert.equal(error, ErrorCode.NoError, `Got ${ErrorCode[error]}`);
@@ -225,24 +221,19 @@ describe("Rollup Transfer Commitment", () => {
         assert.isTrue(safe, "Should be a valid applyTransferBatch");
         const { serialized } = serialize(txs);
         const stateMerkleProof = [];
-        // pathToAccount is just a placeholder, no effect
-        const pathToAccount = 0;
         for (let i = 0; i < COMMIT_SIZE; i++) {
             stateMerkleProof.push({
-                account: proof[i].sender,
-                pathToAccount,
-                siblings: proof[i].senderWitness
+                state: proof[i].sender,
+                witness: proof[i].senderWitness
             });
             stateMerkleProof.push({
-                account: proof[i].receiver,
-                pathToAccount,
-                siblings: proof[i].receiverWitness
+                state: proof[i].receiver,
+                witness: proof[i].receiverWitness
             });
         }
         stateMerkleProof.push({
             state: feeProof.feeReceiver,
-            pathToAccount,
-            siblings: feeProof.feeReceiverWitness
+            witness: feeProof.feeReceiverWitness
         });
         const postStateRoot = stateTree.root;
 

--- a/test/rollupTransfer.test.ts
+++ b/test/rollupTransfer.test.ts
@@ -61,7 +61,7 @@ describe("Rollup Transfer Commitment", () => {
         rollup = await new TestTransferFactory(signer).deploy();
         stateTree = StateTree.new(STATE_TREE_DEPTH);
         for (let i = 0; i < ACCOUNT_SIZE; i++) {
-            stateTree.createAccount(accounts[i]);
+            stateTree.createState(accounts[i]);
         }
     });
 
@@ -90,7 +90,7 @@ describe("Rollup Transfer Commitment", () => {
             txs.push(tx);
             signers.push(sender);
             pubkeys.push(sender.encodePubkey());
-            pubkeyWitnesses.push(registry.witness(sender.accountID));
+            pubkeyWitnesses.push(registry.witness(sender.pubkeyIndex));
             const signature = sender.sign(tx);
             aggSignature = mcl.aggreagate(aggSignature, signature);
         }
@@ -102,7 +102,7 @@ describe("Rollup Transfer Commitment", () => {
         const stateAccounts = [];
         for (let i = 0; i < COMMIT_SIZE; i++) {
             stateWitnesses.push(
-                stateTree.getAccountWitness(signers[i].stateID)
+                stateTree.getStateWitness(signers[i].stateID)
             );
             stateAccounts.push(signers[i].toSolStruct());
         }
@@ -174,12 +174,12 @@ describe("Rollup Transfer Commitment", () => {
                 tokenID,
                 {
                     pathToAccount: sender.stateID,
-                    account: proof.senderAccount,
+                    account: proof.sender,
                     siblings: proof.senderWitness
                 },
                 {
                     pathToAccount: receiver.stateID,
-                    account: proof.receiverAccount,
+                    account: proof.receiver,
                     siblings: proof.receiverWitness
                 }
             );
@@ -229,18 +229,18 @@ describe("Rollup Transfer Commitment", () => {
         const pathToAccount = 0;
         for (let i = 0; i < COMMIT_SIZE; i++) {
             stateMerkleProof.push({
-                account: proof[i].senderAccount,
+                account: proof[i].sender,
                 pathToAccount,
                 siblings: proof[i].senderWitness
             });
             stateMerkleProof.push({
-                account: proof[i].receiverAccount,
+                account: proof[i].receiver,
                 pathToAccount,
                 siblings: proof[i].receiverWitness
             });
         }
         stateMerkleProof.push({
-            account: feeProof.feeReceiverAccount,
+            account: feeProof.feeReceiver,
             pathToAccount,
             siblings: feeProof.feeReceiverWitness
         });

--- a/test/rollupTransfer.test.ts
+++ b/test/rollupTransfer.test.ts
@@ -7,7 +7,7 @@ import { TxTransfer, serialize } from "../ts/tx";
 import * as mcl from "../ts/mcl";
 import { StateTree } from "../ts/stateTree";
 import { AccountRegistry } from "../ts/accountTree";
-import { Account } from "../ts/stateAccount";
+import { State } from "../ts/state";
 import { assert } from "chai";
 import { ethers } from "@nomiclabs/buidler";
 import { randHex } from "../ts/utils";
@@ -25,7 +25,7 @@ describe("Rollup Transfer Commitment", () => {
     let rollup: TestTransfer;
     let registry: AccountRegistry;
     let stateTree: StateTree;
-    const accounts: Account[] = [];
+    const accounts: State[] = [];
     const tokenID = 1;
     const initialBalance = USDT.castInt(1000.0);
     const initialNonce = 9;
@@ -43,7 +43,7 @@ describe("Rollup Transfer Commitment", () => {
         for (let i = 0; i < ACCOUNT_SIZE; i++) {
             const accountID = i;
             const stateID = i;
-            const account = Account.new(
+            const account = State.new(
                 accountID,
                 tokenID,
                 initialBalance,

--- a/test/rollupUtils.test.ts
+++ b/test/rollupUtils.test.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 import { TxTransfer } from "../ts/tx";
-import { EMPTY_ACCOUNT } from "../ts/stateAccount";
+import { EMPTY_STATE } from "../ts/state";
 import { RollupUtilsFactory } from "../types/ethers-contracts/RollupUtilsFactory";
 import { RollupUtils } from "../types/ethers-contracts/RollupUtils";
 import { ethers } from "@nomiclabs/buidler";
@@ -14,7 +14,7 @@ describe("RollupUtils", async function() {
     });
 
     it("test account encoding and decoding", async function() {
-        const account = EMPTY_ACCOUNT;
+        const account = EMPTY_STATE;
 
         const accountBytes = await RollupUtilsInstance.BytesFromAccount(
             account

--- a/test/rollupUtils.test.ts
+++ b/test/rollupUtils.test.ts
@@ -13,19 +13,19 @@ describe("RollupUtils", async function() {
         RollupUtilsInstance = await new RollupUtilsFactory(signer).deploy();
     });
 
-    it("test account encoding and decoding", async function() {
-        const account = EMPTY_STATE;
+    it("test state encoding and decoding", async function() {
+        const state = EMPTY_STATE;
 
-        const accountBytes = await RollupUtilsInstance.BytesFromAccount(
-            account
+        const encodedState = await RollupUtilsInstance.BytesFromState(
+            state
         );
-        const decoded = await RollupUtilsInstance.AccountFromBytes(
-            accountBytes
+        const decoded = await RollupUtilsInstance.StateFromBytes(
+            encodedState
         );
-        assert.equal(decoded.ID.toNumber(), account.ID);
-        assert.equal(decoded.balance.toNumber(), account.balance);
-        assert.equal(decoded.nonce.toNumber(), account.nonce);
-        assert.equal(decoded.tokenType.toNumber(), account.tokenType);
+        assert.equal(decoded.pubkeyIndex.toNumber(), state.pubkeyIndex);
+        assert.equal(decoded.balance.toNumber(), state.balance);
+        assert.equal(decoded.nonce.toNumber(), state.nonce);
+        assert.equal(decoded.tokenType.toNumber(), state.tokenType);
     });
     it("test transfer utils", async function() {
         const txRaw = TxTransfer.rand();

--- a/test/rollupUtils.test.ts
+++ b/test/rollupUtils.test.ts
@@ -16,12 +16,8 @@ describe("RollupUtils", async function() {
     it("test state encoding and decoding", async function() {
         const state = EMPTY_STATE;
 
-        const encodedState = await RollupUtilsInstance.BytesFromState(
-            state
-        );
-        const decoded = await RollupUtilsInstance.StateFromBytes(
-            encodedState
-        );
+        const encodedState = await RollupUtilsInstance.BytesFromState(state);
+        const decoded = await RollupUtilsInstance.StateFromBytes(encodedState);
         assert.equal(decoded.pubkeyIndex.toNumber(), state.pubkeyIndex);
         assert.equal(decoded.balance.toNumber(), state.balance);
         assert.equal(decoded.nonce.toNumber(), state.nonce);

--- a/ts/state.ts
+++ b/ts/state.ts
@@ -3,7 +3,7 @@ import { Tx, SignableTx } from "./tx";
 import { BigNumber, BigNumberish, ethers } from "ethers";
 
 export interface StateSolStruct {
-    ID: number;
+    pubkeyIndex: number;
     tokenType: number;
     balance: number;
     nonce: number;
@@ -13,7 +13,7 @@ export interface StateSolStruct {
  * @dev this is not an zero state leaf contrarily this is a legit state!
 */
 export const EMPTY_STATE: StateSolStruct = {
-    ID: 0,
+    pubkeyIndex: 0,
     tokenType: 0,
     balance: 0,
     nonce: 0
@@ -23,13 +23,13 @@ export class State {
     publicKey: mcl.PublicKey;
     secretKey: mcl.SecretKey;
     public static new(
-        accountID: number,
+        pubkeyIndex: number,
         tokenType: number,
         balance: BigNumberish,
         nonce: number
     ): State {
         return new State(
-            accountID,
+            pubkeyIndex,
             tokenType,
             BigNumber.from(balance),
             nonce
@@ -75,7 +75,7 @@ export class State {
 
     public toSolStruct(): StateSolStruct {
         return {
-            ID: this.pubkeyIndex,
+            pubkeyIndex: this.pubkeyIndex,
             tokenType: this.tokenType,
             balance: this.balance.toNumber(),
             nonce: this.nonce

--- a/ts/state.ts
+++ b/ts/state.ts
@@ -11,7 +11,7 @@ export interface StateSolStruct {
 
 /**
  * @dev this is not an zero state leaf contrarily this is a legit state!
-*/
+ */
 export const EMPTY_STATE: StateSolStruct = {
     pubkeyIndex: 0,
     tokenType: 0,

--- a/ts/state.ts
+++ b/ts/state.ts
@@ -2,22 +2,24 @@ import * as mcl from "./mcl";
 import { Tx, SignableTx } from "./tx";
 import { BigNumber, BigNumberish, ethers } from "ethers";
 
-export interface StateAccountSolStruct {
+export interface StateSolStruct {
     ID: number;
     tokenType: number;
     balance: number;
     nonce: number;
 }
 
-// TODO: this is not an empty accoutn contrarily this is a legit account!
-export const EMPTY_ACCOUNT: StateAccountSolStruct = {
+/**
+ * @dev this is not an zero state leaf contrarily this is a legit state!
+*/
+export const EMPTY_STATE: StateSolStruct = {
     ID: 0,
     tokenType: 0,
     balance: 0,
     nonce: 0
 };
 
-export class Account {
+export class State {
     publicKey: mcl.PublicKey;
     secretKey: mcl.SecretKey;
     public static new(
@@ -25,8 +27,8 @@ export class Account {
         tokenType: number,
         balance: BigNumberish,
         nonce: number
-    ): Account {
-        return new Account(
+    ): State {
+        return new State(
             accountID,
             tokenType,
             BigNumber.from(balance),
@@ -36,13 +38,13 @@ export class Account {
 
     public stateID = -1;
     constructor(
-        public accountID: number,
+        public pubkeyIndex: number,
         public tokenType: number,
         public balance: BigNumber,
         public nonce: number
     ) {}
 
-    public newKeyPair(): Account {
+    public newKeyPair(): State {
         const keyPair = mcl.newKeyPair();
         this.publicKey = keyPair.pubkey;
         this.secretKey = keyPair.secret;
@@ -55,7 +57,7 @@ export class Account {
         return signature;
     }
 
-    public setStateID(stateID: number): Account {
+    public setStateID(stateID: number): State {
         this.stateID = stateID;
         return this;
     }
@@ -67,13 +69,13 @@ export class Account {
     public toStateLeaf(): string {
         return ethers.utils.solidityKeccak256(
             ["uint256", "uint256", "uint256", "uint256"],
-            [this.accountID, this.balance, this.nonce, this.tokenType]
+            [this.pubkeyIndex, this.balance, this.nonce, this.tokenType]
         );
     }
 
-    public toSolStruct(): StateAccountSolStruct {
+    public toSolStruct(): StateSolStruct {
         return {
-            ID: this.accountID,
+            ID: this.pubkeyIndex,
             tokenType: this.tokenType,
             balance: this.balance.toNumber(),
             nonce: this.nonce

--- a/ts/state.ts
+++ b/ts/state.ts
@@ -69,7 +69,7 @@ export class State {
     public toStateLeaf(): string {
         return ethers.utils.solidityKeccak256(
             ["uint256", "uint256", "uint256", "uint256"],
-            [this.pubkeyIndex, this.balance, this.nonce, this.tokenType]
+            [this.pubkeyIndex, this.tokenType, this.balance, this.nonce]
         );
     }
 

--- a/ts/stateTree.ts
+++ b/ts/stateTree.ts
@@ -1,17 +1,17 @@
 import { Tree } from "./tree";
-import { Account, EMPTY_ACCOUNT, StateAccountSolStruct } from "./stateAccount";
+import { State, EMPTY_STATE, StateSolStruct } from "./state";
 import { TxTransfer, TxMassMigration } from "./tx";
 import { BigNumber } from "ethers";
 
 interface ProofTransferTx {
-    senderAccount: StateAccountSolStruct;
-    receiverAccount: StateAccountSolStruct;
+    senderAccount: StateSolStruct
+    receiverAccount: StateSolStruct;
     senderWitness: string[];
     receiverWitness: string[];
     safe: boolean;
 }
 interface ProofTransferFee {
-    feeReceiverAccount: StateAccountSolStruct;
+    feeReceiverAccount: StateSolStruct;
     feeReceiverWitness: string[];
     safe: boolean;
 }
@@ -19,7 +19,7 @@ interface ProofTransferFee {
 type ProofTransferBatch = ProofTransferTx[];
 
 interface ProofOfMassMigrationTx {
-    account: StateAccountSolStruct;
+    account: StateSolStruct;
     witness: string[];
     safe: boolean;
 }
@@ -47,7 +47,7 @@ export class StateTree {
         return new StateTree(stateDepth);
     }
     private stateTree: Tree;
-    private accounts: { [key: number]: Account } = {};
+    private accounts: { [key: number]: State } = {};
     constructor(stateDepth: number) {
         this.stateTree = Tree.new(stateDepth);
     }
@@ -56,7 +56,7 @@ export class StateTree {
         return this.stateTree.witness(stateID).nodes;
     }
 
-    public createAccount(account: Account) {
+    public createAccount(account: State) {
         const stateID = account.stateID;
         if (this.accounts[stateID]) {
             throw new Error("state id is in use");
@@ -170,7 +170,7 @@ export class StateTree {
         } else {
             if (!senderAccount) {
                 return {
-                    senderAccount: EMPTY_ACCOUNT,
+                    senderAccount: EMPTY_STATE,
                     receiverAccount: PLACEHOLDER_PROOF_ACC,
                     senderWitness,
                     receiverWitness: PLACEHOLDER_PROOF_WITNESS,
@@ -182,7 +182,7 @@ export class StateTree {
             return {
                 senderAccount: senderAccStruct,
                 senderWitness,
-                receiverAccount: EMPTY_ACCOUNT,
+                receiverAccount: EMPTY_STATE,
                 receiverWitness: receiverWitness,
                 safe: false
             };

--- a/ts/stateTree.ts
+++ b/ts/stateTree.ts
@@ -4,7 +4,7 @@ import { TxTransfer, TxMassMigration } from "./tx";
 import { BigNumber } from "ethers";
 
 interface ProofTransferTx {
-    sender: StateSolStruct
+    sender: StateSolStruct;
     receiver: StateSolStruct;
     senderWitness: string[];
     receiverWitness: string[];
@@ -97,12 +97,13 @@ export class StateTree {
         const state = this.states[feeReceiverID];
 
         if (state) {
+            const stateStruct = state.toSolStruct();
             const witness = this.stateTree.witness(feeReceiverID).nodes;
             state.balance = state.balance.add(sumOfFee);
             this.states[feeReceiverID] = state;
             this.stateTree.updateSingle(feeReceiverID, state.toStateLeaf());
             return {
-                feeReceiver: state.toSolStruct(),
+                feeReceiver: stateStruct,
                 feeReceiverWitness: witness,
                 safe: true
             };
@@ -146,6 +147,7 @@ export class StateTree {
             this.stateTree.updateSingle(senderID, senderState.toStateLeaf());
 
             const receiverWitness = this.stateTree.witness(receiverID).nodes;
+            const receiverStateStruct = receiverState.toSolStruct();
             receiverState.balance = receiverState.balance.add(tx.amount);
             this.states[receiverID] = receiverState;
             this.stateTree.updateSingle(
@@ -156,7 +158,7 @@ export class StateTree {
             return {
                 sender: senderStateStruct,
                 senderWitness,
-                receiver: receiverState.toSolStruct(),
+                receiver: receiverStateStruct,
                 receiverWitness,
                 safe: true
             };
@@ -170,9 +172,10 @@ export class StateTree {
                     safe: false
                 };
             }
+            const senderStateStruct = senderState.toSolStruct();
             const receiverWitness = this.stateTree.witness(receiverID).nodes;
             return {
-                sender: senderState.toSolStruct(),
+                sender: senderStateStruct,
                 senderWitness,
                 receiver: EMPTY_STATE,
                 receiverWitness: receiverWitness,
@@ -192,6 +195,7 @@ export class StateTree {
         }
         const senderState = this.states[senderID];
         const senderWitness = this.stateTree.witness(senderID).nodes;
+        const senderStateStruct = senderState.toSolStruct();
         if (senderState.balance.lt(tx.amount)) {
             return {
                 state: EMPTY_STATE,
@@ -204,7 +208,7 @@ export class StateTree {
         this.states[senderID] = senderState;
         this.stateTree.updateSingle(senderID, senderState.toStateLeaf());
         return {
-            state: senderState.toSolStruct(),
+            state: senderStateStruct,
             witness: senderWitness,
             safe: true
         };


### PR DESCRIPTION
After this PR, the term "account" means either a public tree leaf or an Ethereum account in our codebase. No more confusion with the term "state"