### PR TITLE
Restrict internal transactions

### DIFF
--- a/contracts/BLSAccountRegistry.sol
+++ b/contracts/BLSAccountRegistry.sol
@@ -13,7 +13,10 @@ contract BLSAccountRegistry is AccountTree {
     event BatchPubkeyRegistered(uint256 startID, uint256 endID);
 
     modifier noInternalTransactions() {
-        require(msg.sender == tx.origin, "BLSAccountRegistry: Internal transactions are forbidden");
+        require(
+            msg.sender == tx.origin,
+            "BLSAccountRegistry: Internal transactions are forbidden"
+        );
         _;
     }
 

--- a/contracts/BLSAccountRegistry.sol
+++ b/contracts/BLSAccountRegistry.sol
@@ -12,7 +12,16 @@ contract BLSAccountRegistry is AccountTree {
     event SinglePubkeyRegistered(uint256 pubkeyID);
     event BatchPubkeyRegistered(uint256 startID, uint256 endID);
 
-    function register(uint256[4] calldata pubkey) external returns (uint256) {
+    modifier noInternalTransactions() {
+        require(msg.sender == tx.origin, "BLSAccountRegistry: Internal transactions are forbidden");
+        _;
+    }
+
+    function register(uint256[4] calldata pubkey)
+        external
+        noInternalTransactions
+        returns (uint256)
+    {
         bytes32 leaf = keccak256(abi.encodePacked(pubkey));
         uint256 pubkeyID = _updateSingle(leaf);
         emit SinglePubkeyRegistered(pubkeyID);
@@ -21,6 +30,7 @@ contract BLSAccountRegistry is AccountTree {
 
     function registerBatch(uint256[4][BATCH_SIZE] calldata pubkeys)
         external
+        noInternalTransactions
         returns (uint256)
     {
         bytes32[BATCH_SIZE] memory leafs;

--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -178,14 +178,6 @@ contract DepositManager is
         _;
     }
 
-    modifier noInternalTransactions() {
-        require(
-            msg.sender == tx.origin,
-            "DepositManager: Internal transactions are forbidden"
-        );
-        _;
-    }
-
     constructor(
         ITokenRegistry _tokenRegistry,
         address _vault,
@@ -214,7 +206,7 @@ contract DepositManager is
         uint256 pubkeyID,
         uint256 l1Amount,
         uint256 tokenID
-    ) external noInternalTransactions {
+    ) external {
         (address addr, uint256 l2Unit) = tokenRegistry.safeGetRecord(tokenID);
         require(
             l1Amount == 0 || l1Amount % l2Unit == 0,

--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -179,7 +179,10 @@ contract DepositManager is
     }
 
     modifier noInternalTransactions() {
-        require(msg.sender == tx.origin, "DepositManager: Internal transactions are forbidden");
+        require(
+            msg.sender == tx.origin,
+            "DepositManager: Internal transactions are forbidden"
+        );
         _;
     }
 

--- a/contracts/DepositManager.sol
+++ b/contracts/DepositManager.sol
@@ -178,6 +178,11 @@ contract DepositManager is
         _;
     }
 
+    modifier noInternalTransactions() {
+        require(msg.sender == tx.origin, "DepositManager: Internal transactions are forbidden");
+        _;
+    }
+
     constructor(
         ITokenRegistry _tokenRegistry,
         address _vault,
@@ -206,7 +211,7 @@ contract DepositManager is
         uint256 pubkeyID,
         uint256 l1Amount,
         uint256 tokenID
-    ) external {
+    ) external noInternalTransactions {
         (address addr, uint256 l2Unit) = tokenRegistry.safeGetRecord(tokenID);
         require(
             l1Amount == 0 || l1Amount % l2Unit == 0,

--- a/contracts/rollup/Rollup.sol
+++ b/contracts/rollup/Rollup.sol
@@ -107,6 +107,11 @@ contract Rollup is BatchManager, EIP712, IEIP712 {
         _;
     }
 
+    modifier noInternalTransactions() {
+        require(msg.sender == tx.origin, "Rollup: Internal transactions are forbidden");
+        _;
+    }
+
     /**
      * @dev When running multiple batch submissions in a single transaction,
      * if one of the earlier batch submissions fails the latter submission
@@ -205,6 +210,7 @@ contract Rollup is BatchManager, EIP712, IEIP712 {
         external
         payable
         onlyCoordinator
+        noInternalTransactions
         isNotRollingBack
         correctBatchID(batchID)
     {
@@ -244,6 +250,7 @@ contract Rollup is BatchManager, EIP712, IEIP712 {
         external
         payable
         onlyCoordinator
+        noInternalTransactions
         isNotRollingBack
         correctBatchID(batchID)
     {
@@ -285,6 +292,7 @@ contract Rollup is BatchManager, EIP712, IEIP712 {
         external
         payable
         onlyCoordinator
+        noInternalTransactions
         isNotRollingBack
         correctBatchID(batchID)
     {
@@ -318,7 +326,14 @@ contract Rollup is BatchManager, EIP712, IEIP712 {
         uint256 batchID,
         Types.CommitmentInclusionProof memory previous,
         Types.SubtreeVacancyProof memory vacant
-    ) public payable onlyCoordinator isNotRollingBack correctBatchID(batchID) {
+    )
+        public
+        payable
+        onlyCoordinator
+        noInternalTransactions
+        isNotRollingBack
+        correctBatchID(batchID)
+    {
         uint256 preBatchID = batchID - 1;
         require(
             previous.path == batches[preBatchID].size() - 1,

--- a/contracts/rollup/Rollup.sol
+++ b/contracts/rollup/Rollup.sol
@@ -108,7 +108,10 @@ contract Rollup is BatchManager, EIP712, IEIP712 {
     }
 
     modifier noInternalTransactions() {
-        require(msg.sender == tx.origin, "Rollup: Internal transactions are forbidden");
+        require(
+            msg.sender == tx.origin,
+            "Rollup: Internal transactions are forbidden"
+        );
         _;
     }
 


### PR DESCRIPTION
This PR restricts internal transactions for crucial SC methods that require parsed data from the calldata. This is a temporary solution until a better one is provided as described in the issue #490.