### PR TITLE
Disallow calling processWithdrawCommitment twice

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -42,7 +42,7 @@ contract Vault is Initializable, ImmutableOwnable {
         Types.MMCommitmentInclusionProof memory commitmentMP
     ) public {
         require(
-            approvedWithdrawals[commitmentMP.commitment.body.withdrawRoot] != true,
+            !approvedWithdrawals[commitmentMP.commitment.body.withdrawRoot],
             "Vault: commitment was already approved for withdrawal"
         );
 

--- a/contracts/WithdrawManager.sol
+++ b/contracts/WithdrawManager.sol
@@ -41,6 +41,10 @@ contract WithdrawManager {
         uint256 batchID,
         Types.MMCommitmentInclusionProof memory commitmentMP
     ) public {
+        require(
+            processed[commitmentMP.commitment.body.withdrawRoot] == "",
+            "WithdrawManager: commitment was already processed"
+        );
         vault.requestApproval(batchID, commitmentMP);
         (address addr, uint256 l2Unit) =
             tokenRegistry.safeGetRecord(commitmentMP.commitment.body.tokenID);

--- a/contracts/WithdrawManager.sol
+++ b/contracts/WithdrawManager.sol
@@ -41,10 +41,6 @@ contract WithdrawManager {
         uint256 batchID,
         Types.MMCommitmentInclusionProof memory commitmentMP
     ) public {
-        require(
-            processed[commitmentMP.commitment.body.withdrawRoot] == "",
-            "WithdrawManager: commitment was already processed"
-        );
         vault.requestApproval(batchID, commitmentMP);
         (address addr, uint256 l2Unit) =
             tokenRegistry.safeGetRecord(commitmentMP.commitment.body.tokenID);

--- a/contracts/WithdrawManager.sol
+++ b/contracts/WithdrawManager.sol
@@ -15,7 +15,7 @@ import { Vault } from "./Vault.sol";
 
 contract WithdrawManager {
     using Tx for bytes;
-    using Types for Types.UserState;
+    using Types for Types.MMUserState;
     using SafeERC20 for IERC20;
 
     // withdrawRoot => a bitmap of whether a publicIndex owner has the token claimed

--- a/contracts/client/FrontendCreate2Transfer.sol
+++ b/contracts/client/FrontendCreate2Transfer.sol
@@ -154,7 +154,8 @@ contract FrontendCreate2Transfer {
         newReceiver = Transition.createState(
             _tx.toPubkeyID,
             tokenID,
-            _tx.amount
+            _tx.amount,
+            0
         );
 
         return (sender.encode(), newReceiver, result);

--- a/contracts/client/FrontendCreate2Transfer.sol
+++ b/contracts/client/FrontendCreate2Transfer.sol
@@ -154,8 +154,7 @@ contract FrontendCreate2Transfer {
         newReceiver = Transition.createState(
             _tx.toPubkeyID,
             tokenID,
-            _tx.amount,
-            0
+            _tx.amount
         );
 
         return (sender.encode(), newReceiver, result);

--- a/contracts/client/FrontendMassMigration.sol
+++ b/contracts/client/FrontendMassMigration.sol
@@ -123,7 +123,8 @@ contract FrontendMassMigration {
         newReceiver = Transition.createState(
             sender.pubkeyID,
             tokenID,
-            _tx.amount
+            _tx.amount,
+            sender.nonce
         );
         return (sender.encode(), newReceiver, result);
     }

--- a/contracts/client/FrontendMassMigration.sol
+++ b/contracts/client/FrontendMassMigration.sol
@@ -120,7 +120,8 @@ contract FrontendMassMigration {
             sender
         );
         if (result != Types.Result.Ok) return (sender.encode(), "", result);
-        newReceiver = Transition.createState(
+        newReceiver = Transition.createMMState(
+            _tx.fromIndex,
             sender.pubkeyID,
             tokenID,
             _tx.amount,

--- a/contracts/libs/Transition.sol
+++ b/contracts/libs/Transition.sol
@@ -63,7 +63,12 @@ library Transition {
             from
         );
         if (result != Types.Result.Ok) return (newRoot, "", result);
-        freshState = createState(from.state.pubkeyID, tokenID, _tx.amount, from.state.nonce);
+        freshState = createState(
+            from.state.pubkeyID,
+            tokenID,
+            _tx.amount,
+            from.state.nonce
+        );
 
         return (newRoot, freshState, Types.Result.Ok);
     }

--- a/contracts/libs/Transition.sol
+++ b/contracts/libs/Transition.sol
@@ -63,7 +63,7 @@ library Transition {
             from
         );
         if (result != Types.Result.Ok) return (newRoot, "", result);
-        freshState = createState(from.state.pubkeyID, tokenID, _tx.amount);
+        freshState = createState(from.state.pubkeyID, tokenID, _tx.amount, from.state.nonce);
 
         return (newRoot, freshState, Types.Result.Ok);
     }
@@ -106,7 +106,7 @@ library Transition {
             "Create2Transfer: receiver proof invalid"
         );
         bytes memory encodedState =
-            createState(_tx.toPubkeyID, tokenID, _tx.amount);
+            createState(_tx.toPubkeyID, tokenID, _tx.amount, 0);
 
         newRoot = MerkleTree.computeRoot(
             keccak256(encodedState),
@@ -212,14 +212,15 @@ library Transition {
     function createState(
         uint256 pubkeyID,
         uint256 tokenID,
-        uint256 amount
+        uint256 amount,
+        uint256 nonce
     ) internal pure returns (bytes memory stateEncoded) {
         Types.UserState memory state =
             Types.UserState({
                 pubkeyID: pubkeyID,
                 tokenID: tokenID,
                 balance: amount,
-                nonce: 0
+                nonce: nonce
             });
         return state.encode();
     }

--- a/contracts/libs/Transition.sol
+++ b/contracts/libs/Transition.sol
@@ -240,13 +240,13 @@ library Transition {
         uint256 nonce
     ) internal pure returns (bytes memory stateEncoded) {
         Types.MMUserState memory state =
-        Types.MMUserState({
-        stateID: stateID,
-        pubkeyID: pubkeyID,
-        tokenID: tokenID,
-        balance: amount,
-        nonce: nonce
-        });
+            Types.MMUserState({
+                stateID: stateID,
+                pubkeyID: pubkeyID,
+                tokenID: tokenID,
+                balance: amount,
+                nonce: nonce
+            });
         return state.encode();
     }
 }

--- a/contracts/libs/Transition.sol
+++ b/contracts/libs/Transition.sol
@@ -113,7 +113,7 @@ library Transition {
             "Create2Transfer: receiver proof invalid"
         );
         bytes memory encodedState =
-            createState(_tx.toPubkeyID, tokenID, _tx.amount, 0);
+            createState(_tx.toPubkeyID, tokenID, _tx.amount);
 
         newRoot = MerkleTree.computeRoot(
             keccak256(encodedState),
@@ -219,15 +219,14 @@ library Transition {
     function createState(
         uint256 pubkeyID,
         uint256 tokenID,
-        uint256 amount,
-        uint256 nonce
+        uint256 amount
     ) internal pure returns (bytes memory stateEncoded) {
         Types.UserState memory state =
             Types.UserState({
                 pubkeyID: pubkeyID,
                 tokenID: tokenID,
                 balance: amount,
-                nonce: nonce
+                nonce: 0
             });
         return state.encode();
     }

--- a/contracts/libs/Transition.sol
+++ b/contracts/libs/Transition.sol
@@ -13,6 +13,7 @@ import { Tx } from "./Tx.sol";
 library Transition {
     using SafeMath for uint256;
     using Types for Types.UserState;
+    using Types for Types.MMUserState;
 
     function processTransfer(
         bytes32 stateRoot,
@@ -63,7 +64,8 @@ library Transition {
             from
         );
         if (result != Types.Result.Ok) return (newRoot, "", result);
-        freshState = createState(
+        freshState = createMMState(
+            _tx.fromIndex,
             from.state.pubkeyID,
             tokenID,
             _tx.amount,
@@ -227,6 +229,24 @@ library Transition {
                 balance: amount,
                 nonce: nonce
             });
+        return state.encode();
+    }
+
+    function createMMState(
+        uint256 stateID,
+        uint256 pubkeyID,
+        uint256 tokenID,
+        uint256 amount,
+        uint256 nonce
+    ) internal pure returns (bytes memory stateEncoded) {
+        Types.MMUserState memory state =
+        Types.MMUserState({
+        stateID: stateID,
+        pubkeyID: pubkeyID,
+        tokenID: tokenID,
+        balance: amount,
+        nonce: nonce
+        });
         return state.encode();
     }
 }

--- a/contracts/libs/Types.sol
+++ b/contracts/libs/Types.sol
@@ -223,13 +223,36 @@ library Types {
             .decode(encoded, (uint256, uint256, uint256, uint256));
     }
 
+    struct MMUserState {
+        uint256 stateID;
+        uint256 pubkeyID;
+        uint256 tokenID;
+        uint256 balance;
+        uint256 nonce;
+    }
+
+    function encode(MMUserState memory state)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return
+            abi.encodePacked(
+                state.stateID,
+                state.pubkeyID,
+                state.tokenID,
+                state.balance,
+                state.nonce
+            );
+    }
+
     struct StateMerkleProof {
         UserState state;
         bytes32[] witness;
     }
 
     struct StateMerkleProofWithPath {
-        UserState state;
+        MMUserState state;
         uint256 path;
         bytes32[] witness;
     }

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -332,7 +332,7 @@ describe("Integration Test", function() {
             const { user, index } = group.pickRandom();
             const signature = user.signRaw(withdrawerAddress).sol;
             // The new stateID in the migration tree is the position user in the group
-            const withdrawProof = tree.getWithdrawProof(index);
+            const withdrawProof = tree.getWithdrawProof(user.stateID, index);
             await withdrawManager
                 .connect(withdrawer)
                 .claimTokens(

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -331,7 +331,6 @@ describe("Integration Test", function() {
             const tree = migrationTrees[i];
             const { user, index } = group.pickRandom();
             const signature = user.signRaw(withdrawerAddress).sol;
-            // The new stateID in the migration tree is the position user in the group
             const withdrawProof = tree.getWithdrawProof(user.stateID, index);
             await withdrawManager
                 .connect(withdrawer)

--- a/test/slow/rollup.massMigration.test.ts
+++ b/test/slow/rollup.massMigration.test.ts
@@ -224,11 +224,11 @@ describe("Mass Migrations", async function() {
 
         const batchId = Number(await rollup.nextBatchID());
 
-        const {
-            tx,
-            commitment,
-            migrationTree
-        } = await createAndSubmitBatch(rollup, batchId, alice);
+        const { tx, commitment, migrationTree } = await createAndSubmitBatch(
+            rollup,
+            batchId,
+            alice
+        );
 
         const batch = commitment.toBatch();
 
@@ -285,13 +285,16 @@ describe("Mass Migrations", async function() {
         assert.equal(alice.pubkeyID, aliceClone.pubkeyID);
         assert.notEqual(alice.stateID, aliceClone.stateID);
 
-        const {
-            tx: tx1,
-            commitment: commitment1
-        } = await createAndSubmitBatch(rollup, 1, alice);
-        const {
-            commitment: commitment2
-        } = await createAndSubmitBatch(rollup, 2, aliceClone);
+        const { tx: tx1, commitment: commitment1 } = await createAndSubmitBatch(
+            rollup,
+            1,
+            alice
+        );
+        const { commitment: commitment2 } = await createAndSubmitBatch(
+            rollup,
+            2,
+            aliceClone
+        );
 
         await mineBlocks(ethers.provider, TESTING_PARAMS.BLOCKS_TO_FINALISE);
 

--- a/test/slow/rollup.massMigration.test.ts
+++ b/test/slow/rollup.massMigration.test.ts
@@ -201,6 +201,12 @@ describe("Mass Migrations", async function() {
             "Transaction cost: Process Withdraw Commitment",
             receiptProcess.gasUsed.toNumber()
         );
+
+        await expectRevert(
+            withdrawManager.processWithdrawCommitment(batchId, batch.proof(0)),
+            "WithdrawManager: commitment was already processed"
+        );
+
         const withdrawProof = migrationTree.getWithdrawProof(0);
         const [, claimer] = await ethers.getSigners();
         const claimerAddress = await claimer.getAddress();

--- a/test/slow/rollup.massMigration.test.ts
+++ b/test/slow/rollup.massMigration.test.ts
@@ -126,7 +126,7 @@ describe("Mass Migrations", async function() {
 
         await expectRevert(
             withdrawManager.processWithdrawCommitment(batchId, proof),
-            "WithdrawManager: commitment was already processed"
+            "Vault: commitment was already approved for withdrawal"
         );
     }
 

--- a/ts/commitments.ts
+++ b/ts/commitments.ts
@@ -154,7 +154,7 @@ export class MassMigrationCommitment extends Commitment {
                 origin.pubkeyID,
                 origin.tokenID,
                 tx.amount,
-                tx.nonce,
+                tx.nonce
             );
             states.push(destination);
         }

--- a/ts/commitments.ts
+++ b/ts/commitments.ts
@@ -154,7 +154,7 @@ export class MassMigrationCommitment extends Commitment {
                 origin.pubkeyID,
                 origin.tokenID,
                 tx.amount,
-                0
+                tx.nonce,
             );
             states.push(destination);
         }

--- a/ts/commitments.ts
+++ b/ts/commitments.ts
@@ -4,7 +4,7 @@ import { Rollup } from "../types/ethers-contracts/Rollup";
 import { ZERO_BYTES32 } from "./constants";
 import { Usage, Wei } from "./interfaces";
 import { solG1 } from "./mcl";
-import { State } from "./state";
+import { MMState } from "./mmState";
 import { MigrationTree, StateProvider } from "./stateTree";
 import { MemoryTree } from "./tree/memoryTree";
 import { serialize, TxMassMigration } from "./tx";
@@ -150,7 +150,8 @@ export class MassMigrationCommitment extends Commitment {
         const states = [];
         for (const tx of txs) {
             const origin = stateProvider.getState(tx.fromIndex).state;
-            const destination = State.new(
+            const destination = MMState.new(
+                tx.fromIndex,
                 origin.pubkeyID,
                 origin.tokenID,
                 tx.amount,

--- a/ts/mmState.ts
+++ b/ts/mmState.ts
@@ -1,0 +1,86 @@
+import { BigNumber, BigNumberish, ethers } from "ethers";
+import { solidityPack } from "ethers/lib/utils";
+import { State } from "./state";
+
+export class MMState implements State {
+    public static new(
+        stateID: BigNumberish,
+        pubkeyID: BigNumberish,
+        tokenID: BigNumberish,
+        balance: BigNumberish,
+        nonce: BigNumberish
+    ): MMState {
+        return new MMState(
+            BigNumber.from(stateID),
+            BigNumber.from(pubkeyID),
+            BigNumber.from(tokenID),
+            BigNumber.from(balance),
+            BigNumber.from(nonce)
+        );
+    }
+
+    constructor(
+        public stateID: BigNumber,
+        public pubkeyID: BigNumber,
+        public tokenID: BigNumber,
+        public balance: BigNumber,
+        public nonce: BigNumber
+    ) {}
+
+    public encode(): string {
+        return solidityPack(
+            ["uint256", "uint256", "uint256", "uint256", "uint256"],
+            [
+                this.stateID,
+                this.pubkeyID,
+                this.tokenID,
+                this.balance,
+                this.nonce
+            ]
+        );
+    }
+
+    public hash(): string {
+        return ethers.utils.solidityKeccak256(
+            ["uint256", "uint256", "uint256", "uint256", "uint256"],
+            [
+                this.stateID,
+                this.pubkeyID,
+                this.tokenID,
+                this.balance,
+                this.nonce
+            ]
+        );
+    }
+
+    public toJSON() {
+        return {
+            stateID: this.stateID.toString(),
+            pubkeyID: this.pubkeyID.toString(),
+            tokenID: this.tokenID.toString(),
+            balance: this.balance.toString(),
+            nonce: this.nonce.toString()
+        };
+    }
+
+    public toString(): string {
+        const propsStr = Object.entries(this.toJSON())
+            .map(([k, v]) => `${k} ${v}`)
+            .join(" ");
+        return `<State  ${propsStr}>`;
+    }
+
+    public clone() {
+        return new MMState(
+            this.stateID,
+            this.pubkeyID,
+            this.tokenID,
+            this.balance,
+            this.nonce
+        );
+    }
+
+    public toStateLeaf(): string {
+        return this.hash();
+    }
+}

--- a/ts/stateTree.ts
+++ b/ts/stateTree.ts
@@ -1,7 +1,7 @@
 import { Hasher } from "./tree";
 import { State, ZERO_STATE } from "./state";
 import { TxTransfer, TxMassMigration, TxCreate2Transfer } from "./tx";
-import { BigNumber, constants } from "ethers";
+import { BigNumber, BigNumberish, constants } from "ethers";
 import { ZERO_BYTES32 } from "./constants";
 import { minTreeDepth, sum } from "./utils";
 import {
@@ -15,6 +15,7 @@ import {
 } from "./exceptions";
 import { Vacant } from "./interfaces";
 import { MemoryTree } from "./tree/memoryTree";
+import { MMState } from "./mmState";
 
 export interface StateProvider {
     getState(stateID: number): SolStateMerkleProof;
@@ -379,8 +380,17 @@ export class MigrationTree extends StateTree {
         return new this(depth).createStateBulk(0, states);
     }
 
-    public getWithdrawProof(stateID: number) {
-        const { state, witness } = this.getState(stateID);
-        return { state, witness, path: stateID };
+    public getWithdrawProof(stateID: BigNumberish, txIndex: number) {
+        const { state, witness } = this.getState(txIndex);
+
+        const mmState = MMState.new(
+            stateID,
+            state.pubkeyID,
+            state.tokenID,
+            state.balance,
+            state.nonce
+        );
+
+        return { state: mmState, witness, path: txIndex };
     }
 }


### PR DESCRIPTION
Currently, anyone can call `processWithdrawCommitment` multiple times which may lead to permanent lock up of tokens in the `WithdrawManager`. This PR fixes it and removes redundant code from the `Vault` smart contract.