### PR TITLE
remove production contracts

### DIFF
--- a/contracts/prod/MassMigration.sol
+++ b/contracts/prod/MassMigration.sol
@@ -1,6 +1,0 @@
-pragma solidity ^0.5.15;
-pragma experimental ABIEncoderV2;
-
-import { MassMigration } from "../MassMigrations.sol";
-
-contract MassMigrationProduction is MassMigration {}

--- a/contracts/prod/Transfer.sol
+++ b/contracts/prod/Transfer.sol
@@ -1,6 +1,0 @@
-pragma solidity ^0.5.15;
-pragma experimental ABIEncoderV2;
-
-import { Transfer } from "../Transfer.sol";
-
-contract TransferProduction is Transfer {}

--- a/ts/allContractsInterfaces.ts
+++ b/ts/allContractsInterfaces.ts
@@ -6,7 +6,7 @@ import { MerkleTreeUtils } from "../types/ethers-contracts/MerkleTreeUtils";
 import { Logger } from "../types/ethers-contracts/Logger";
 import { TokenRegistry } from "../types/ethers-contracts/TokenRegistry";
 import { Pob } from "../types/ethers-contracts/Pob";
-import { TransferProduction } from "../types/ethers-contracts/TransferProduction";
+import { Transfer } from "../types/ethers-contracts/Transfer";
 import { TestToken } from "../types/ethers-contracts/TestToken";
 import { DepositManager } from "../types/ethers-contracts/DepositManager";
 import { Rollup } from "../types/ethers-contracts/Rollup";
@@ -22,7 +22,7 @@ export interface allContracts {
     merkleTreeUtils: MerkleTreeUtils;
     blsAccountRegistry: BlsAccountRegistry;
     tokenRegistry: TokenRegistry;
-    transfer: TransferProduction;
+    transfer: Transfer;
     massMigration: MassMigration;
     pob: Pob;
     testToken: TestToken;

--- a/ts/deploy.ts
+++ b/ts/deploy.ts
@@ -9,8 +9,8 @@ import { MerkleTreeUtils } from "../types/ethers-contracts/MerkleTreeUtils";
 import { LoggerFactory } from "../types/ethers-contracts/LoggerFactory";
 import { TokenRegistryFactory } from "../types/ethers-contracts/TokenRegistryFactory";
 import { PobFactory } from "../types/ethers-contracts/PobFactory";
-import { TransferProductionFactory } from "../types/ethers-contracts/TransferProductionFactory";
-import { MassMigrationProductionFactory } from "../types/ethers-contracts/MassMigrationProductionFactory";
+import { TransferFactory } from "../types/ethers-contracts/TransferFactory";
+import { MassMigrationFactory } from "../types/ethers-contracts/MassMigrationFactory";
 import { TestTokenFactory } from "../types/ethers-contracts/TestTokenFactory";
 import { DepositManagerFactory } from "../types/ethers-contracts/DepositManagerFactory";
 import { RollupFactory } from "../types/ethers-contracts/RollupFactory";
@@ -119,9 +119,7 @@ export async function deployAll(
         await paramManager.TOKEN_REGISTRY()
     );
 
-    const massMigration = await new MassMigrationProductionFactory(
-        signer
-    ).deploy();
+    const massMigration = await new MassMigrationFactory(signer).deploy();
     await waitAndRegister(
         massMigration,
         "mass_migs",
@@ -130,7 +128,7 @@ export async function deployAll(
         await paramManager.MASS_MIGS()
     );
 
-    const transfer = await new TransferProductionFactory(signer).deploy();
+    const transfer = await new TransferFactory(signer).deploy();
     await waitAndRegister(
         transfer,
         "transfer",


### PR DESCRIPTION
We created XProduction contracts because the fraud proof contracts depend on too many external contracts and their constructors were complicated. It was difficult to do unit tests for the fraud proof contracts. So we moved the constructor to an inherited contract named Xproduction.

But now our fraudproof contracts no longer depend on many other contracts. No complexity in unit tests. The Xproduction contracts can go.

