### PR TITLE
Rework deposit

### DIFF
--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -39,10 +39,6 @@ contract DepositCore is SubtreeQueue {
 
     uint256 public MAX_SUBTREE_SIZE;
 
-    constructor(uint256 maxSubtreeDepth) public {
-        MAX_SUBTREE_SIZE = 1 << maxSubtreeDepth;
-    }
-
     function insertAndMerge(bytes32 depositLeaf)
         internal
         returns (bytes32 readySubtree)
@@ -130,7 +126,7 @@ contract DepositManager is DepositCore {
         );
         logger = Logger(nameRegistry.getContractDetails(ParamManager.LOGGER()));
         vault = nameRegistry.getContractDetails(ParamManager.VAULT());
-        DepositCore(governance.MAX_DEPOSIT_SUBTREE());
+        MAX_SUBTREE_SIZE = 1 << governance.MAX_DEPOSIT_SUBTREE();
     }
 
     /**

--- a/contracts/Logger.sol
+++ b/contracts/Logger.sol
@@ -74,16 +74,6 @@ contract Logger {
         emit DepositQueued(accountID, data);
     }
 
-    event DepositLeafMerged(bytes32 left, bytes32 right, bytes32 newRoot);
-
-    function logDepositLeafMerged(
-        bytes32 left,
-        bytes32 right,
-        bytes32 newRoot
-    ) public {
-        emit DepositLeafMerged(left, right, newRoot);
-    }
-
     event DepositSubTreeReady(bytes32 root);
 
     function logDepositSubTreeReady(bytes32 root) public {

--- a/contracts/Rollup.sol
+++ b/contracts/Rollup.sol
@@ -184,7 +184,7 @@ contract RollupHelpers is RollupSetup {
             delete batches[i];
 
             // queue deposits again
-            depositManager.enqueue(batch.depositRoot);
+            depositManager.reenqueue(batch.depositRoot);
 
             totalSlashings++;
 

--- a/contracts/test/TestDepositCore.sol
+++ b/contracts/test/TestDepositCore.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.5.15;
+pragma experimental ABIEncoderV2;
+import { DepositCore } from "../DepositManager.sol";
+
+contract TestDepositCore is DepositCore {
+    constructor(uint256 maxSubtreeDepth) public {
+        MAX_SUBTREE_SIZE = 1 << maxSubtreeDepth;
+    }
+
+    function testInsertAndMerge(bytes32 depositLeaf)
+        external
+        returns (uint256 gasCost, bytes32 readySubtree)
+    {
+        uint256 operationCost = gasleft();
+        readySubtree = insertAndMerge(depositLeaf);
+        gasCost = operationCost - gasleft();
+    }
+
+    function getQueue(uint256 index) public view returns (bytes32) {
+        return queue[index];
+    }
+}

--- a/test/deposit.test.ts
+++ b/test/deposit.test.ts
@@ -1,10 +1,61 @@
 import { ethers } from "@nomiclabs/buidler";
-import { expect } from "chai";
+import { assert, expect } from "chai";
+import { constants } from "ethers";
 import { solidityKeccak256 } from "ethers/lib/utils";
 import { allContracts } from "../ts/allContractsInterfaces";
 import { TESTING_PARAMS } from "../ts/constants";
 import { deployAll } from "../ts/deploy";
 import { State } from "../ts/state";
+import { Tree } from "../ts/tree";
+import { randomLeaves } from "../ts/utils";
+import { TestDepositCore } from "../types/ethers-contracts/TestDepositCore";
+import { TestDepositCoreFactory } from "../types/ethers-contracts/TestDepositCoreFactory";
+
+describe("Deposit Core", async function() {
+    let contract: TestDepositCore;
+    const maxSubtreeDepth = 4;
+    before(async function() {
+        const [signer] = await ethers.getSigners();
+        contract = await new TestDepositCoreFactory(signer).deploy(
+            maxSubtreeDepth
+        );
+    });
+    it("insert and merge many deposits", async function() {
+        const maxSubtreeSize = 2 ** maxSubtreeDepth;
+        const leaves = randomLeaves(maxSubtreeSize);
+        const tree = Tree.new(maxSubtreeDepth);
+        for (let i = 0; i < maxSubtreeSize; i++) {
+            const {
+                gasCost,
+                readySubtree
+            } = await contract.callStatic.testInsertAndMerge(leaves[i]);
+            console.log(
+                `Insert leaf ${i} \t Operation cost: ${gasCost.toNumber()}`
+            );
+            await contract.testInsertAndMerge(leaves[i]);
+            tree.updateSingle(i, leaves[i]);
+            if (i !== maxSubtreeSize - 1) {
+                assert.equal(
+                    readySubtree,
+                    constants.HashZero,
+                    "Not a ready subtree yet"
+                );
+            } else {
+                assert.equal(
+                    readySubtree,
+                    tree.root,
+                    "Should be the merkle root of all leaves"
+                );
+            }
+        }
+        assert.equal((await contract.back()).toNumber(), 1);
+        assert.equal(
+            await contract.getQueue(1),
+            tree.root,
+            "subtree root should be in the subtree queue now"
+        );
+    });
+});
 
 const LARGE_AMOUNT_OF_TOKEN = 1000000;
 

--- a/test/deposit.test.ts
+++ b/test/deposit.test.ts
@@ -50,12 +50,6 @@ describe("DepositManager", async function() {
         await expect(depositManager.depositFor(1, 10, tokenType))
             .to.emit(logger, "DepositQueued")
             .withArgs(1, deposit1.encode())
-            .and.to.emit(logger, "DepositLeafMerged")
-            .withArgs(
-                deposit0.toStateLeaf(),
-                deposit1.toStateLeaf(),
-                pendingDeposit
-            )
             .and.to.emit(logger, "DepositSubTreeReady")
             .withArgs(pendingDeposit);
     });


### PR DESCRIPTION
In this PR, we separate the core logic of the deposit subtree manipulation from the interaction with other contracts, like token, logs, and governance. So that the deposit behavior can be better understood, tested, and benchmarked.

### Cost of submitting deposits with max subtree depth 4

```
Insert leaf 0    Operation cost: 63383
Insert leaf 1    Operation cost: 48232
Insert leaf 2    Operation cost: 33383
Insert leaf 3    Operation cost: 67278
Insert leaf 4    Operation cost: 33383
Insert leaf 5    Operation cost: 48232
Insert leaf 6    Operation cost: 33383
Insert leaf 7    Operation cost: 82124
Insert leaf 8    Operation cost: 33383
Insert leaf 9    Operation cost: 48232
Insert leaf 10   Operation cost: 33383
Insert leaf 11   Operation cost: 67278
Insert leaf 12   Operation cost: 33383
Insert leaf 13   Operation cost: 48232
Insert leaf 14   Operation cost: 33383
Insert leaf 15   Operation cost: 145649
```

### deposit 2 leaves in the integration test

[before](https://github.com/thehubbleproject/RedditHubble/runs/1178083256#step:7:42):

```
Deposit 0 transaction cost 167105
Deposit 1 transaction cost 231165
```

after:
```
Deposit 0 transaction cost 163444
Deposit 1 transaction cost 171132
```