### PR TITLE
Build test factories

### DIFF
--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -21,8 +21,7 @@ async function main() {
         for (let j = 0; j < txPerCommitment; j++) {
             transactions.push(TxTransfer.rand());
         }
-        const { serialized } = serialize(transactions);
-        commitment.txs = serialized;
+        commitment.txs = serialize(transactions);
         commitments.push(commitment);
     }
     const batch = new TransferBatch(commitments);

--- a/test/rollup.test.ts
+++ b/test/rollup.test.ts
@@ -81,7 +81,7 @@ describe("Rollup", async function() {
         );
         assert.isTrue(safe);
         const postStateRoot = stateTree.root;
-        const { serialized } = serialize([tx]);
+        const serialized = serialize([tx]);
         const aggregatedSignature0 = mcl.g1ToHex(signature);
 
         const root = await registry.root();

--- a/test/rollupTransfer.test.ts
+++ b/test/rollupTransfer.test.ts
@@ -68,7 +68,7 @@ describe("Rollup Transfer Commitment", () => {
         const signature = mcl.g1ToHex(aggSignature);
         const stateTransitionProof = stateTree.applyTransferBatch(txs, 0);
         assert.isTrue(stateTransitionProof.safe);
-        const { serialized, commit } = serialize(txs);
+        const serialized = serialize(txs);
 
         // Need post stateWitnesses
         const postStates = txs.map(tx => stateTree.getState(tx.fromIndex));
@@ -192,7 +192,7 @@ describe("Rollup Transfer Commitment", () => {
             feeReceiver
         );
         assert.isTrue(safe, "Should be a valid applyTransferBatch");
-        const { serialized } = serialize(txs);
+        const serialized = serialize(txs);
         const stateMerkleProof = [];
         for (let i = 0; i < COMMIT_SIZE; i++) {
             stateMerkleProof.push({

--- a/test/rollupTransfer.test.ts
+++ b/test/rollupTransfer.test.ts
@@ -13,6 +13,7 @@ import { ethers } from "@nomiclabs/buidler";
 import { randHex } from "../ts/utils";
 import { ErrorCode } from "../ts/interfaces";
 import { USDT } from "../ts/decimal";
+import { txTransferFactory, UserStateFactory } from "../ts/factory";
 
 const DOMAIN_HEX = randHex(32);
 const DOMAIN = Uint8Array.from(Buffer.from(DOMAIN_HEX.slice(2), "hex"));
@@ -25,10 +26,8 @@ describe("Rollup Transfer Commitment", () => {
     let rollup: TestTransfer;
     let registry: AccountRegistry;
     let stateTree: StateTree;
-    const states: State[] = [];
+    let states: State[] = [];
     const tokenID = 1;
-    const initialBalance = USDT.castInt(1000.0);
-    const initialNonce = 9;
 
     before(async function() {
         await mcl.init();
@@ -40,18 +39,8 @@ describe("Rollup Transfer Commitment", () => {
         ).deploy(logger.address);
 
         registry = await AccountRegistry.new(registryContract);
-        for (let i = 0; i < STATE_SIZE; i++) {
-            const accountID = i;
-            const stateID = i;
-            const state = State.new(
-                accountID,
-                tokenID,
-                initialBalance,
-                initialNonce + i
-            );
-            state.setStateID(stateID);
-            state.newKeyPair();
-            states.push(state);
+        states = UserStateFactory.buildList(STATE_SIZE);
+        for (const state of states) {
             await registry.register(state.encodePubkey());
         }
     });
@@ -60,54 +49,38 @@ describe("Rollup Transfer Commitment", () => {
         const [signer, ...rest] = await ethers.getSigners();
         rollup = await new TestTransferFactory(signer).deploy();
         stateTree = StateTree.new(STATE_TREE_DEPTH);
-        for (let i = 0; i < STATE_SIZE; i++) {
-            stateTree.createState(states[i]);
-        }
+        stateTree.createStateBulk(states);
     });
 
     it("transfer commitment: signature check", async function() {
-        const txs: TxTransfer[] = [];
-        const amount = USDT.castInt(20.01);
-        const fee = USDT.castInt(1.001);
+        const txs = txTransferFactory(states, COMMIT_SIZE);
         let aggSignature = mcl.newG1();
-        let s0 = stateTree.root;
-        let signers = [];
         const pubkeys = [];
         const pubkeyWitnesses = [];
-        for (let i = 0; i < COMMIT_SIZE; i++) {
-            const senderIndex = i;
-            const reciverIndex = (i + 5) % STATE_SIZE;
-            const sender = states[senderIndex];
-            const receiver = states[reciverIndex];
-            const tx = new TxTransfer(
-                sender.stateID,
-                receiver.stateID,
-                amount,
-                fee,
-                sender.nonce,
-                USDT
-            );
-            txs.push(tx);
-            signers.push(sender);
+
+        for (const tx of txs) {
+            const sender = states[tx.fromIndex];
             pubkeys.push(sender.encodePubkey());
             pubkeyWitnesses.push(registry.witness(sender.pubkeyIndex));
             const signature = sender.sign(tx);
             aggSignature = mcl.aggreagate(aggSignature, signature);
         }
-        let signature = mcl.g1ToHex(aggSignature);
-        let stateTransitionProof = stateTree.applyTransferBatch(txs, 0);
+        const signature = mcl.g1ToHex(aggSignature);
+        const stateTransitionProof = stateTree.applyTransferBatch(txs, 0);
         assert.isTrue(stateTransitionProof.safe);
         const { serialized, commit } = serialize(txs);
-        const stateWitnesses = [];
-        const statesReordered = [];
-        for (let i = 0; i < COMMIT_SIZE; i++) {
-            stateWitnesses.push(stateTree.getStateWitness(signers[i].stateID));
-            statesReordered.push(signers[i].toSolStruct());
-        }
+
+        // Need post stateWitnesses
+        const postStates = txs.map(tx => stateTree.getState(tx.fromIndex));
+        const stateWitnesses = txs.map(tx =>
+            stateTree.getStateWitness(tx.fromIndex)
+        );
+
         const postStateRoot = stateTree.root;
         const accountRoot = registry.root();
+
         const proof = {
-            states: statesReordered,
+            states: postStates,
             stateWitnesses,
             pubkeys,
             pubkeyWitnesses

--- a/test/rollupTransfer.test.ts
+++ b/test/rollupTransfer.test.ts
@@ -119,7 +119,6 @@ describe("Rollup Transfer Commitment", () => {
 
     it("transfer commitment: processTx", async function() {
         const txs = txTransferFactory(states, COMMIT_SIZE);
-        const tokenID = states[0].tokenType;
         for (const tx of txs) {
             const preRoot = stateTree.root;
             const proof = stateTree.applyTxTransfer(tx);
@@ -127,8 +126,8 @@ describe("Rollup Transfer Commitment", () => {
             const postRoot = stateTree.root;
             const { 0: processedRoot, 3: error } = await rollup.testProcessTx(
                 preRoot,
-                tx.extended(tokenID),
-                tokenID,
+                tx,
+                states[0].tokenType,
                 {
                     state: proof.sender,
                     witness: proof.senderWitness

--- a/test/txSerialization.test.ts
+++ b/test/txSerialization.test.ts
@@ -14,7 +14,7 @@ describe("Tx Serialization", async () => {
 
     it("parse transfer transaction", async function() {
         const txs = TxTransfer.buildList(COMMIT_SIZE);
-        const { serialized } = serialize(txs);
+        const serialized = serialize(txs);
         assert.equal(
             (await c.transfer_size(serialized)).toNumber(),
             txs.length
@@ -39,9 +39,7 @@ describe("Tx Serialization", async () => {
     });
     it("serialize transfer transaction", async function() {
         const txs = TxTransfer.buildList(COMMIT_SIZE);
-        const { serialized } = serialize(txs);
-        const _serialized = await c.transfer_serialize(txs);
-        assert.equal(serialized, _serialized);
+        assert.equal(await c.transfer_serialize(txs), serialize(txs));
     });
     it("transfer trasaction casting", async function() {
         const txs = TxTransfer.buildList(COMMIT_SIZE);
@@ -51,14 +49,13 @@ describe("Tx Serialization", async () => {
             const bytes = await c.transfer_bytesFromEncoded(extended);
             txsInBytes.push(bytes);
         }
-        const { serialized } = serialize(txs);
-        const _serialized = await c.transfer_serializeFromEncoded(txsInBytes);
-        assert.equal(serialized, _serialized);
+        const serialized = await c.transfer_serializeFromEncoded(txsInBytes);
+        assert.equal(serialized, serialize(txs));
     });
 
     it("massMigration", async function() {
         const txs = TxMassMigration.buildList(COMMIT_SIZE);
-        const { serialized } = serialize(txs);
+        const serialized = serialize(txs);
         const size = await c.massMigration_size(serialized);
         assert.equal(size.toNumber(), txs.length);
         for (let i in txs) {

--- a/test/txSerialization.test.ts
+++ b/test/txSerialization.test.ts
@@ -3,6 +3,7 @@ import { TestTx } from "../types/ethers-contracts/TestTx";
 import { TxTransfer, serialize, TxMassMigration } from "../ts/tx";
 import { assert } from "chai";
 import { ethers } from "@nomiclabs/buidler";
+import { COMMIT_SIZE } from "../ts/constants";
 
 describe("Tx Serialization", async () => {
     let c: TestTx;
@@ -12,23 +13,22 @@ describe("Tx Serialization", async () => {
     });
 
     it("parse transfer transaction", async function() {
-        const txSize = 16;
-        const txs: TxTransfer[] = [];
-        for (let i = 0; i < txSize; i++) {
-            txs.push(TxTransfer.rand());
-        }
+        const txs = TxTransfer.buildList(COMMIT_SIZE);
         const { serialized } = serialize(txs);
-        assert.equal((await c.transfer_size(serialized)).toNumber(), txSize);
+        assert.equal(
+            (await c.transfer_size(serialized)).toNumber(),
+            txs.length
+        );
         assert.isFalse(await c.transfer_hasExcessData(serialized));
-        for (let i = 0; i < txSize; i++) {
-            const decoded = await c.transfer_decode(serialized, i);
-            assert.equal(
-                decoded.fromIndex.toString(),
-                txs[i].fromIndex.toString()
+        for (let i in txs) {
+            const { fromIndex, toIndex, amount, fee } = await c.transfer_decode(
+                serialized,
+                i
             );
-            assert.equal(decoded.toIndex.toString(), txs[i].toIndex.toString());
-            assert.equal(decoded.amount.toString(), txs[i].amount.toString());
-            assert.equal(decoded.fee.toString(), txs[i].fee.toString());
+            assert.equal(fromIndex.toString(), txs[i].fromIndex.toString());
+            assert.equal(toIndex.toString(), txs[i].toIndex.toString());
+            assert.equal(amount.toString(), txs[i].amount.toString());
+            assert.equal(fee.toString(), txs[i].fee.toString());
             const message = await c.transfer_messageOf(
                 serialized,
                 i,
@@ -38,25 +38,17 @@ describe("Tx Serialization", async () => {
         }
     });
     it("serialize transfer transaction", async function() {
-        const txSize = 16;
-        const txs: TxTransfer[] = [];
-        for (let i = 0; i < txSize; i++) {
-            const tx = TxTransfer.rand();
-            txs.push(tx);
-        }
+        const txs = TxTransfer.buildList(COMMIT_SIZE);
         const { serialized } = serialize(txs);
         const _serialized = await c.transfer_serialize(txs);
         assert.equal(serialized, _serialized);
     });
     it("transfer trasaction casting", async function() {
-        const txSize = 16;
-        const txs = [];
+        const txs = TxTransfer.buildList(COMMIT_SIZE);
         const txsInBytes = [];
-        for (let i = 0; i < txSize; i++) {
-            const tx = TxTransfer.rand();
+        for (const tx of txs) {
             const extended = tx.extended();
             const bytes = await c.transfer_bytesFromEncoded(extended);
-            txs.push(tx);
             txsInBytes.push(bytes);
         }
         const { serialized } = serialize(txs);
@@ -65,16 +57,11 @@ describe("Tx Serialization", async () => {
     });
 
     it("massMigration", async function() {
-        const txSize = 16;
-        const txs: TxMassMigration[] = [];
-        for (let i = 0; i < txSize; i++) {
-            const tx = TxMassMigration.rand();
-            txs.push(tx);
-        }
+        const txs = TxMassMigration.buildList(COMMIT_SIZE);
         const { serialized } = serialize(txs);
         const size = await c.massMigration_size(serialized);
-        assert.equal(size.toNumber(), txSize);
-        for (let i = 0; i < txSize; i++) {
+        assert.equal(size.toNumber(), txs.length);
+        for (let i in txs) {
             const {
                 fromIndex,
                 toIndex,

--- a/ts/constants.ts
+++ b/ts/constants.ts
@@ -6,6 +6,9 @@ export const TESTING_PARAMS: DeploymentParameters = {
     STAKE_AMOUNT: "0.1"
 };
 
+export const COMMIT_SIZE = 32;
+export const STATE_TREE_DEPTH = 32;
+
 // ethers.utils.keccak256(ethers.constants.HashZero)
 export const ZERO_BYTES32 =
     "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563";

--- a/ts/factory.ts
+++ b/ts/factory.ts
@@ -3,7 +3,6 @@ import { COMMIT_SIZE } from "./constants";
 import { USDT } from "./decimal";
 import { State } from "./state";
 import { TxTransfer } from "./tx";
-import { randomNum } from "./utils";
 
 export class UserStateFactory {
     public static buildList(
@@ -35,12 +34,12 @@ export function txTransferFactory(
     n: number = COMMIT_SIZE
 ): TxTransfer[] {
     const txs: TxTransfer[] = [];
-    const amount = states[0].balance.div(10);
-    const fee = amount.div(10);
     for (let i = 0; i < n; i++) {
         const senderIndex = i;
         const reciverIndex = (i + 5) % n;
         const sender = states[senderIndex];
+        const amount = sender.balance.div(10);
+        const fee = amount.div(10);
         const tx = new TxTransfer(
             senderIndex,
             reciverIndex,

--- a/ts/factory.ts
+++ b/ts/factory.ts
@@ -3,7 +3,6 @@ import { COMMIT_SIZE } from "./constants";
 import { USDT } from "./decimal";
 import { State } from "./state";
 import { TxTransfer } from "./tx";
-import * as Factory from "factory.ts";
 import { randomNum } from "./utils";
 
 export class UserStateFactory {

--- a/ts/factory.ts
+++ b/ts/factory.ts
@@ -1,0 +1,56 @@
+import { BigNumber } from "ethers";
+import { COMMIT_SIZE } from "./constants";
+import { USDT } from "./decimal";
+import { State } from "./state";
+import { TxTransfer } from "./tx";
+import * as Factory from "factory.ts";
+import { randomNum } from "./utils";
+
+export class UserStateFactory {
+    public static buildList(
+        numOfStates: number,
+        tokenID: number = 1,
+        initialBalance: BigNumber = USDT.castInt(1000.0),
+        initialNonce: number = 9
+    ) {
+        const states: State[] = [];
+        for (let i = 0; i < numOfStates; i++) {
+            const accountID = i;
+            const stateID = i;
+            const state = State.new(
+                accountID,
+                tokenID,
+                initialBalance,
+                initialNonce + i
+            );
+            state.setStateID(stateID);
+            state.newKeyPair();
+            states.push(state);
+        }
+        return states;
+    }
+}
+
+export function txTransferFactory(
+    states: State[],
+    n: number = COMMIT_SIZE
+): TxTransfer[] {
+    const txs: TxTransfer[] = [];
+    const amount = states[0].balance.div(10);
+    const fee = amount.div(10);
+    for (let i = 0; i < n; i++) {
+        const senderIndex = i;
+        const reciverIndex = (i + 5) % n;
+        const sender = states[senderIndex];
+        const tx = new TxTransfer(
+            senderIndex,
+            reciverIndex,
+            amount,
+            fee,
+            sender.nonce,
+            USDT
+        );
+        txs.push(tx);
+    }
+    return txs;
+}

--- a/ts/state.ts
+++ b/ts/state.ts
@@ -35,6 +35,14 @@ export class State {
             nonce
         );
     }
+    public clone() {
+        return new State(
+            this.pubkeyIndex,
+            this.tokenType,
+            this.balance,
+            this.nonce
+        );
+    }
 
     public stateID = -1;
     constructor(

--- a/ts/stateTree.ts
+++ b/ts/stateTree.ts
@@ -60,9 +60,17 @@ export class StateTree {
         this.stateTree.updateSingle(stateID, leaf);
         this.states[stateID] = state;
     }
+    public createStateBulk(states: State[]) {
+        for (const state of states) {
+            this.createState(state);
+        }
+    }
 
     public get root() {
         return this.stateTree.root;
+    }
+    public getState(stateID: number) {
+        return this.states[stateID];
     }
 
     public applyTransferBatch(

--- a/ts/stateTree.ts
+++ b/ts/stateTree.ts
@@ -58,7 +58,8 @@ export class StateTree {
         }
         const leaf = state.toStateLeaf();
         this.stateTree.updateSingle(stateID, leaf);
-        this.states[stateID] = state;
+        // Need to clone the object so that whatever we do on this.states later won't affect the input state.
+        this.states[stateID] = state.clone();
     }
     public createStateBulk(states: State[]) {
         for (const state of states) {

--- a/ts/tx.ts
+++ b/ts/tx.ts
@@ -9,6 +9,7 @@ import {
     hexlify,
     solidityKeccak256
 } from "ethers/lib/utils";
+import { COMMIT_SIZE } from "./constants";
 
 const amountLen = 2;
 const feeLen = 2;
@@ -67,6 +68,14 @@ export class TxTransfer implements SignableTx {
         const nonce = randomNum(nonceLen);
         return new TxTransfer(sender, receiver, amount, fee, nonce, USDT);
     }
+    public static buildList(n: number = COMMIT_SIZE): TxTransfer[] {
+        const txs = [];
+        for (let i = 0; i < n; i++) {
+            txs.push(TxTransfer.rand());
+        }
+        return txs;
+    }
+
     constructor(
         public readonly fromIndex: number,
         public readonly toIndex: number,
@@ -141,6 +150,13 @@ export class TxMassMigration implements SignableTx {
             nonce,
             USDT
         );
+    }
+    public static buildList(n: number = COMMIT_SIZE): TxMassMigration[] {
+        const txs = [];
+        for (let i = 0; i < n; i++) {
+            txs.push(TxMassMigration.rand());
+        }
+        return txs;
     }
     constructor(
         public readonly fromIndex: number,

--- a/ts/tx.ts
+++ b/ts/tx.ts
@@ -40,10 +40,8 @@ export function calculateRoot(txs: Tx[]) {
     return tree.root;
 }
 
-export function serialize(txs: Tx[]) {
-    const serialized = hexlify(concat(txs.map(tx => tx.encode())));
-    const commit = solidityKeccak256(["bytes"], [serialized]);
-    return { serialized, commit };
+export function serialize(txs: Tx[]): string {
+    return hexlify(concat(txs.map(tx => tx.encode())));
 }
 
 function checkByteLength(


### PR DESCRIPTION
So we can build desired states, txs, or commitments without code duplication and duplicated works.
This helps us writing more tests.